### PR TITLE
Add attribute plan modifier for force-new properties

### DIFF
--- a/internal/aws/accessanalyzer/analyzer_resource_gen.go
+++ b/internal/aws/accessanalyzer/analyzer_resource_gen.go
@@ -39,7 +39,9 @@ func analyzerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// AnalyzerName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AnalyzerName is a force-new property.
+			},
 		},
 		"archive_rules": {
 			// Property: ArchiveRules
@@ -239,7 +241,9 @@ func analyzerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1024),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/acmpca/certificate_authority_activation_resource_gen.go
+++ b/internal/aws/acmpca/certificate_authority_activation_resource_gen.go
@@ -31,7 +31,7 @@ func certificateAuthorityActivationResourceType(ctx context.Context) (tfsdk.Reso
 			Description: "Certificate Authority certificate that will be installed in the Certificate Authority.",
 			Type:        types.StringType,
 			Required:    true,
-			// Certificate is a write-only attribute.
+			// Certificate is a write-only property.
 		},
 		"certificate_authority_arn": {
 			// Property: CertificateAuthorityArn
@@ -43,7 +43,9 @@ func certificateAuthorityActivationResourceType(ctx context.Context) (tfsdk.Reso
 			Description: "Arn of the Certificate Authority.",
 			Type:        types.StringType,
 			Required:    true,
-			// CertificateAuthorityArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateAuthorityArn is a force-new property.
+			},
 		},
 		"certificate_chain": {
 			// Property: CertificateChain
@@ -55,7 +57,7 @@ func certificateAuthorityActivationResourceType(ctx context.Context) (tfsdk.Reso
 			Description: "Certificate chain for the Certificate Authority certificate.",
 			Type:        types.StringType,
 			Optional:    true,
-			// CertificateChain is a write-only attribute.
+			// CertificateChain is a write-only property.
 		},
 		"complete_certificate_chain": {
 			// Property: CompleteCertificateChain

--- a/internal/aws/acmpca/certificate_authority_resource_gen.go
+++ b/internal/aws/acmpca/certificate_authority_resource_gen.go
@@ -475,7 +475,9 @@ func certificateAuthorityResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			),
 			Optional: true,
 			Computed: true,
-			// CsrExtensions is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CsrExtensions is a force-new property.
+			},
 		},
 		"key_algorithm": {
 			// Property: KeyAlgorithm
@@ -487,7 +489,9 @@ func certificateAuthorityResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Description: "Public key algorithm and size, in bits, of the key pair that your CA creates when it issues a certificate.",
 			Type:        types.StringType,
 			Required:    true,
-			// KeyAlgorithm is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KeyAlgorithm is a force-new property.
+			},
 		},
 		"key_storage_security_standard": {
 			// Property: KeyStorageSecurityStandard
@@ -500,7 +504,9 @@ func certificateAuthorityResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// KeyStorageSecurityStandard is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KeyStorageSecurityStandard is a force-new property.
+			},
 		},
 		"revocation_configuration": {
 			// Property: RevocationConfiguration
@@ -585,7 +591,9 @@ func certificateAuthorityResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Description: "Algorithm your CA uses to sign certificate requests.",
 			Type:        types.StringType,
 			Required:    true,
-			// SigningAlgorithm is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SigningAlgorithm is a force-new property.
+			},
 		},
 		"subject": {
 			// Property: Subject
@@ -715,8 +723,10 @@ func certificateAuthorityResourceType(ctx context.Context) (tfsdk.ResourceType, 
 				},
 			),
 			Required: true,
-			// Subject is a force-new attribute.
-			// Subject is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Subject is a force-new property.
+			},
+			// Subject is a write-only property.
 		},
 		"tags": {
 			// Property: Tags
@@ -763,7 +773,9 @@ func certificateAuthorityResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Description: "The type of the certificate authority.",
 			Type:        types.StringType,
 			Required:    true,
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/acmpca/certificate_resource_gen.go
+++ b/internal/aws/acmpca/certificate_resource_gen.go
@@ -670,8 +670,10 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// ApiPassthrough is a force-new attribute.
-			// ApiPassthrough is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ApiPassthrough is a force-new property.
+			},
+			// ApiPassthrough is a write-only property.
 		},
 		"arn": {
 			// Property: Arn
@@ -701,7 +703,9 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// CertificateAuthorityArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateAuthorityArn is a force-new property.
+			},
 		},
 		"certificate_signing_request": {
 			// Property: CertificateSigningRequest
@@ -717,8 +721,10 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// CertificateSigningRequest is a force-new attribute.
-			// CertificateSigningRequest is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateSigningRequest is a force-new property.
+			},
+			// CertificateSigningRequest is a write-only property.
 		},
 		"signing_algorithm": {
 			// Property: SigningAlgorithm
@@ -730,7 +736,9 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name of the algorithm that will be used to sign the Certificate.",
 			Type:        types.StringType,
 			Required:    true,
-			// SigningAlgorithm is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SigningAlgorithm is a force-new property.
+			},
 		},
 		"template_arn": {
 			// Property: TemplateArn
@@ -741,7 +749,9 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// TemplateArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TemplateArn is a force-new property.
+			},
 		},
 		"validity": {
 			// Property: Validity
@@ -779,7 +789,9 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// Validity is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Validity is a force-new property.
+			},
 		},
 		"validity_not_before": {
 			// Property: ValidityNotBefore
@@ -818,7 +830,9 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// ValidityNotBefore is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ValidityNotBefore is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/amplify/app_resource_gen.go
+++ b/internal/aws/amplify/app_resource_gen.go
@@ -36,7 +36,7 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// AccessToken is a write-only attribute.
+			// AccessToken is a write-only property.
 		},
 		"app_id": {
 			// Property: AppId
@@ -280,7 +280,7 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// AutoBranchCreationConfig is a write-only attribute.
+			// AutoBranchCreationConfig is a write-only property.
 		},
 		"basic_auth_config": {
 			// Property: BasicAuthConfig
@@ -330,7 +330,7 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// BasicAuthConfig is a write-only attribute.
+			// BasicAuthConfig is a write-only property.
 		},
 		"build_spec": {
 			// Property: BuildSpec
@@ -569,7 +569,7 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1000),
 			},
-			// OauthToken is a write-only attribute.
+			// OauthToken is a write-only property.
 		},
 		"repository": {
 			// Property: Repository

--- a/internal/aws/amplify/branch_resource_gen.go
+++ b/internal/aws/amplify/branch_resource_gen.go
@@ -37,7 +37,9 @@ func branchResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 20),
 			},
-			// AppId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AppId is a force-new property.
+			},
 		},
 		"arn": {
 			// Property: Arn
@@ -102,7 +104,7 @@ func branchResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// BasicAuthConfig is a write-only attribute.
+			// BasicAuthConfig is a write-only property.
 		},
 		"branch_name": {
 			// Property: BranchName
@@ -118,7 +120,9 @@ func branchResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// BranchName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BranchName is a force-new property.
+			},
 		},
 		"build_spec": {
 			// Property: BuildSpec

--- a/internal/aws/amplify/domain_resource_gen.go
+++ b/internal/aws/amplify/domain_resource_gen.go
@@ -37,7 +37,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 20),
 			},
-			// AppId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AppId is a force-new property.
+			},
 		},
 		"arn": {
 			// Property: Arn
@@ -103,7 +105,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 255),
 			},
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"domain_status": {
 			// Property: DomainStatus

--- a/internal/aws/apigateway/api_key_resource_gen.go
+++ b/internal/aws/apigateway/api_key_resource_gen.go
@@ -78,8 +78,10 @@ func apiKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.BoolType,
 			Optional:    true,
 			Computed:    true,
-			// GenerateDistinctId is a force-new attribute.
-			// GenerateDistinctId is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GenerateDistinctId is a force-new property.
+			},
+			// GenerateDistinctId is a write-only property.
 		},
 		"name": {
 			// Property: Name
@@ -92,7 +94,9 @@ func apiKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"stage_keys": {
 			// Property: StageKeys
@@ -205,7 +209,9 @@ func apiKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Value is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Value is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/apigateway/documentation_version_resource_gen.go
+++ b/internal/aws/apigateway/documentation_version_resource_gen.go
@@ -48,7 +48,9 @@ func documentationVersionResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// DocumentationVersion is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DocumentationVersion is a force-new property.
+			},
 		},
 		"rest_api_id": {
 			// Property: RestApiId
@@ -64,7 +66,9 @@ func documentationVersionResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// RestApiId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RestApiId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/apigateway/domain_name_resource_gen.go
+++ b/internal/aws/apigateway/domain_name_resource_gen.go
@@ -57,7 +57,9 @@ func domainNameResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"endpoint_configuration": {
 			// Property: EndpointConfiguration

--- a/internal/aws/apigateway/model_resource_gen.go
+++ b/internal/aws/apigateway/model_resource_gen.go
@@ -32,7 +32,9 @@ func modelResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ContentType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ContentType is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -56,7 +58,9 @@ func modelResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"rest_api_id": {
 			// Property: RestApiId
@@ -68,7 +72,9 @@ func modelResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of a REST API with which to associate this model.",
 			Type:        types.StringType,
 			Required:    true,
-			// RestApiId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RestApiId is a force-new property.
+			},
 		},
 		"schema": {
 			// Property: Schema

--- a/internal/aws/apigateway/request_validator_resource_gen.go
+++ b/internal/aws/apigateway/request_validator_resource_gen.go
@@ -32,7 +32,9 @@ func requestValidatorResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"request_validator_id": {
 			// Property: RequestValidatorId
@@ -55,7 +57,9 @@ func requestValidatorResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Description: "The identifier of the targeted API entity.",
 			Type:        types.StringType,
 			Required:    true,
-			// RestApiId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RestApiId is a force-new property.
+			},
 		},
 		"validate_request_body": {
 			// Property: ValidateRequestBody

--- a/internal/aws/apigateway/resource_resource_gen.go
+++ b/internal/aws/apigateway/resource_resource_gen.go
@@ -31,7 +31,9 @@ func resourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The parent resource's identifier.",
 			Type:        types.StringType,
 			Required:    true,
-			// ParentId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ParentId is a force-new property.
+			},
 		},
 		"path_part": {
 			// Property: PathPart
@@ -43,7 +45,9 @@ func resourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The last path segment for this resource.",
 			Type:        types.StringType,
 			Required:    true,
-			// PathPart is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PathPart is a force-new property.
+			},
 		},
 		"resource_id": {
 			// Property: ResourceId
@@ -66,7 +70,9 @@ func resourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the RestApi resource in which you want to create this resource..",
 			Type:        types.StringType,
 			Required:    true,
-			// RestApiId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RestApiId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/apigateway/usage_plan_key_resource_gen.go
+++ b/internal/aws/apigateway/usage_plan_key_resource_gen.go
@@ -44,7 +44,9 @@ func usagePlanKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the usage plan key.",
 			Type:        types.StringType,
 			Required:    true,
-			// KeyId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KeyId is a force-new property.
+			},
 		},
 		"key_type": {
 			// Property: KeyType
@@ -64,7 +66,9 @@ func usagePlanKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"API_KEY",
 				}),
 			},
-			// KeyType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KeyType is a force-new property.
+			},
 		},
 		"usage_plan_id": {
 			// Property: UsagePlanId
@@ -76,7 +80,9 @@ func usagePlanKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the usage plan.",
 			Type:        types.StringType,
 			Required:    true,
-			// UsagePlanId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // UsagePlanId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/appflow/connector_profile_resource_gen.go
+++ b/internal/aws/appflow/connector_profile_resource_gen.go
@@ -1420,7 +1420,7 @@ func connectorProfileResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 				},
 			),
 			Optional: true,
-			// ConnectorProfileConfig is a write-only attribute.
+			// ConnectorProfileConfig is a write-only property.
 		},
 		"connector_profile_name": {
 			// Property: ConnectorProfileName
@@ -1437,7 +1437,9 @@ func connectorProfileResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 256),
 			},
-			// ConnectorProfileName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConnectorProfileName is a force-new property.
+			},
 		},
 		"connector_type": {
 			// Property: ConnectorType
@@ -1483,7 +1485,9 @@ func connectorProfileResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 					"Veeva",
 				}),
 			},
-			// ConnectorType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConnectorType is a force-new property.
+			},
 		},
 		"credentials_arn": {
 			// Property: CredentialsArn
@@ -1515,7 +1519,9 @@ func connectorProfileResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// KMSArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KMSArn is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/appflow/flow_resource_gen.go
+++ b/internal/aws/appflow/flow_resource_gen.go
@@ -1049,7 +1049,9 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// FlowName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FlowName is a force-new property.
+			},
 		},
 		"kms_arn": {
 			// Property: KMSArn
@@ -1068,7 +1070,9 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// KMSArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KMSArn is a force-new property.
+			},
 		},
 		"source_flow_config": {
 			// Property: SourceFlowConfig

--- a/internal/aws/appintegrations/event_integration_resource_gen.go
+++ b/internal/aws/appintegrations/event_integration_resource_gen.go
@@ -193,7 +193,9 @@ func eventIntegrationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// EventBridgeBus is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EventBridgeBus is a force-new property.
+			},
 		},
 		"event_filter": {
 			// Property: EventFilter
@@ -228,7 +230,9 @@ func eventIntegrationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 				},
 			),
 			Required: true,
-			// EventFilter is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EventFilter is a force-new property.
+			},
 		},
 		"event_integration_arn": {
 			// Property: EventIntegrationArn
@@ -260,7 +264,9 @@ func eventIntegrationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/applicationinsights/application_resource_gen.go
+++ b/internal/aws/applicationinsights/application_resource_gen.go
@@ -1756,7 +1756,9 @@ func applicationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// ResourceGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceGroupName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/apprunner/service_resource_gen.go
+++ b/internal/aws/apprunner/service_resource_gen.go
@@ -39,7 +39,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1011),
 			},
-			// AutoScalingConfigurationArn is a write-only attribute.
+			// AutoScalingConfigurationArn is a write-only property.
 		},
 		"encryption_configuration": {
 			// Property: EncryptionConfiguration
@@ -77,7 +77,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// EncryptionConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EncryptionConfiguration is a force-new property.
+			},
 		},
 		"health_check_configuration": {
 			// Property: HealthCheckConfiguration
@@ -288,7 +290,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(4, 40),
 			},
-			// ServiceName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServiceName is a force-new property.
+			},
 		},
 		"service_url": {
 			// Property: ServiceUrl
@@ -766,8 +770,10 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
-			// Tags is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
+			// Tags is a write-only property.
 		},
 	}
 

--- a/internal/aws/athena/named_query_resource_gen.go
+++ b/internal/aws/athena/named_query_resource_gen.go
@@ -38,7 +38,9 @@ func namedQueryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Database is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Database is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -56,7 +58,9 @@ func namedQueryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -74,7 +78,9 @@ func namedQueryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"named_query_id": {
 			// Property: NamedQueryId
@@ -102,7 +108,9 @@ func namedQueryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 262144),
 			},
-			// QueryString is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // QueryString is a force-new property.
+			},
 		},
 		"work_group": {
 			// Property: WorkGroup
@@ -120,7 +128,9 @@ func namedQueryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// WorkGroup is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // WorkGroup is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/athena/prepared_statement_resource_gen.go
+++ b/internal/aws/athena/prepared_statement_resource_gen.go
@@ -70,7 +70,9 @@ func preparedStatementResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// StatementName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StatementName is a force-new property.
+			},
 		},
 		"work_group": {
 			// Property: WorkGroup
@@ -87,7 +89,9 @@ func preparedStatementResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// WorkGroup is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // WorkGroup is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/athena/work_group_resource_gen.go
+++ b/internal/aws/athena/work_group_resource_gen.go
@@ -66,7 +66,9 @@ func workGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"recursive_delete_option": {
 			// Property: RecursiveDeleteOption

--- a/internal/aws/auditmanager/assessment_resource_gen.go
+++ b/internal/aws/auditmanager/assessment_resource_gen.go
@@ -159,7 +159,9 @@ func assessmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// AwsAccount is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AwsAccount is a force-new property.
+			},
 		},
 		"creation_time": {
 			// Property: CreationTime
@@ -373,7 +375,7 @@ func assessmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The description of the specified assessment.",
 			Type:        types.StringType,
 			Optional:    true,
-			// Description is a write-only attribute.
+			// Description is a write-only property.
 		},
 		"framework_id": {
 			// Property: FrameworkId
@@ -392,7 +394,9 @@ func assessmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(32, 36),
 			},
-			// FrameworkId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FrameworkId is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -410,7 +414,7 @@ func assessmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 127),
 			},
-			// Name is a write-only attribute.
+			// Name is a write-only property.
 		},
 		"roles": {
 			// Property: Roles

--- a/internal/aws/autoscaling/warm_pool_resource_gen.go
+++ b/internal/aws/autoscaling/warm_pool_resource_gen.go
@@ -29,7 +29,9 @@ func warmPoolResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// AutoScalingGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AutoScalingGroupName is a force-new property.
+			},
 		},
 		"max_group_prepared_capacity": {
 			// Property: MaxGroupPreparedCapacity

--- a/internal/aws/backup/backup_selection_resource_gen.go
+++ b/internal/aws/backup/backup_selection_resource_gen.go
@@ -29,7 +29,9 @@ func backupSelectionResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// BackupPlanId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BackupPlanId is a force-new property.
+			},
 		},
 		"backup_selection": {
 			// Property: BackupSelection
@@ -125,7 +127,9 @@ func backupSelectionResourceType(ctx context.Context) (tfsdk.ResourceType, error
 				},
 			),
 			Required: true,
-			// BackupSelection is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BackupSelection is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id

--- a/internal/aws/backup/backup_vault_resource_gen.go
+++ b/internal/aws/backup/backup_vault_resource_gen.go
@@ -48,7 +48,9 @@ func backupVaultResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// BackupVaultName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BackupVaultName is a force-new property.
+			},
 		},
 		"backup_vault_tags": {
 			// Property: BackupVaultTags
@@ -75,7 +77,9 @@ func backupVaultResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// EncryptionKeyArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EncryptionKeyArn is a force-new property.
+			},
 		},
 		"notifications": {
 			// Property: Notifications

--- a/internal/aws/budgets/budgets_action_resource_gen.go
+++ b/internal/aws/budgets/budgets_action_resource_gen.go
@@ -97,7 +97,9 @@ func budgetsActionResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"RUN_SSM_DOCUMENTS",
 				}),
 			},
-			// ActionType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ActionType is a force-new property.
+			},
 		},
 		"approval_model": {
 			// Property: ApprovalModel
@@ -126,7 +128,9 @@ func budgetsActionResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// BudgetName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BudgetName is a force-new property.
+			},
 		},
 		"definition": {
 			// Property: Definition

--- a/internal/aws/cassandra/keyspace_resource_gen.go
+++ b/internal/aws/cassandra/keyspace_resource_gen.go
@@ -35,7 +35,9 @@ func keyspaceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// KeyspaceName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KeyspaceName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/cassandra/table_resource_gen.go
+++ b/internal/aws/cassandra/table_resource_gen.go
@@ -187,7 +187,9 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// ClusteringKeyColumns is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ClusteringKeyColumns is a force-new property.
+			},
 		},
 		"encryption_specification": {
 			// Property: EncryptionSpecification
@@ -250,7 +252,9 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "Name for Cassandra keyspace",
 			Type:        types.StringType,
 			Required:    true,
-			// KeyspaceName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KeyspaceName is a force-new property.
+			},
 		},
 		"partition_key_columns": {
 			// Property: PartitionKeyColumns
@@ -301,7 +305,9 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// PartitionKeyColumns is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PartitionKeyColumns is a force-new property.
+			},
 		},
 		"point_in_time_recovery_enabled": {
 			// Property: PointInTimeRecoveryEnabled
@@ -370,7 +376,9 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// TableName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TableName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/ce/cost_category_resource_gen.go
+++ b/internal/aws/ce/cost_category_resource_gen.go
@@ -78,7 +78,9 @@ func costCategoryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 50),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"rule_version": {
 			// Property: RuleVersion

--- a/internal/aws/chatbot/slack_channel_configuration_resource_gen.go
+++ b/internal/aws/chatbot/slack_channel_configuration_resource_gen.go
@@ -51,7 +51,9 @@ func slackChannelConfigurationResourceType(ctx context.Context) (tfsdk.ResourceT
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// ConfigurationName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConfigurationName is a force-new property.
+			},
 		},
 		"iam_role_arn": {
 			// Property: IamRoleArn
@@ -109,7 +111,9 @@ func slackChannelConfigurationResourceType(ctx context.Context) (tfsdk.ResourceT
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// SlackWorkspaceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SlackWorkspaceId is a force-new property.
+			},
 		},
 		"sns_topic_arns": {
 			// Property: SnsTopicArns

--- a/internal/aws/cloudformation/module_default_version_resource_gen.go
+++ b/internal/aws/cloudformation/module_default_version_resource_gen.go
@@ -35,7 +35,9 @@ func moduleDefaultVersionResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Arn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Arn is a force-new property.
+			},
 		},
 		"module_name": {
 			// Property: ModuleName
@@ -49,8 +51,10 @@ func moduleDefaultVersionResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ModuleName is a force-new attribute.
-			// ModuleName is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModuleName is a force-new property.
+			},
+			// ModuleName is a write-only property.
 		},
 		"version_id": {
 			// Property: VersionId
@@ -64,8 +68,10 @@ func moduleDefaultVersionResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// VersionId is a force-new attribute.
-			// VersionId is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VersionId is a force-new property.
+			},
+			// VersionId is a write-only property.
 		},
 	}
 

--- a/internal/aws/cloudformation/module_version_resource_gen.go
+++ b/internal/aws/cloudformation/module_version_resource_gen.go
@@ -80,7 +80,9 @@ func moduleVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Description: "The name of the module being registered.\n\nRecommended module naming pattern: company_or_organization::service::type::MODULE.",
 			Type:        types.StringType,
 			Required:    true,
-			// ModuleName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModuleName is a force-new property.
+			},
 		},
 		"module_package": {
 			// Property: ModulePackage
@@ -92,8 +94,10 @@ func moduleVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Description: "The url to the S3 bucket containing the schema and template fragment for the module you want to register.",
 			Type:        types.StringType,
 			Required:    true,
-			// ModulePackage is a force-new attribute.
-			// ModulePackage is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModulePackage is a force-new property.
+			},
+			// ModulePackage is a write-only property.
 		},
 		"schema": {
 			// Property: Schema

--- a/internal/aws/cloudformation/public_type_version_resource_gen.go
+++ b/internal/aws/cloudformation/public_type_version_resource_gen.go
@@ -35,7 +35,9 @@ func publicTypeVersionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Arn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Arn is a force-new property.
+			},
 		},
 		"log_delivery_bucket": {
 			// Property: LogDeliveryBucket
@@ -48,7 +50,9 @@ func publicTypeVersionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// LogDeliveryBucket is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LogDeliveryBucket is a force-new property.
+			},
 		},
 		"public_type_arn": {
 			// Property: PublicTypeArn
@@ -79,7 +83,9 @@ func publicTypeVersionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(5, 64),
 			},
-			// PublicVersionNumber is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PublicVersionNumber is a force-new property.
+			},
 		},
 		"publisher_id": {
 			// Property: PublisherId
@@ -116,7 +122,9 @@ func publicTypeVersionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 					"MODULE",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 		"type_name": {
 			// Property: TypeName
@@ -130,7 +138,9 @@ func publicTypeVersionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// TypeName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TypeName is a force-new property.
+			},
 		},
 		"type_version_arn": {
 			// Property: TypeVersionArn

--- a/internal/aws/cloudformation/publisher_resource_gen.go
+++ b/internal/aws/cloudformation/publisher_resource_gen.go
@@ -31,7 +31,9 @@ func publisherResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "Whether you accept the terms and conditions for publishing extensions in the CloudFormation registry. You must accept the terms and conditions in order to publish public extensions to the CloudFormation registry. The terms and conditions can be found at https://cloudformation-registry-documents.s3.amazonaws.com/Terms_and_Conditions_for_AWS_CloudFormation_Registry_Publishers.pdf",
 			Type:        types.BoolType,
 			Required:    true,
-			// AcceptTermsAndConditions is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AcceptTermsAndConditions is a force-new property.
+			},
 		},
 		"connection_arn": {
 			// Property: ConnectionArn
@@ -45,7 +47,9 @@ func publisherResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ConnectionArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConnectionArn is a force-new property.
+			},
 		},
 		"identity_provider": {
 			// Property: IdentityProvider

--- a/internal/aws/cloudformation/resource_version_resource_gen.go
+++ b/internal/aws/cloudformation/resource_version_resource_gen.go
@@ -46,7 +46,9 @@ func resourceVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ExecutionRoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ExecutionRoleArn is a force-new property.
+			},
 		},
 		"is_default_version": {
 			// Property: IsDefaultVersion
@@ -105,7 +107,9 @@ func resourceVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			),
 			Optional: true,
 			Computed: true,
-			// LoggingConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LoggingConfig is a force-new property.
+			},
 		},
 		"provisioning_type": {
 			// Property: ProvisioningType
@@ -133,8 +137,10 @@ func resourceVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Description: "A url to the S3 bucket containing the schema handler package that contains the schema, event handlers, and associated files for the type you want to register.\n\nFor information on generating a schema handler package for the type you want to register, see submit in the CloudFormation CLI User Guide.",
 			Type:        types.StringType,
 			Required:    true,
-			// SchemaHandlerPackage is a force-new attribute.
-			// SchemaHandlerPackage is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SchemaHandlerPackage is a force-new property.
+			},
+			// SchemaHandlerPackage is a write-only property.
 		},
 		"type_arn": {
 			// Property: TypeArn
@@ -159,7 +165,9 @@ func resourceVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Description: "The name of the type being registered.\n\nWe recommend that type names adhere to the following pattern: company_or_organization::service::type.",
 			Type:        types.StringType,
 			Required:    true,
-			// TypeName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TypeName is a force-new property.
+			},
 		},
 		"version_id": {
 			// Property: VersionId

--- a/internal/aws/cloudformation/stack_set_resource_gen.go
+++ b/internal/aws/cloudformation/stack_set_resource_gen.go
@@ -94,7 +94,7 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"DELEGATED_ADMIN",
 				}),
 			},
-			// CallAs is a write-only attribute.
+			// CallAs is a write-only property.
 		},
 		"capabilities": {
 			// Property: Capabilities
@@ -246,7 +246,7 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// OperationPreferences is a write-only attribute.
+			// OperationPreferences is a write-only property.
 		},
 		"parameters": {
 			// Property: Parameters
@@ -315,7 +315,9 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"SELF_MANAGED",
 				}),
 			},
-			// PermissionModel is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PermissionModel is a force-new property.
+			},
 		},
 		"stack_instances_group": {
 			// Property: StackInstancesGroup
@@ -484,7 +486,9 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// StackSetName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StackSetName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -579,7 +583,7 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// TemplateURL is a write-only attribute.
+			// TemplateURL is a write-only property.
 		},
 	}
 

--- a/internal/aws/cloudformation/type_activation_resource_gen.go
+++ b/internal/aws/cloudformation/type_activation_resource_gen.go
@@ -57,7 +57,9 @@ func typeActivationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ExecutionRoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ExecutionRoleArn is a force-new property.
+			},
 		},
 		"logging_config": {
 			// Property: LoggingConfig
@@ -105,7 +107,9 @@ func typeActivationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			),
 			Optional: true,
 			Computed: true,
-			// LoggingConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LoggingConfig is a force-new property.
+			},
 		},
 		"major_version": {
 			// Property: MajorVersion
@@ -139,7 +143,9 @@ func typeActivationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1024),
 			},
-			// PublicTypeArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PublicTypeArn is a force-new property.
+			},
 		},
 		"publisher_id": {
 			// Property: PublisherId
@@ -158,7 +164,9 @@ func typeActivationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 40),
 			},
-			// PublisherId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PublisherId is a force-new property.
+			},
 		},
 		"type": {
 			// Property: Type
@@ -181,7 +189,9 @@ func typeActivationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"MODULE",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 		"type_name": {
 			// Property: TypeName
@@ -195,7 +205,9 @@ func typeActivationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// TypeName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TypeName is a force-new property.
+			},
 		},
 		"type_name_alias": {
 			// Property: TypeNameAlias
@@ -214,7 +226,9 @@ func typeActivationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(10, 204),
 			},
-			// TypeNameAlias is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TypeNameAlias is a force-new property.
+			},
 		},
 		"version_bump": {
 			// Property: VersionBump

--- a/internal/aws/cloudfront/function_resource_gen.go
+++ b/internal/aws/cloudfront/function_resource_gen.go
@@ -29,7 +29,7 @@ func functionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.BoolType,
 			Optional: true,
-			// AutoPublish is a write-only attribute.
+			// AutoPublish is a write-only property.
 		},
 		"function_arn": {
 			// Property: FunctionARN
@@ -48,7 +48,7 @@ func functionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Optional: true,
-			// FunctionCode is a write-only attribute.
+			// FunctionCode is a write-only property.
 		},
 		"function_config": {
 			// Property: FunctionConfig

--- a/internal/aws/cloudfront/realtime_log_config_resource_gen.go
+++ b/internal/aws/cloudfront/realtime_log_config_resource_gen.go
@@ -126,7 +126,9 @@ func realtimeLogConfigResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"sampling_rate": {
 			// Property: SamplingRate

--- a/internal/aws/cloudtrail/trail_resource_gen.go
+++ b/internal/aws/cloudtrail/trail_resource_gen.go
@@ -388,7 +388,9 @@ func trailResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(3, 128),
 			},
-			// TrailName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TrailName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/cloudwatch/composite_alarm_resource_gen.go
+++ b/internal/aws/cloudwatch/composite_alarm_resource_gen.go
@@ -86,7 +86,9 @@ func compositeAlarmResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// AlarmName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AlarmName is a force-new property.
+			},
 		},
 		"alarm_rule": {
 			// Property: AlarmRule

--- a/internal/aws/cloudwatch/metric_stream_resource_gen.go
+++ b/internal/aws/cloudwatch/metric_stream_resource_gen.go
@@ -186,7 +186,9 @@ func metricStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"output_format": {
 			// Property: OutputFormat
@@ -294,7 +296,7 @@ func metricStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// Tags is a write-only attribute.
+			// Tags is a write-only property.
 		},
 	}
 

--- a/internal/aws/codeartifact/domain_resource_gen.go
+++ b/internal/aws/codeartifact/domain_resource_gen.go
@@ -52,7 +52,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(2, 50),
 			},
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"encryption_key": {
 			// Property: EncryptionKey
@@ -64,7 +66,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.",
 			Type:        types.StringType,
 			Computed:    true,
-			// EncryptionKey is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EncryptionKey is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name

--- a/internal/aws/codeartifact/repository_resource_gen.go
+++ b/internal/aws/codeartifact/repository_resource_gen.go
@@ -67,7 +67,9 @@ func repositoryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(2, 50),
 			},
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"domain_owner": {
 			// Property: DomainOwner
@@ -80,7 +82,9 @@ func repositoryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The 12-digit account ID of the AWS account that owns the domain.",
 			Type:        types.StringType,
 			Computed:    true,
-			// DomainOwner is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainOwner is a force-new property.
+			},
 		},
 		"external_connections": {
 			// Property: ExternalConnections
@@ -139,7 +143,9 @@ func repositoryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(2, 100),
 			},
-			// RepositoryName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RepositoryName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/codeguruprofiler/profiling_group_resource_gen.go
+++ b/internal/aws/codeguruprofiler/profiling_group_resource_gen.go
@@ -134,7 +134,9 @@ func profilingGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"AWSLambda",
 				}),
 			},
-			// ComputePlatform is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ComputePlatform is a force-new property.
+			},
 		},
 		"profiling_group_name": {
 			// Property: ProfilingGroupName
@@ -152,7 +154,9 @@ func profilingGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// ProfilingGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProfilingGroupName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/codegurureviewer/repository_association_resource_gen.go
+++ b/internal/aws/codegurureviewer/repository_association_resource_gen.go
@@ -54,7 +54,9 @@ func repositoryAssociationResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(3, 63),
 			},
-			// BucketName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BucketName is a force-new property.
+			},
 		},
 		"connection_arn": {
 			// Property: ConnectionArn
@@ -73,7 +75,9 @@ func repositoryAssociationResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 256),
 			},
-			// ConnectionArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConnectionArn is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -91,7 +95,9 @@ func repositoryAssociationResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"owner": {
 			// Property: Owner
@@ -110,7 +116,9 @@ func repositoryAssociationResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// Owner is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Owner is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -172,7 +180,9 @@ func repositoryAssociationResourceType(ctx context.Context) (tfsdk.ResourceType,
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"type": {
 			// Property: Type
@@ -198,7 +208,9 @@ func repositoryAssociationResourceType(ctx context.Context) (tfsdk.ResourceType,
 					"S3Bucket",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/codestarconnections/connection_resource_gen.go
+++ b/internal/aws/codestarconnections/connection_resource_gen.go
@@ -52,7 +52,9 @@ func connectionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 32),
 			},
-			// ConnectionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConnectionName is a force-new property.
+			},
 		},
 		"connection_status": {
 			// Property: ConnectionStatus
@@ -82,7 +84,9 @@ func connectionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 256),
 			},
-			// HostArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // HostArn is a force-new property.
+			},
 		},
 		"owner_account_id": {
 			// Property: OwnerAccountId
@@ -109,7 +113,9 @@ func connectionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ProviderType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProviderType is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/codestarnotifications/notification_rule_resource_gen.go
+++ b/internal/aws/codestarnotifications/notification_rule_resource_gen.go
@@ -91,7 +91,9 @@ func notificationRuleResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// Resource is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Resource is a force-new property.
+			},
 		},
 		"status": {
 			// Property: Status
@@ -121,7 +123,9 @@ func notificationRuleResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"targets": {
 			// Property: Targets

--- a/internal/aws/config/configuration_aggregator_resource_gen.go
+++ b/internal/aws/config/configuration_aggregator_resource_gen.go
@@ -106,7 +106,9 @@ func configurationAggregatorResourceType(ctx context.Context) (tfsdk.ResourceTyp
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// ConfigurationAggregatorName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConfigurationAggregatorName is a force-new property.
+			},
 		},
 		"organization_aggregation_source": {
 			// Property: OrganizationAggregationSource

--- a/internal/aws/config/conformance_pack_resource_gen.go
+++ b/internal/aws/config/conformance_pack_resource_gen.go
@@ -99,7 +99,9 @@ func conformancePackResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// ConformancePackName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConformancePackName is a force-new property.
+			},
 		},
 		"delivery_s3_bucket": {
 			// Property: DeliveryS3Bucket
@@ -148,7 +150,7 @@ func conformancePackResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 51200),
 			},
-			// TemplateBody is a write-only attribute.
+			// TemplateBody is a write-only property.
 		},
 		"template_s3_uri": {
 			// Property: TemplateS3Uri
@@ -166,7 +168,7 @@ func conformancePackResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// TemplateS3Uri is a write-only attribute.
+			// TemplateS3Uri is a write-only property.
 		},
 	}
 

--- a/internal/aws/config/organization_conformance_pack_resource_gen.go
+++ b/internal/aws/config/organization_conformance_pack_resource_gen.go
@@ -146,7 +146,9 @@ func organizationConformancePackResourceType(ctx context.Context) (tfsdk.Resourc
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// OrganizationConformancePackName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // OrganizationConformancePackName is a force-new property.
+			},
 		},
 		"template_body": {
 			// Property: TemplateBody
@@ -163,7 +165,7 @@ func organizationConformancePackResourceType(ctx context.Context) (tfsdk.Resourc
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 51200),
 			},
-			// TemplateBody is a write-only attribute.
+			// TemplateBody is a write-only property.
 		},
 		"template_s3_uri": {
 			// Property: TemplateS3Uri
@@ -181,7 +183,7 @@ func organizationConformancePackResourceType(ctx context.Context) (tfsdk.Resourc
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// TemplateS3Uri is a write-only attribute.
+			// TemplateS3Uri is a write-only property.
 		},
 	}
 

--- a/internal/aws/config/stored_query_resource_gen.go
+++ b/internal/aws/config/stored_query_resource_gen.go
@@ -90,7 +90,9 @@ func storedQueryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// QueryName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // QueryName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/customerprofiles/domain_resource_gen.go
+++ b/internal/aws/customerprofiles/domain_resource_gen.go
@@ -98,7 +98,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"last_updated_at": {
 			// Property: LastUpdatedAt

--- a/internal/aws/customerprofiles/integration_resource_gen.go
+++ b/internal/aws/customerprofiles/integration_resource_gen.go
@@ -50,7 +50,9 @@ func integrationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"flow_definition": {
 			// Property: FlowDefinition
@@ -962,7 +964,7 @@ func integrationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// FlowDefinition is a write-only attribute.
+			// FlowDefinition is a write-only property.
 		},
 		"last_updated_at": {
 			// Property: LastUpdatedAt
@@ -1065,7 +1067,9 @@ func integrationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Uri is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Uri is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/customerprofiles/object_type_resource_gen.go
+++ b/internal/aws/customerprofiles/object_type_resource_gen.go
@@ -77,7 +77,9 @@ func objectTypeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"encryption_key": {
 			// Property: EncryptionKey
@@ -339,7 +341,9 @@ func objectTypeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// ObjectTypeName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ObjectTypeName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/databrew/dataset_resource_gen.go
+++ b/internal/aws/databrew/dataset_resource_gen.go
@@ -485,7 +485,9 @@ func datasetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"path_options": {
 			// Property: PathOptions
@@ -963,7 +965,9 @@ func datasetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/databrew/job_resource_gen.go
+++ b/internal/aws/databrew/job_resource_gen.go
@@ -487,7 +487,9 @@ func jobResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"output_location": {
 			// Property: OutputLocation
@@ -1141,7 +1143,9 @@ func jobResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"timeout": {
 			// Property: Timeout
@@ -1174,7 +1178,9 @@ func jobResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"RECIPE",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/databrew/project_resource_gen.go
+++ b/internal/aws/databrew/project_resource_gen.go
@@ -54,7 +54,9 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"recipe_name": {
 			// Property: RecipeName
@@ -189,7 +191,9 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/databrew/schedule_resource_gen.go
+++ b/internal/aws/databrew/schedule_resource_gen.go
@@ -74,7 +74,9 @@ func scheduleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -128,7 +130,9 @@ func scheduleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/datasync/agent_resource_gen.go
+++ b/internal/aws/datasync/agent_resource_gen.go
@@ -38,8 +38,10 @@ func agentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 29),
 			},
-			// ActivationKey is a force-new attribute.
-			// ActivationKey is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ActivationKey is a force-new property.
+			},
+			// ActivationKey is a write-only property.
 		},
 		"agent_arn": {
 			// Property: AgentArn
@@ -104,7 +106,9 @@ func agentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.ListType{ElemType: types.StringType},
 			Optional:    true,
 			Computed:    true,
-			// SecurityGroupArns is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SecurityGroupArns is a force-new property.
+			},
 		},
 		"subnet_arns": {
 			// Property: SubnetArns
@@ -123,7 +127,9 @@ func agentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.ListType{ElemType: types.StringType},
 			Optional:    true,
 			Computed:    true,
-			// SubnetArns is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SubnetArns is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -200,7 +206,9 @@ func agentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// VpcEndpointId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcEndpointId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/datasync/location_efs_resource_gen.go
+++ b/internal/aws/datasync/location_efs_resource_gen.go
@@ -79,7 +79,9 @@ func locationEFSResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// Ec2Config is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Ec2Config is a force-new property.
+			},
 		},
 		"efs_filesystem_arn": {
 			// Property: EfsFilesystemArn
@@ -96,8 +98,10 @@ func locationEFSResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// EfsFilesystemArn is a force-new attribute.
-			// EfsFilesystemArn is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EfsFilesystemArn is a force-new property.
+			},
+			// EfsFilesystemArn is a write-only property.
 		},
 		"location_arn": {
 			// Property: LocationArn
@@ -141,8 +145,10 @@ func locationEFSResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 4096),
 			},
-			// Subdirectory is a force-new attribute.
-			// Subdirectory is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Subdirectory is a force-new property.
+			},
+			// Subdirectory is a write-only property.
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/datasync/location_fsx_windows_resource_gen.go
+++ b/internal/aws/datasync/location_fsx_windows_resource_gen.go
@@ -39,7 +39,9 @@ func locationFSxWindowsResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 253),
 			},
-			// Domain is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Domain is a force-new property.
+			},
 		},
 		"fsx_filesystem_arn": {
 			// Property: FsxFilesystemArn
@@ -56,8 +58,10 @@ func locationFSxWindowsResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// FsxFilesystemArn is a force-new attribute.
-			// FsxFilesystemArn is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FsxFilesystemArn is a force-new property.
+			},
+			// FsxFilesystemArn is a write-only property.
 		},
 		"location_arn": {
 			// Property: LocationArn
@@ -100,8 +104,10 @@ func locationFSxWindowsResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 104),
 			},
-			// Password is a force-new attribute.
-			// Password is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Password is a force-new property.
+			},
+			// Password is a write-only property.
 		},
 		"security_group_arns": {
 			// Property: SecurityGroupArns
@@ -119,7 +125,9 @@ func locationFSxWindowsResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Description: "The ARNs of the security groups that are to use to configure the FSx for Windows file system.",
 			Type:        types.ListType{ElemType: types.StringType},
 			Required:    true,
-			// SecurityGroupArns is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SecurityGroupArns is a force-new property.
+			},
 		},
 		"subdirectory": {
 			// Property: Subdirectory
@@ -137,8 +145,10 @@ func locationFSxWindowsResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 4096),
 			},
-			// Subdirectory is a force-new attribute.
-			// Subdirectory is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Subdirectory is a force-new property.
+			},
+			// Subdirectory is a write-only property.
 		},
 		"tags": {
 			// Property: Tags
@@ -218,7 +228,9 @@ func locationFSxWindowsResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 104),
 			},
-			// User is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // User is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/datasync/location_nfs_resource_gen.go
+++ b/internal/aws/datasync/location_nfs_resource_gen.go
@@ -146,8 +146,10 @@ func locationNFSResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 255),
 			},
-			// ServerHostname is a force-new attribute.
-			// ServerHostname is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServerHostname is a force-new property.
+			},
+			// ServerHostname is a write-only property.
 		},
 		"subdirectory": {
 			// Property: Subdirectory
@@ -164,7 +166,7 @@ func locationNFSResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 4096),
 			},
-			// Subdirectory is a write-only attribute.
+			// Subdirectory is a write-only property.
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/datasync/location_object_storage_resource_gen.go
+++ b/internal/aws/datasync/location_object_storage_resource_gen.go
@@ -78,8 +78,10 @@ func locationObjectStorageResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(3, 63),
 			},
-			// BucketName is a force-new attribute.
-			// BucketName is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BucketName is a force-new property.
+			},
+			// BucketName is a write-only property.
 		},
 		"location_arn": {
 			// Property: LocationArn
@@ -123,7 +125,7 @@ func locationObjectStorageResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(8, 200),
 			},
-			// SecretKey is a write-only attribute.
+			// SecretKey is a write-only property.
 		},
 		"server_hostname": {
 			// Property: ServerHostname
@@ -140,8 +142,10 @@ func locationObjectStorageResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 255),
 			},
-			// ServerHostname is a force-new attribute.
-			// ServerHostname is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServerHostname is a force-new property.
+			},
+			// ServerHostname is a write-only property.
 		},
 		"server_port": {
 			// Property: ServerPort
@@ -195,7 +199,7 @@ func locationObjectStorageResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 4096),
 			},
-			// Subdirectory is a write-only attribute.
+			// Subdirectory is a write-only property.
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/datasync/location_s3_resource_gen.go
+++ b/internal/aws/datasync/location_s3_resource_gen.go
@@ -64,8 +64,10 @@ func locationS3ResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 156),
 			},
-			// S3BucketArn is a force-new attribute.
-			// S3BucketArn is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // S3BucketArn is a force-new property.
+			},
+			// S3BucketArn is a write-only property.
 		},
 		"s3_config": {
 			// Property: S3Config
@@ -101,7 +103,9 @@ func locationS3ResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// S3Config is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // S3Config is a force-new property.
+			},
 		},
 		"s3_storage_class": {
 			// Property: S3StorageClass
@@ -132,7 +136,9 @@ func locationS3ResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"DEEP_ARCHIVE",
 				}),
 			},
-			// S3StorageClass is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // S3StorageClass is a force-new property.
+			},
 		},
 		"subdirectory": {
 			// Property: Subdirectory
@@ -150,8 +156,10 @@ func locationS3ResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 4096),
 			},
-			// Subdirectory is a force-new attribute.
-			// Subdirectory is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Subdirectory is a force-new property.
+			},
+			// Subdirectory is a write-only property.
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/datasync/location_smb_resource_gen.go
+++ b/internal/aws/datasync/location_smb_resource_gen.go
@@ -141,7 +141,7 @@ func locationSMBResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 104),
 			},
-			// Password is a write-only attribute.
+			// Password is a write-only property.
 		},
 		"server_hostname": {
 			// Property: ServerHostname
@@ -158,8 +158,10 @@ func locationSMBResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 255),
 			},
-			// ServerHostname is a force-new attribute.
-			// ServerHostname is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServerHostname is a force-new property.
+			},
+			// ServerHostname is a write-only property.
 		},
 		"subdirectory": {
 			// Property: Subdirectory
@@ -176,7 +178,7 @@ func locationSMBResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 4096),
 			},
-			// Subdirectory is a write-only attribute.
+			// Subdirectory is a write-only property.
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/datasync/task_resource_gen.go
+++ b/internal/aws/datasync/task_resource_gen.go
@@ -54,7 +54,9 @@ func taskResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// DestinationLocationArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DestinationLocationArn is a force-new property.
+			},
 		},
 		"destination_network_interface_arns": {
 			// Property: DestinationNetworkInterfaceArns
@@ -530,7 +532,9 @@ func taskResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// SourceLocationArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SourceLocationArn is a force-new property.
+			},
 		},
 		"source_network_interface_arns": {
 			// Property: SourceNetworkInterfaceArns

--- a/internal/aws/detective/member_invitation_resource_gen.go
+++ b/internal/aws/detective/member_invitation_resource_gen.go
@@ -45,7 +45,9 @@ func memberInvitationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Description: "The ARN of the graph to which the member account will be invited",
 			Type:        types.StringType,
 			Required:    true,
-			// GraphArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GraphArn is a force-new property.
+			},
 		},
 		"member_email_address": {
 			// Property: MemberEmailAddress
@@ -70,7 +72,9 @@ func memberInvitationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Description: "The AWS account ID to be invited to join the graph as a member",
 			Type:        types.StringType,
 			Required:    true,
-			// MemberId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // MemberId is a force-new property.
+			},
 		},
 		"message": {
 			// Property: Message

--- a/internal/aws/devopsguru/notification_channel_resource_gen.go
+++ b/internal/aws/devopsguru/notification_channel_resource_gen.go
@@ -69,7 +69,9 @@ func notificationChannelResourceType(ctx context.Context) (tfsdk.ResourceType, e
 				},
 			),
 			Required: true,
-			// Config is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Config is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id

--- a/internal/aws/dynamodb/global_table_resource_gen.go
+++ b/internal/aws/dynamodb/global_table_resource_gen.go
@@ -396,7 +396,9 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// KeySchema is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KeySchema is a force-new property.
+			},
 		},
 		"local_secondary_indexes": {
 			// Property: LocalSecondaryIndexes
@@ -523,7 +525,9 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// LocalSecondaryIndexes is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LocalSecondaryIndexes is a force-new property.
+			},
 		},
 		"replicas": {
 			// Property: Replicas
@@ -1098,7 +1102,9 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// TableName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TableName is a force-new property.
+			},
 		},
 		"time_to_live_specification": {
 			// Property: TimeToLiveSpecification

--- a/internal/aws/ec2/carrier_gateway_resource_gen.go
+++ b/internal/aws/ec2/carrier_gateway_resource_gen.go
@@ -115,7 +115,9 @@ func carrierGatewayResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Description: "The ID of the VPC.",
 			Type:        types.StringType,
 			Required:    true,
-			// VpcId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/dhcp_options_resource_gen.go
+++ b/internal/aws/ec2/dhcp_options_resource_gen.go
@@ -43,7 +43,9 @@ func dHCPOptionsResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"domain_name_servers": {
 			// Property: DomainNameServers
@@ -63,7 +65,9 @@ func dHCPOptionsResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// DomainNameServers is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainNameServers is a force-new property.
+			},
 		},
 		"netbios_name_servers": {
 			// Property: NetbiosNameServers
@@ -83,7 +87,9 @@ func dHCPOptionsResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// NetbiosNameServers is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetbiosNameServers is a force-new property.
+			},
 		},
 		"netbios_node_type": {
 			// Property: NetbiosNodeType
@@ -96,7 +102,9 @@ func dHCPOptionsResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.NumberType,
 			Optional:    true,
 			Computed:    true,
-			// NetbiosNodeType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetbiosNodeType is a force-new property.
+			},
 		},
 		"ntp_servers": {
 			// Property: NtpServers
@@ -113,7 +121,9 @@ func dHCPOptionsResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.ListType{ElemType: types.StringType},
 			Optional:    true,
 			Computed:    true,
-			// NtpServers is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NtpServers is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/ec2/ec2_fleet_resource_gen.go
+++ b/internal/aws/ec2/ec2_fleet_resource_gen.go
@@ -271,7 +271,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// LaunchTemplateConfigs is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LaunchTemplateConfigs is a force-new property.
+			},
 		},
 		"on_demand_options": {
 			// Property: OnDemandOptions
@@ -358,7 +360,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// OnDemandOptions is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // OnDemandOptions is a force-new property.
+			},
 		},
 		"replace_unhealthy_instances": {
 			// Property: ReplaceUnhealthyInstances
@@ -369,7 +373,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.BoolType,
 			Optional: true,
 			Computed: true,
-			// ReplaceUnhealthyInstances is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ReplaceUnhealthyInstances is a force-new property.
+			},
 		},
 		"spot_options": {
 			// Property: SpotOptions
@@ -466,7 +472,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// SpotOptions is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SpotOptions is a force-new property.
+			},
 		},
 		"tag_specifications": {
 			// Property: TagSpecifications
@@ -635,7 +643,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// TagSpecifications is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TagSpecifications is a force-new property.
+			},
 		},
 		"target_capacity_specification": {
 			// Property: TargetCapacitySpecification
@@ -706,7 +716,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.BoolType,
 			Optional: true,
 			Computed: true,
-			// TerminateInstancesWithExpiration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TerminateInstancesWithExpiration is a force-new property.
+			},
 		},
 		"type": {
 			// Property: Type
@@ -729,7 +741,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"instant",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 		"valid_from": {
 			// Property: ValidFrom
@@ -740,7 +754,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// ValidFrom is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ValidFrom is a force-new property.
+			},
 		},
 		"valid_until": {
 			// Property: ValidUntil
@@ -751,7 +767,9 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// ValidUntil is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ValidUntil is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/egress_only_internet_gateway_resource_gen.go
+++ b/internal/aws/ec2/egress_only_internet_gateway_resource_gen.go
@@ -42,7 +42,9 @@ func egressOnlyInternetGatewayResourceType(ctx context.Context) (tfsdk.ResourceT
 			Description: "The ID of the VPC for which to create the egress-only internet gateway.",
 			Type:        types.StringType,
 			Required:    true,
-			// VpcId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/enclave_certificate_iam_role_association_resource_gen.go
+++ b/internal/aws/ec2/enclave_certificate_iam_role_association_resource_gen.go
@@ -39,7 +39,9 @@ func enclaveCertificateIamRoleAssociationResourceType(ctx context.Context) (tfsd
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1283),
 			},
-			// CertificateArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateArn is a force-new property.
+			},
 		},
 		"certificate_s3_bucket_name": {
 			// Property: CertificateS3BucketName
@@ -90,7 +92,9 @@ func enclaveCertificateIamRoleAssociationResourceType(ctx context.Context) (tfsd
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1283),
 			},
-			// RoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RoleArn is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/flow_log_resource_gen.go
+++ b/internal/aws/ec2/flow_log_resource_gen.go
@@ -34,7 +34,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// DeliverLogsPermissionArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DeliverLogsPermissionArn is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -58,7 +60,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// LogDestination is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LogDestination is a force-new property.
+			},
 		},
 		"log_destination_type": {
 			// Property: LogDestinationType
@@ -81,7 +85,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"s3",
 				}),
 			},
-			// LogDestinationType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LogDestinationType is a force-new property.
+			},
 		},
 		"log_format": {
 			// Property: LogFormat
@@ -94,7 +100,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// LogFormat is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LogFormat is a force-new property.
+			},
 		},
 		"log_group_name": {
 			// Property: LogGroupName
@@ -107,7 +115,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// LogGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LogGroupName is a force-new property.
+			},
 		},
 		"max_aggregation_interval": {
 			// Property: MaxAggregationInterval
@@ -120,7 +130,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.NumberType,
 			Optional:    true,
 			Computed:    true,
-			// MaxAggregationInterval is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // MaxAggregationInterval is a force-new property.
+			},
 		},
 		"resource_id": {
 			// Property: ResourceId
@@ -132,7 +144,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the subnet, network interface, or VPC for which you want to create a flow log.",
 			Type:        types.StringType,
 			Required:    true,
-			// ResourceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceId is a force-new property.
+			},
 		},
 		"resource_type": {
 			// Property: ResourceType
@@ -156,7 +170,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"VPC",
 				}),
 			},
-			// ResourceType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceType is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -222,7 +238,9 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"REJECT",
 				}),
 			},
-			// TrafficType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TrafficType is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/gateway_route_table_association_resource_gen.go
+++ b/internal/aws/ec2/gateway_route_table_association_resource_gen.go
@@ -42,7 +42,9 @@ func gatewayRouteTableAssociationResourceType(ctx context.Context) (tfsdk.Resour
 			Description: "The ID of the gateway.",
 			Type:        types.StringType,
 			Required:    true,
-			// GatewayId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GatewayId is a force-new property.
+			},
 		},
 		"route_table_id": {
 			// Property: RouteTableId

--- a/internal/aws/ec2/local_gateway_route_resource_gen.go
+++ b/internal/aws/ec2/local_gateway_route_resource_gen.go
@@ -31,7 +31,9 @@ func localGatewayRouteResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Description: "The CIDR block used for destination matches.",
 			Type:        types.StringType,
 			Required:    true,
-			// DestinationCidrBlock is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DestinationCidrBlock is a force-new property.
+			},
 		},
 		"local_gateway_route_table_id": {
 			// Property: LocalGatewayRouteTableId
@@ -43,7 +45,9 @@ func localGatewayRouteResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Description: "The ID of the local gateway route table.",
 			Type:        types.StringType,
 			Required:    true,
-			// LocalGatewayRouteTableId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LocalGatewayRouteTableId is a force-new property.
+			},
 		},
 		"local_gateway_virtual_interface_group_id": {
 			// Property: LocalGatewayVirtualInterfaceGroupId
@@ -55,7 +59,9 @@ func localGatewayRouteResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Description: "The ID of the virtual interface group.",
 			Type:        types.StringType,
 			Required:    true,
-			// LocalGatewayVirtualInterfaceGroupId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LocalGatewayVirtualInterfaceGroupId is a force-new property.
+			},
 		},
 		"state": {
 			// Property: State

--- a/internal/aws/ec2/local_gateway_route_table_vpc_association_resource_gen.go
+++ b/internal/aws/ec2/local_gateway_route_table_vpc_association_resource_gen.go
@@ -44,7 +44,9 @@ func localGatewayRouteTableVPCAssociationResourceType(ctx context.Context) (tfsd
 			Description: "The ID of the local gateway route table.",
 			Type:        types.StringType,
 			Required:    true,
-			// LocalGatewayRouteTableId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LocalGatewayRouteTableId is a force-new property.
+			},
 		},
 		"local_gateway_route_table_vpc_association_id": {
 			// Property: LocalGatewayRouteTableVpcAssociationId
@@ -127,7 +129,9 @@ func localGatewayRouteTableVPCAssociationResourceType(ctx context.Context) (tfsd
 			Description: "The ID of the VPC.",
 			Type:        types.StringType,
 			Required:    true,
-			// VpcId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/network_insights_analysis_resource_gen.go
+++ b/internal/aws/ec2/network_insights_analysis_resource_gen.go
@@ -1363,7 +1363,9 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 			Type:     types.ListType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// FilterInArns is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FilterInArns is a force-new property.
+			},
 		},
 		"forward_path_components": {
 			// Property: ForwardPathComponents
@@ -2054,7 +2056,9 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// NetworkInsightsPathId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkInsightsPathId is a force-new property.
+			},
 		},
 		"network_path_found": {
 			// Property: NetworkPathFound

--- a/internal/aws/ec2/network_insights_path_resource_gen.go
+++ b/internal/aws/ec2/network_insights_path_resource_gen.go
@@ -40,7 +40,9 @@ func networkInsightsPathResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// Destination is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Destination is a force-new property.
+			},
 		},
 		"destination_ip": {
 			// Property: DestinationIp
@@ -51,7 +53,9 @@ func networkInsightsPathResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// DestinationIp is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DestinationIp is a force-new property.
+			},
 		},
 		"destination_port": {
 			// Property: DestinationPort
@@ -62,7 +66,9 @@ func networkInsightsPathResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			Type:     types.NumberType,
 			Optional: true,
 			Computed: true,
-			// DestinationPort is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DestinationPort is a force-new property.
+			},
 		},
 		"network_insights_path_arn": {
 			// Property: NetworkInsightsPathArn
@@ -100,7 +106,9 @@ func networkInsightsPathResourceType(ctx context.Context) (tfsdk.ResourceType, e
 					"udp",
 				}),
 			},
-			// Protocol is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Protocol is a force-new property.
+			},
 		},
 		"source": {
 			// Property: Source
@@ -110,7 +118,9 @@ func networkInsightsPathResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// Source is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Source is a force-new property.
+			},
 		},
 		"source_ip": {
 			// Property: SourceIp
@@ -121,7 +131,9 @@ func networkInsightsPathResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// SourceIp is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SourceIp is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/ec2/spot_fleet_resource_gen.go
+++ b/internal/aws/ec2/spot_fleet_resource_gen.go
@@ -573,7 +573,9 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"lowestPrice",
 							}),
 						},
-						// AllocationStrategy is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // AllocationStrategy is a force-new property.
+						},
 					},
 					"context": {
 						// Property: Context
@@ -597,7 +599,9 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						// Property: IamFleetRole
 						Type:     types.StringType,
 						Required: true,
-						// IamFleetRole is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // IamFleetRole is a force-new property.
+						},
 					},
 					"instance_interruption_behavior": {
 						// Property: InstanceInterruptionBehavior
@@ -611,14 +615,18 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"terminate",
 							}),
 						},
-						// InstanceInterruptionBehavior is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // InstanceInterruptionBehavior is a force-new property.
+						},
 					},
 					"instance_pools_to_use_count": {
 						// Property: InstancePoolsToUseCount
 						Type:     types.NumberType,
 						Optional: true,
 						Computed: true,
-						// InstancePoolsToUseCount is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // InstancePoolsToUseCount is a force-new property.
+						},
 					},
 					"launch_specifications": {
 						// Property: LaunchSpecifications
@@ -1017,7 +1025,9 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Validators: []tfsdk.AttributeValidator{
 							validate.UniqueItems(),
 						},
-						// LaunchSpecifications is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // LaunchSpecifications is a force-new property.
+						},
 					},
 					"launch_template_configs": {
 						// Property: LaunchTemplateConfigs
@@ -1094,7 +1104,9 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Validators: []tfsdk.AttributeValidator{
 							validate.UniqueItems(),
 						},
-						// LaunchTemplateConfigs is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // LaunchTemplateConfigs is a force-new property.
+						},
 					},
 					"load_balancers_config": {
 						// Property: LoadBalancersConfig
@@ -1154,35 +1166,45 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						),
 						Optional: true,
 						Computed: true,
-						// LoadBalancersConfig is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // LoadBalancersConfig is a force-new property.
+						},
 					},
 					"on_demand_allocation_strategy": {
 						// Property: OnDemandAllocationStrategy
 						Type:     types.StringType,
 						Optional: true,
 						Computed: true,
-						// OnDemandAllocationStrategy is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // OnDemandAllocationStrategy is a force-new property.
+						},
 					},
 					"on_demand_max_total_price": {
 						// Property: OnDemandMaxTotalPrice
 						Type:     types.StringType,
 						Optional: true,
 						Computed: true,
-						// OnDemandMaxTotalPrice is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // OnDemandMaxTotalPrice is a force-new property.
+						},
 					},
 					"on_demand_target_capacity": {
 						// Property: OnDemandTargetCapacity
 						Type:     types.NumberType,
 						Optional: true,
 						Computed: true,
-						// OnDemandTargetCapacity is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // OnDemandTargetCapacity is a force-new property.
+						},
 					},
 					"replace_unhealthy_instances": {
 						// Property: ReplaceUnhealthyInstances
 						Type:     types.BoolType,
 						Optional: true,
 						Computed: true,
-						// ReplaceUnhealthyInstances is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // ReplaceUnhealthyInstances is a force-new property.
+						},
 					},
 					"spot_maintenance_strategies": {
 						// Property: SpotMaintenanceStrategies
@@ -1210,21 +1232,27 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						),
 						Optional: true,
 						Computed: true,
-						// SpotMaintenanceStrategies is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // SpotMaintenanceStrategies is a force-new property.
+						},
 					},
 					"spot_max_total_price": {
 						// Property: SpotMaxTotalPrice
 						Type:     types.StringType,
 						Optional: true,
 						Computed: true,
-						// SpotMaxTotalPrice is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // SpotMaxTotalPrice is a force-new property.
+						},
 					},
 					"spot_price": {
 						// Property: SpotPrice
 						Type:     types.StringType,
 						Optional: true,
 						Computed: true,
-						// SpotPrice is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // SpotPrice is a force-new property.
+						},
 					},
 					"target_capacity": {
 						// Property: TargetCapacity
@@ -1236,7 +1264,9 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Type:     types.BoolType,
 						Optional: true,
 						Computed: true,
-						// TerminateInstancesWithExpiration is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // TerminateInstancesWithExpiration is a force-new property.
+						},
 					},
 					"type": {
 						// Property: Type
@@ -1249,21 +1279,27 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"request",
 							}),
 						},
-						// Type is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // Type is a force-new property.
+						},
 					},
 					"valid_from": {
 						// Property: ValidFrom
 						Type:     types.StringType,
 						Optional: true,
 						Computed: true,
-						// ValidFrom is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // ValidFrom is a force-new property.
+						},
 					},
 					"valid_until": {
 						// Property: ValidUntil
 						Type:     types.StringType,
 						Optional: true,
 						Computed: true,
-						// ValidUntil is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // ValidUntil is a force-new property.
+						},
 					},
 				},
 			),

--- a/internal/aws/ec2/transit_gateway_connect_resource_gen.go
+++ b/internal/aws/ec2/transit_gateway_connect_resource_gen.go
@@ -56,7 +56,9 @@ func transitGatewayConnectResourceType(ctx context.Context) (tfsdk.ResourceType,
 				},
 			),
 			Required: true,
-			// Options is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Options is a force-new property.
+			},
 		},
 		"state": {
 			// Property: State
@@ -142,7 +144,9 @@ func transitGatewayConnectResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Description: "The ID of the attachment from which the Connect attachment was created.",
 			Type:        types.StringType,
 			Required:    true,
-			// TransportTransitGatewayAttachmentId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TransportTransitGatewayAttachmentId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/transit_gateway_multicast_domain_association_resource_gen.go
+++ b/internal/aws/ec2/transit_gateway_multicast_domain_association_resource_gen.go
@@ -64,7 +64,9 @@ func transitGatewayMulticastDomainAssociationResourceType(ctx context.Context) (
 			Description: "The IDs of the subnets to associate with the transit gateway multicast domain.",
 			Type:        types.StringType,
 			Required:    true,
-			// SubnetId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SubnetId is a force-new property.
+			},
 		},
 		"transit_gateway_attachment_id": {
 			// Property: TransitGatewayAttachmentId
@@ -76,7 +78,9 @@ func transitGatewayMulticastDomainAssociationResourceType(ctx context.Context) (
 			Description: "The ID of the transit gateway attachment.",
 			Type:        types.StringType,
 			Required:    true,
-			// TransitGatewayAttachmentId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TransitGatewayAttachmentId is a force-new property.
+			},
 		},
 		"transit_gateway_multicast_domain_id": {
 			// Property: TransitGatewayMulticastDomainId
@@ -88,7 +92,9 @@ func transitGatewayMulticastDomainAssociationResourceType(ctx context.Context) (
 			Description: "The ID of the transit gateway multicast domain.",
 			Type:        types.StringType,
 			Required:    true,
-			// TransitGatewayMulticastDomainId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TransitGatewayMulticastDomainId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/transit_gateway_multicast_domain_resource_gen.go
+++ b/internal/aws/ec2/transit_gateway_multicast_domain_resource_gen.go
@@ -142,7 +142,9 @@ func transitGatewayMulticastDomainResourceType(ctx context.Context) (tfsdk.Resou
 			Description: "The ID of the transit gateway.",
 			Type:        types.StringType,
 			Required:    true,
-			// TransitGatewayId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TransitGatewayId is a force-new property.
+			},
 		},
 		"transit_gateway_multicast_domain_arn": {
 			// Property: TransitGatewayMulticastDomainArn

--- a/internal/aws/ec2/transit_gateway_multicast_group_member_resource_gen.go
+++ b/internal/aws/ec2/transit_gateway_multicast_group_member_resource_gen.go
@@ -31,7 +31,9 @@ func transitGatewayMulticastGroupMemberResourceType(ctx context.Context) (tfsdk.
 			Description: "The IP address assigned to the transit gateway multicast group.",
 			Type:        types.StringType,
 			Required:    true,
-			// GroupIpAddress is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GroupIpAddress is a force-new property.
+			},
 		},
 		"group_member": {
 			// Property: GroupMember
@@ -76,7 +78,9 @@ func transitGatewayMulticastGroupMemberResourceType(ctx context.Context) (tfsdk.
 			Description: "The ID of the transit gateway attachment.",
 			Type:        types.StringType,
 			Required:    true,
-			// NetworkInterfaceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkInterfaceId is a force-new property.
+			},
 		},
 		"resource_id": {
 			// Property: ResourceId
@@ -143,7 +147,9 @@ func transitGatewayMulticastGroupMemberResourceType(ctx context.Context) (tfsdk.
 			Description: "The ID of the transit gateway multicast domain.",
 			Type:        types.StringType,
 			Required:    true,
-			// TransitGatewayMulticastDomainId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TransitGatewayMulticastDomainId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/transit_gateway_multicast_group_source_resource_gen.go
+++ b/internal/aws/ec2/transit_gateway_multicast_group_source_resource_gen.go
@@ -31,7 +31,9 @@ func transitGatewayMulticastGroupSourceResourceType(ctx context.Context) (tfsdk.
 			Description: "The IP address assigned to the transit gateway multicast group.",
 			Type:        types.StringType,
 			Required:    true,
-			// GroupIpAddress is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GroupIpAddress is a force-new property.
+			},
 		},
 		"group_member": {
 			// Property: GroupMember
@@ -76,7 +78,9 @@ func transitGatewayMulticastGroupSourceResourceType(ctx context.Context) (tfsdk.
 			Description: "The ID of the transit gateway attachment.",
 			Type:        types.StringType,
 			Required:    true,
-			// NetworkInterfaceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkInterfaceId is a force-new property.
+			},
 		},
 		"resource_id": {
 			// Property: ResourceId
@@ -143,7 +147,9 @@ func transitGatewayMulticastGroupSourceResourceType(ctx context.Context) (tfsdk.
 			Description: "The ID of the transit gateway multicast domain.",
 			Type:        types.StringType,
 			Required:    true,
-			// TransitGatewayMulticastDomainId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TransitGatewayMulticastDomainId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/transit_gateway_peering_attachment_resource_gen.go
+++ b/internal/aws/ec2/transit_gateway_peering_attachment_resource_gen.go
@@ -43,7 +43,9 @@ func transitGatewayPeeringAttachmentResourceType(ctx context.Context) (tfsdk.Res
 			Description: "The ID of the peer account",
 			Type:        types.StringType,
 			Required:    true,
-			// PeerAccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PeerAccountId is a force-new property.
+			},
 		},
 		"peer_region": {
 			// Property: PeerRegion
@@ -55,7 +57,9 @@ func transitGatewayPeeringAttachmentResourceType(ctx context.Context) (tfsdk.Res
 			Description: "Peer Region",
 			Type:        types.StringType,
 			Required:    true,
-			// PeerRegion is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PeerRegion is a force-new property.
+			},
 		},
 		"peer_transit_gateway_id": {
 			// Property: PeerTransitGatewayId
@@ -67,7 +71,9 @@ func transitGatewayPeeringAttachmentResourceType(ctx context.Context) (tfsdk.Res
 			Description: "The ID of the peer transit gateway.",
 			Type:        types.StringType,
 			Required:    true,
-			// PeerTransitGatewayId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PeerTransitGatewayId is a force-new property.
+			},
 		},
 		"state": {
 			// Property: State
@@ -177,7 +183,9 @@ func transitGatewayPeeringAttachmentResourceType(ctx context.Context) (tfsdk.Res
 			Description: "The ID of the transit gateway.",
 			Type:        types.StringType,
 			Required:    true,
-			// TransitGatewayId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TransitGatewayId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ec2/transit_gateway_resource_gen.go
+++ b/internal/aws/ec2/transit_gateway_resource_gen.go
@@ -30,7 +30,9 @@ func transitGatewayResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.NumberType,
 			Optional: true,
 			Computed: true,
-			// AmazonSideAsn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AmazonSideAsn is a force-new property.
+			},
 		},
 		"association_default_route_table_id": {
 			// Property: AssociationDefaultRouteTableId
@@ -104,7 +106,9 @@ func transitGatewayResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// MulticastSupport is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // MulticastSupport is a force-new property.
+			},
 		},
 		"propagation_default_route_table_id": {
 			// Property: PropagationDefaultRouteTableId

--- a/internal/aws/ecr/repository_resource_gen.go
+++ b/internal/aws/ecr/repository_resource_gen.go
@@ -73,7 +73,9 @@ func repositoryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"KMS",
 							}),
 						},
-						// EncryptionType is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // EncryptionType is a force-new property.
+						},
 					},
 					"kms_key": {
 						// Property: KmsKey
@@ -84,13 +86,17 @@ func repositoryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Validators: []tfsdk.AttributeValidator{
 							validate.StringLenBetween(1, 2048),
 						},
-						// KmsKey is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // KmsKey is a force-new property.
+						},
 					},
 				},
 			),
 			Optional: true,
 			Computed: true,
-			// EncryptionConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EncryptionConfiguration is a force-new property.
+			},
 		},
 		"image_scanning_configuration": {
 			// Property: ImageScanningConfiguration
@@ -205,7 +211,9 @@ func repositoryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(2, 256),
 			},
-			// RepositoryName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RepositoryName is a force-new property.
+			},
 		},
 		"repository_policy_text": {
 			// Property: RepositoryPolicyText

--- a/internal/aws/ecs/capacity_provider_resource_gen.go
+++ b/internal/aws/ecs/capacity_provider_resource_gen.go
@@ -77,7 +77,9 @@ func capacityProviderResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 						// Property: AutoScalingGroupArn
 						Type:     types.StringType,
 						Required: true,
-						// AutoScalingGroupArn is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // AutoScalingGroupArn is a force-new property.
+						},
 					},
 					"managed_scaling": {
 						// Property: ManagedScaling
@@ -143,7 +145,9 @@ func capacityProviderResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/ecs/cluster_capacity_provider_associations_resource_gen.go
+++ b/internal/aws/ecs/cluster_capacity_provider_associations_resource_gen.go
@@ -61,7 +61,9 @@ func clusterCapacityProviderAssociationsResourceType(ctx context.Context) (tfsdk
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// Cluster is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Cluster is a force-new property.
+			},
 		},
 		"default_capacity_provider_strategy": {
 			// Property: DefaultCapacityProviderStrategy

--- a/internal/aws/ecs/cluster_resource_gen.go
+++ b/internal/aws/ecs/cluster_resource_gen.go
@@ -55,7 +55,9 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ClusterName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ClusterName is a force-new property.
+			},
 		},
 		"cluster_settings": {
 			// Property: ClusterSettings

--- a/internal/aws/ecs/primary_task_set_resource_gen.go
+++ b/internal/aws/ecs/primary_task_set_resource_gen.go
@@ -31,7 +31,9 @@ func primaryTaskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Description: "The short name or full Amazon Resource Name (ARN) of the cluster that hosts the service to create the task set in.",
 			Type:        types.StringType,
 			Required:    true,
-			// Cluster is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Cluster is a force-new property.
+			},
 		},
 		"service": {
 			// Property: Service
@@ -43,7 +45,9 @@ func primaryTaskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Description: "The short name or full Amazon Resource Name (ARN) of the service to create the task set in.",
 			Type:        types.StringType,
 			Required:    true,
-			// Service is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Service is a force-new property.
+			},
 		},
 		"task_set_id": {
 			// Property: TaskSetId

--- a/internal/aws/ecs/service_resource_gen.go
+++ b/internal/aws/ecs/service_resource_gen.go
@@ -75,7 +75,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// Cluster is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Cluster is a force-new property.
+			},
 		},
 		"deployment_configuration": {
 			// Property: DeploymentConfiguration
@@ -177,7 +179,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// DeploymentController is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DeploymentController is a force-new property.
+			},
 		},
 		"desired_count": {
 			// Property: DesiredCount
@@ -197,7 +201,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.BoolType,
 			Optional: true,
 			Computed: true,
-			// EnableECSManagedTags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EnableECSManagedTags is a force-new property.
+			},
 		},
 		"enable_execute_command": {
 			// Property: EnableExecuteCommand
@@ -238,7 +244,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"EXTERNAL",
 				}),
 			},
-			// LaunchType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LaunchType is a force-new property.
+			},
 		},
 		"load_balancers": {
 			// Property: LoadBalancers
@@ -291,7 +299,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// LoadBalancers is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LoadBalancers is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -419,7 +429,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// PlacementConstraints is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PlacementConstraints is a force-new property.
+			},
 		},
 		"placement_strategies": {
 			// Property: PlacementStrategies
@@ -471,7 +483,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// PlacementStrategies is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PlacementStrategies is a force-new property.
+			},
 		},
 		"platform_version": {
 			// Property: PlatformVersion
@@ -501,7 +515,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"TASK_DEFINITION",
 				}),
 			},
-			// PropagateTags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PropagateTags is a force-new property.
+			},
 		},
 		"role": {
 			// Property: Role
@@ -512,7 +528,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// Role is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Role is a force-new property.
+			},
 		},
 		"scheduling_strategy": {
 			// Property: SchedulingStrategy
@@ -533,7 +551,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"REPLICA",
 				}),
 			},
-			// SchedulingStrategy is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SchedulingStrategy is a force-new property.
+			},
 		},
 		"service_arn": {
 			// Property: ServiceArn
@@ -553,7 +573,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// ServiceName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServiceName is a force-new property.
+			},
 		},
 		"service_registries": {
 			// Property: ServiceRegistries
@@ -606,7 +628,9 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// ServiceRegistries is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServiceRegistries is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/ecs/task_definition_resource_gen.go
+++ b/internal/aws/ecs/task_definition_resource_gen.go
@@ -1084,7 +1084,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// ContainerDefinitions is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ContainerDefinitions is a force-new property.
+			},
 		},
 		"cpu": {
 			// Property: Cpu
@@ -1095,7 +1097,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// Cpu is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Cpu is a force-new property.
+			},
 		},
 		"ephemeral_storage": {
 			// Property: EphemeralStorage
@@ -1120,7 +1124,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			),
 			Optional: true,
 			Computed: true,
-			// EphemeralStorage is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EphemeralStorage is a force-new property.
+			},
 		},
 		"execution_role_arn": {
 			// Property: ExecutionRoleArn
@@ -1131,7 +1137,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// ExecutionRoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ExecutionRoleArn is a force-new property.
+			},
 		},
 		"family": {
 			// Property: Family
@@ -1142,7 +1150,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// Family is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Family is a force-new property.
+			},
 		},
 		"inference_accelerators": {
 			// Property: InferenceAccelerators
@@ -1183,7 +1193,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// InferenceAccelerators is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InferenceAccelerators is a force-new property.
+			},
 		},
 		"ipc_mode": {
 			// Property: IpcMode
@@ -1194,7 +1206,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// IpcMode is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // IpcMode is a force-new property.
+			},
 		},
 		"memory": {
 			// Property: Memory
@@ -1205,7 +1219,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// Memory is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Memory is a force-new property.
+			},
 		},
 		"network_mode": {
 			// Property: NetworkMode
@@ -1216,7 +1232,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// NetworkMode is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkMode is a force-new property.
+			},
 		},
 		"pid_mode": {
 			// Property: PidMode
@@ -1227,7 +1245,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// PidMode is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PidMode is a force-new property.
+			},
 		},
 		"placement_constraints": {
 			// Property: PlacementConstraints
@@ -1271,7 +1291,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// PlacementConstraints is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PlacementConstraints is a force-new property.
+			},
 		},
 		"proxy_configuration": {
 			// Property: ProxyConfiguration
@@ -1345,7 +1367,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			),
 			Optional: true,
 			Computed: true,
-			// ProxyConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProxyConfiguration is a force-new property.
+			},
 		},
 		"requires_compatibilities": {
 			// Property: RequiresCompatibilities
@@ -1363,7 +1387,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// RequiresCompatibilities is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RequiresCompatibilities is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -1420,7 +1446,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// TaskRoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TaskRoleArn is a force-new property.
+			},
 		},
 		"volumes": {
 			// Property: Volumes
@@ -1642,7 +1670,9 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// Volumes is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Volumes is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ecs/task_set_resource_gen.go
+++ b/internal/aws/ecs/task_set_resource_gen.go
@@ -33,7 +33,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The short name or full Amazon Resource Name (ARN) of the cluster that hosts the service to create the task set in.",
 			Type:        types.StringType,
 			Required:    true,
-			// Cluster is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Cluster is a force-new property.
+			},
 		},
 		"external_id": {
 			// Property: ExternalId
@@ -46,7 +48,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ExternalId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ExternalId is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -80,7 +84,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"FARGATE",
 				}),
 			},
-			// LaunchType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LaunchType is a force-new property.
+			},
 		},
 		"load_balancers": {
 			// Property: LoadBalancers
@@ -142,7 +148,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// LoadBalancers is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LoadBalancers is a force-new property.
+			},
 		},
 		"network_configuration": {
 			// Property: NetworkConfiguration
@@ -234,7 +242,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// NetworkConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkConfiguration is a force-new property.
+			},
 		},
 		"platform_version": {
 			// Property: PlatformVersion
@@ -247,7 +257,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// PlatformVersion is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PlatformVersion is a force-new property.
+			},
 		},
 		"scale": {
 			// Property: Scale
@@ -307,7 +319,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The short name or full Amazon Resource Name (ARN) of the service to create the task set in.",
 			Type:        types.StringType,
 			Required:    true,
-			// Service is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Service is a force-new property.
+			},
 		},
 		"service_registries": {
 			// Property: ServiceRegistries
@@ -370,7 +384,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// ServiceRegistries is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServiceRegistries is a force-new property.
+			},
 		},
 		"task_definition": {
 			// Property: TaskDefinition
@@ -382,7 +398,9 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The short name or full Amazon Resource Name (ARN) of the task definition for the tasks in the task set to use.",
 			Type:        types.StringType,
 			Required:    true,
-			// TaskDefinition is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TaskDefinition is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/efs/access_point_resource_gen.go
+++ b/internal/aws/efs/access_point_resource_gen.go
@@ -99,7 +99,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ClientToken is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ClientToken is a force-new property.
+			},
 		},
 		"file_system_id": {
 			// Property: FileSystemId
@@ -111,7 +113,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the EFS file system that the access point provides access to.",
 			Type:        types.StringType,
 			Required:    true,
-			// FileSystemId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FileSystemId is a force-new property.
+			},
 		},
 		"posix_user": {
 			// Property: PosixUser
@@ -148,7 +152,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Description: "The POSIX group ID used for all file system operations using this access point.",
 						Type:        types.StringType,
 						Required:    true,
-						// Gid is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // Gid is a force-new property.
+						},
 					},
 					"secondary_gids": {
 						// Property: SecondaryGids
@@ -156,20 +162,26 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Type:        types.ListType{ElemType: types.StringType},
 						Optional:    true,
 						Computed:    true,
-						// SecondaryGids is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // SecondaryGids is a force-new property.
+						},
 					},
 					"uid": {
 						// Property: Uid
 						Description: "The POSIX user ID used for all file system operations using this access point.",
 						Type:        types.StringType,
 						Required:    true,
-						// Uid is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // Uid is a force-new property.
+						},
 					},
 				},
 			),
 			Optional: true,
 			Computed: true,
-			// PosixUser is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PosixUser is a force-new property.
+			},
 		},
 		"root_directory": {
 			// Property: RootDirectory
@@ -238,7 +250,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						),
 						Optional: true,
 						Computed: true,
-						// CreationInfo is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // CreationInfo is a force-new property.
+						},
 					},
 					"path": {
 						// Property: Path
@@ -249,13 +263,17 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Validators: []tfsdk.AttributeValidator{
 							validate.StringLenBetween(1, 100),
 						},
-						// Path is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // Path is a force-new property.
+						},
 					},
 				},
 			),
 			Optional: true,
 			Computed: true,
-			// RootDirectory is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RootDirectory is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/efs/file_system_resource_gen.go
+++ b/internal/aws/efs/file_system_resource_gen.go
@@ -41,7 +41,9 @@ func fileSystemResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// AvailabilityZoneName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AvailabilityZoneName is a force-new property.
+			},
 		},
 		"backup_policy": {
 			// Property: BackupPolicy
@@ -79,7 +81,7 @@ func fileSystemResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "Whether to bypass the FileSystemPolicy lockout safety check. The policy lockout safety check determines whether the policy in the request will prevent the principal making the request to be locked out from making future PutFileSystemPolicy requests on the file system. Set BypassPolicyLockoutSafetyCheck to True only when you intend to prevent the principal that is making the request from making a subsequent PutFileSystemPolicy request on the file system. Defaults to false",
 			Type:        types.BoolType,
 			Optional:    true,
-			// BypassPolicyLockoutSafetyCheck is a write-only attribute.
+			// BypassPolicyLockoutSafetyCheck is a write-only property.
 		},
 		"encrypted": {
 			// Property: Encrypted
@@ -90,7 +92,9 @@ func fileSystemResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.BoolType,
 			Optional: true,
 			Computed: true,
-			// Encrypted is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Encrypted is a force-new property.
+			},
 		},
 		"file_system_id": {
 			// Property: FileSystemId
@@ -162,7 +166,9 @@ func fileSystemResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// KmsKeyId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KmsKeyId is a force-new property.
+			},
 		},
 		"lifecycle_policies": {
 			// Property: LifecyclePolicies
@@ -207,7 +213,9 @@ func fileSystemResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// PerformanceMode is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PerformanceMode is a force-new property.
+			},
 		},
 		"provisioned_throughput_in_mibps": {
 			// Property: ProvisionedThroughputInMibps

--- a/internal/aws/eks/addon_resource_gen.go
+++ b/internal/aws/eks/addon_resource_gen.go
@@ -37,7 +37,9 @@ func addonResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// AddonName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AddonName is a force-new property.
+			},
 		},
 		"addon_version": {
 			// Property: AddonVersion
@@ -79,7 +81,9 @@ func addonResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// ClusterName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ClusterName is a force-new property.
+			},
 		},
 		"resolve_conflicts": {
 			// Property: ResolveConflicts
@@ -103,7 +107,7 @@ func addonResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"OVERWRITE",
 				}),
 			},
-			// ResolveConflicts is a write-only attribute.
+			// ResolveConflicts is a write-only property.
 		},
 		"service_account_role_arn": {
 			// Property: ServiceAccountRoleArn

--- a/internal/aws/eks/fargate_profile_resource_gen.go
+++ b/internal/aws/eks/fargate_profile_resource_gen.go
@@ -46,7 +46,9 @@ func fargateProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// ClusterName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ClusterName is a force-new property.
+			},
 		},
 		"fargate_profile_name": {
 			// Property: FargateProfileName
@@ -63,7 +65,9 @@ func fargateProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// FargateProfileName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FargateProfileName is a force-new property.
+			},
 		},
 		"pod_execution_role_arn": {
 			// Property: PodExecutionRoleArn
@@ -79,7 +83,9 @@ func fargateProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// PodExecutionRoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PodExecutionRoleArn is a force-new property.
+			},
 		},
 		"selectors": {
 			// Property: Selectors
@@ -170,7 +176,9 @@ func fargateProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 				},
 			),
 			Required: true,
-			// Selectors is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Selectors is a force-new property.
+			},
 		},
 		"subnets": {
 			// Property: Subnets
@@ -184,7 +192,9 @@ func fargateProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.ListType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Subnets is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Subnets is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/elasticache/global_replication_group_resource_gen.go
+++ b/internal/aws/elasticache/global_replication_group_resource_gen.go
@@ -33,7 +33,7 @@ func globalReplicationGroupResourceType(ctx context.Context) (tfsdk.ResourceType
 			Description: "AutomaticFailoverEnabled",
 			Type:        types.BoolType,
 			Optional:    true,
-			// AutomaticFailoverEnabled is a write-only attribute.
+			// AutomaticFailoverEnabled is a write-only property.
 		},
 		"cache_node_type": {
 			// Property: CacheNodeType
@@ -45,7 +45,7 @@ func globalReplicationGroupResourceType(ctx context.Context) (tfsdk.ResourceType
 			Description: "The cache node type of the Global Datastore",
 			Type:        types.StringType,
 			Optional:    true,
-			// CacheNodeType is a write-only attribute.
+			// CacheNodeType is a write-only property.
 		},
 		"cache_parameter_group_name": {
 			// Property: CacheParameterGroupName
@@ -68,7 +68,7 @@ func globalReplicationGroupResourceType(ctx context.Context) (tfsdk.ResourceType
 			Description: "The engine version of the Global Datastore.",
 			Type:        types.StringType,
 			Optional:    true,
-			// EngineVersion is a write-only attribute.
+			// EngineVersion is a write-only property.
 		},
 		"global_node_group_count": {
 			// Property: GlobalNodeGroupCount
@@ -80,7 +80,7 @@ func globalReplicationGroupResourceType(ctx context.Context) (tfsdk.ResourceType
 			Description: "Indicates the number of node groups in the Global Datastore.",
 			Type:        types.NumberType,
 			Optional:    true,
-			// GlobalNodeGroupCount is a write-only attribute.
+			// GlobalNodeGroupCount is a write-only property.
 		},
 		"global_replication_group_description": {
 			// Property: GlobalReplicationGroupDescription
@@ -92,7 +92,7 @@ func globalReplicationGroupResourceType(ctx context.Context) (tfsdk.ResourceType
 			Description: "The optional description of the Global Datastore",
 			Type:        types.StringType,
 			Optional:    true,
-			// GlobalReplicationGroupDescription is a write-only attribute.
+			// GlobalReplicationGroupDescription is a write-only property.
 		},
 		"global_replication_group_id": {
 			// Property: GlobalReplicationGroupId
@@ -115,7 +115,7 @@ func globalReplicationGroupResourceType(ctx context.Context) (tfsdk.ResourceType
 			Description: "The suffix name of a Global Datastore. Amazon ElastiCache automatically applies a prefix to the Global Datastore ID when it is created. Each AWS Region has its own prefix. ",
 			Type:        types.StringType,
 			Optional:    true,
-			// GlobalReplicationGroupIdSuffix is a write-only attribute.
+			// GlobalReplicationGroupIdSuffix is a write-only property.
 		},
 		"members": {
 			// Property: Members
@@ -277,7 +277,7 @@ func globalReplicationGroupResourceType(ctx context.Context) (tfsdk.ResourceType
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// RegionalConfigurations is a write-only attribute.
+			// RegionalConfigurations is a write-only property.
 		},
 		"status": {
 			// Property: Status

--- a/internal/aws/elasticache/user_group_resource_gen.go
+++ b/internal/aws/elasticache/user_group_resource_gen.go
@@ -52,7 +52,9 @@ func userGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"redis",
 				}),
 			},
-			// Engine is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Engine is a force-new property.
+			},
 		},
 		"status": {
 			// Property: Status
@@ -76,7 +78,9 @@ func userGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the user group.",
 			Type:        types.StringType,
 			Required:    true,
-			// UserGroupId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // UserGroupId is a force-new property.
+			},
 		},
 		"user_ids": {
 			// Property: UserIds

--- a/internal/aws/elasticache/user_resource_gen.go
+++ b/internal/aws/elasticache/user_resource_gen.go
@@ -33,7 +33,7 @@ func userResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "Access permissions string used for this user account.",
 			Type:        types.StringType,
 			Optional:    true,
-			// AccessString is a write-only attribute.
+			// AccessString is a write-only property.
 		},
 		"arn": {
 			// Property: Arn
@@ -64,7 +64,9 @@ func userResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"redis",
 				}),
 			},
-			// Engine is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Engine is a force-new property.
+			},
 		},
 		"no_password_required": {
 			// Property: NoPasswordRequired
@@ -76,7 +78,7 @@ func userResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "Indicates a password is not required for this user account.",
 			Type:        types.BoolType,
 			Optional:    true,
-			// NoPasswordRequired is a write-only attribute.
+			// NoPasswordRequired is a write-only property.
 		},
 		"passwords": {
 			// Property: Passwords
@@ -96,7 +98,7 @@ func userResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// Passwords is a write-only attribute.
+			// Passwords is a write-only property.
 		},
 		"status": {
 			// Property: Status
@@ -120,7 +122,9 @@ func userResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the user.",
 			Type:        types.StringType,
 			Required:    true,
-			// UserId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // UserId is a force-new property.
+			},
 		},
 		"user_name": {
 			// Property: UserName
@@ -132,7 +136,9 @@ func userResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The username of the user.",
 			Type:        types.StringType,
 			Required:    true,
-			// UserName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // UserName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/emr/studio_resource_gen.go
+++ b/internal/aws/emr/studio_resource_gen.go
@@ -53,7 +53,9 @@ func studioResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"IAM",
 				}),
 			},
-			// AuthMode is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AuthMode is a force-new property.
+			},
 		},
 		"default_s3_location": {
 			// Property: DefaultS3Location
@@ -104,7 +106,9 @@ func studioResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(4, 256),
 			},
-			// EngineSecurityGroupId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EngineSecurityGroupId is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -132,7 +136,9 @@ func studioResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// ServiceRole is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServiceRole is a force-new property.
+			},
 		},
 		"studio_id": {
 			// Property: StudioId
@@ -248,7 +254,9 @@ func studioResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// UserRole is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // UserRole is a force-new property.
+			},
 		},
 		"vpc_id": {
 			// Property: VpcId
@@ -261,7 +269,9 @@ func studioResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the Amazon Virtual Private Cloud (Amazon VPC) to associate with the Studio.",
 			Type:        types.StringType,
 			Required:    true,
-			// VpcId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcId is a force-new property.
+			},
 		},
 		"workspace_security_group_id": {
 			// Property: WorkspaceSecurityGroupId
@@ -274,7 +284,9 @@ func studioResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the Amazon EMR Studio Workspace security group. The Workspace security group allows outbound network traffic to resources in the Engine security group, and it must be in the same VPC specified by VpcId.",
 			Type:        types.StringType,
 			Required:    true,
-			// WorkspaceSecurityGroupId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // WorkspaceSecurityGroupId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/emr/studio_session_mapping_resource_gen.go
+++ b/internal/aws/emr/studio_session_mapping_resource_gen.go
@@ -33,7 +33,9 @@ func studioSessionMappingResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Description: "The name of the user or group. For more information, see UserName and DisplayName in the AWS SSO Identity Store API Reference. Either IdentityName or IdentityId must be specified.",
 			Type:        types.StringType,
 			Required:    true,
-			// IdentityName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // IdentityName is a force-new property.
+			},
 		},
 		"identity_type": {
 			// Property: IdentityType
@@ -55,7 +57,9 @@ func studioSessionMappingResourceType(ctx context.Context) (tfsdk.ResourceType, 
 					"GROUP",
 				}),
 			},
-			// IdentityType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // IdentityType is a force-new property.
+			},
 		},
 		"session_policy_arn": {
 			// Property: SessionPolicyArn
@@ -83,7 +87,9 @@ func studioSessionMappingResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(4, 256),
 			},
-			// StudioId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StudioId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/emrcontainers/virtual_cluster_resource_gen.go
+++ b/internal/aws/emrcontainers/virtual_cluster_resource_gen.go
@@ -125,7 +125,9 @@ func virtualClusterResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 				},
 			),
 			Required: true,
-			// ContainerProvider is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ContainerProvider is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -156,7 +158,9 @@ func virtualClusterResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/events/api_destination_resource_gen.go
+++ b/internal/aws/events/api_destination_resource_gen.go
@@ -127,7 +127,9 @@ func apiDestinationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/events/archive_resource_gen.go
+++ b/internal/aws/events/archive_resource_gen.go
@@ -29,7 +29,9 @@ func archiveResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Computed: true,
-			// ArchiveName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ArchiveName is a force-new property.
+			},
 		},
 		"arn": {
 			// Property: Arn
@@ -75,7 +77,9 @@ func archiveResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// SourceArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SourceArn is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/finspace/environment_resource_gen.go
+++ b/internal/aws/finspace/environment_resource_gen.go
@@ -219,7 +219,9 @@ func environmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// KmsKeyId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KmsKeyId is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name

--- a/internal/aws/fis/experiment_template_resource_gen.go
+++ b/internal/aws/fis/experiment_template_resource_gen.go
@@ -234,7 +234,9 @@ func experimentTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			// Pattern: ""
 			Type:     types.MapType{ElemType: types.StringType},
 			Required: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"targets": {
 			// Property: Targets

--- a/internal/aws/fms/policy_resource_gen.go
+++ b/internal/aws/fms/policy_resource_gen.go
@@ -45,7 +45,7 @@ func policyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.BoolType,
 			Optional: true,
-			// DeleteAllPolicyResources is a write-only attribute.
+			// DeleteAllPolicyResources is a write-only property.
 		},
 		"exclude_map": {
 			// Property: ExcludeMap

--- a/internal/aws/frauddetector/detector_resource_gen.go
+++ b/internal/aws/frauddetector/detector_resource_gen.go
@@ -112,7 +112,9 @@ func detectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// DetectorId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DetectorId is a force-new property.
+			},
 		},
 		"detector_version_id": {
 			// Property: DetectorVersionId

--- a/internal/aws/frauddetector/entity_type_resource_gen.go
+++ b/internal/aws/frauddetector/entity_type_resource_gen.go
@@ -88,7 +88,9 @@ func entityTypeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/frauddetector/event_type_resource_gen.go
+++ b/internal/aws/frauddetector/event_type_resource_gen.go
@@ -628,7 +628,9 @@ func eventTypeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/frauddetector/label_resource_gen.go
+++ b/internal/aws/frauddetector/label_resource_gen.go
@@ -88,7 +88,9 @@ func labelResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/frauddetector/outcome_resource_gen.go
+++ b/internal/aws/frauddetector/outcome_resource_gen.go
@@ -88,7 +88,9 @@ func outcomeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/frauddetector/variable_resource_gen.go
+++ b/internal/aws/frauddetector/variable_resource_gen.go
@@ -140,7 +140,9 @@ func variableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name of the variable.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/gamelift/fleet_resource_gen.go
+++ b/internal/aws/gamelift/fleet_resource_gen.go
@@ -36,7 +36,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// BuildId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BuildId is a force-new property.
+			},
 		},
 		"certificate_configuration": {
 			// Property: CertificateConfiguration
@@ -77,7 +79,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// CertificateConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateConfiguration is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -222,7 +226,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// EC2InstanceType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EC2InstanceType is a force-new property.
+			},
 		},
 		"fleet_id": {
 			// Property: FleetId
@@ -259,7 +265,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"SPOT",
 				}),
 			},
-			// FleetType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FleetType is a force-new property.
+			},
 		},
 		"instance_role_arn": {
 			// Property: InstanceRoleARN
@@ -278,7 +286,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// InstanceRoleARN is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InstanceRoleARN is a force-new property.
+			},
 		},
 		"locations": {
 			// Property: Locations
@@ -405,7 +415,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.ListType{ElemType: types.StringType},
 			Optional:    true,
 			Computed:    true,
-			// LogPaths is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LogPaths is a force-new property.
+			},
 		},
 		"max_size": {
 			// Property: MaxSize
@@ -515,7 +527,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// PeerVpcAwsAccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PeerVpcAwsAccountId is a force-new property.
+			},
 		},
 		"peer_vpc_id": {
 			// Property: PeerVpcId
@@ -535,7 +549,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// PeerVpcId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PeerVpcId is a force-new property.
+			},
 		},
 		"resource_creation_limit_policy": {
 			// Property: ResourceCreationLimitPolicy
@@ -723,7 +739,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ScriptId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ScriptId is a force-new property.
+			},
 		},
 		"server_launch_parameters": {
 			// Property: ServerLaunchParameters
@@ -742,7 +760,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// ServerLaunchParameters is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServerLaunchParameters is a force-new property.
+			},
 		},
 		"server_launch_path": {
 			// Property: ServerLaunchPath
@@ -761,7 +781,9 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// ServerLaunchPath is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServerLaunchPath is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/gamelift/game_server_group_resource_gen.go
+++ b/internal/aws/gamelift/game_server_group_resource_gen.go
@@ -146,7 +146,7 @@ func gameServerGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error
 					"RETAIN",
 				}),
 			},
-			// DeleteOption is a write-only attribute.
+			// DeleteOption is a write-only property.
 		},
 		"game_server_group_arn": {
 			// Property: GameServerGroupArn

--- a/internal/aws/globalaccelerator/endpoint_group_resource_gen.go
+++ b/internal/aws/globalaccelerator/endpoint_group_resource_gen.go
@@ -103,7 +103,9 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Description: "The name of the AWS Region where the endpoint group is located",
 			Type:        types.StringType,
 			Required:    true,
-			// EndpointGroupRegion is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EndpointGroupRegion is a force-new property.
+			},
 		},
 		"health_check_interval_seconds": {
 			// Property: HealthCheckIntervalSeconds
@@ -177,7 +179,9 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Description: "The Amazon Resource Name (ARN) of the listener",
 			Type:        types.StringType,
 			Required:    true,
-			// ListenerArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ListenerArn is a force-new property.
+			},
 		},
 		"port_overrides": {
 			// Property: PortOverrides

--- a/internal/aws/globalaccelerator/listener_resource_gen.go
+++ b/internal/aws/globalaccelerator/listener_resource_gen.go
@@ -33,7 +33,9 @@ func listenerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The Amazon Resource Name (ARN) of the accelerator.",
 			Type:        types.StringType,
 			Required:    true,
-			// AcceleratorArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AcceleratorArn is a force-new property.
+			},
 		},
 		"client_affinity": {
 			// Property: ClientAffinity

--- a/internal/aws/glue/registry_resource_gen.go
+++ b/internal/aws/glue/registry_resource_gen.go
@@ -66,7 +66,9 @@ func registryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -128,8 +130,10 @@ func registryResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
-			// Tags is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
+			// Tags is a write-only property.
 		},
 	}
 

--- a/internal/aws/glue/schema_resource_gen.go
+++ b/internal/aws/glue/schema_resource_gen.go
@@ -130,7 +130,9 @@ func schemaResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"JSON",
 				}),
 			},
-			// DataFormat is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataFormat is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -175,7 +177,9 @@ func schemaResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"registry": {
 			// Property: Registry
@@ -220,7 +224,9 @@ func schemaResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Registry is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Registry is a force-new property.
+			},
 		},
 		"schema_definition": {
 			// Property: SchemaDefinition
@@ -237,8 +243,10 @@ func schemaResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 170000),
 			},
-			// SchemaDefinition is a force-new attribute.
-			// SchemaDefinition is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SchemaDefinition is a force-new property.
+			},
+			// SchemaDefinition is a write-only property.
 		},
 		"tags": {
 			// Property: Tags
@@ -300,8 +308,10 @@ func schemaResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
-			// Tags is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
+			// Tags is a write-only property.
 		},
 	}
 

--- a/internal/aws/glue/schema_version_metadata_resource_gen.go
+++ b/internal/aws/glue/schema_version_metadata_resource_gen.go
@@ -38,7 +38,9 @@ func schemaVersionMetadataResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// Key is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Key is a force-new property.
+			},
 		},
 		"schema_version_id": {
 			// Property: SchemaVersionId
@@ -51,7 +53,9 @@ func schemaVersionMetadataResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Description: "Represents the version ID associated with the schema version.",
 			Type:        types.StringType,
 			Required:    true,
-			// SchemaVersionId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SchemaVersionId is a force-new property.
+			},
 		},
 		"value": {
 			// Property: Value
@@ -68,7 +72,9 @@ func schemaVersionMetadataResourceType(ctx context.Context) (tfsdk.ResourceType,
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// Value is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Value is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/glue/schema_version_resource_gen.go
+++ b/internal/aws/glue/schema_version_resource_gen.go
@@ -80,7 +80,9 @@ func schemaVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 				},
 			),
 			Required: true,
-			// Schema is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Schema is a force-new property.
+			},
 		},
 		"schema_definition": {
 			// Property: SchemaDefinition
@@ -97,7 +99,9 @@ func schemaVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 170000),
 			},
-			// SchemaDefinition is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SchemaDefinition is a force-new property.
+			},
 		},
 		"version_id": {
 			// Property: VersionId

--- a/internal/aws/greengrassv2/component_version_resource_gen.go
+++ b/internal/aws/greengrassv2/component_version_resource_gen.go
@@ -59,8 +59,10 @@ func componentVersionResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// InlineRecipe is a force-new attribute.
-			// InlineRecipe is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InlineRecipe is a force-new property.
+			},
+			// InlineRecipe is a write-only property.
 		},
 		"lambda_function": {
 			// Property: LambdaFunction
@@ -515,8 +517,10 @@ func componentVersionResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			),
 			Optional: true,
 			Computed: true,
-			// LambdaFunction is a force-new attribute.
-			// LambdaFunction is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LambdaFunction is a force-new property.
+			},
+			// LambdaFunction is a write-only property.
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iam/oidc_provider_resource_gen.go
+++ b/internal/aws/iam/oidc_provider_resource_gen.go
@@ -138,7 +138,9 @@ func oIDCProviderResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Url is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Url is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/iam/saml_provider_resource_gen.go
+++ b/internal/aws/iam/saml_provider_resource_gen.go
@@ -51,7 +51,9 @@ func sAMLProviderResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"saml_metadata_document": {
 			// Property: SamlMetadataDocument

--- a/internal/aws/iam/server_certificate_resource_gen.go
+++ b/internal/aws/iam/server_certificate_resource_gen.go
@@ -51,7 +51,9 @@ func serverCertificateResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 16384),
 			},
-			// CertificateBody is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateBody is a force-new property.
+			},
 		},
 		"certificate_chain": {
 			// Property: CertificateChain
@@ -68,7 +70,9 @@ func serverCertificateResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2097152),
 			},
-			// CertificateChain is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateChain is a force-new property.
+			},
 		},
 		"path": {
 			// Property: Path
@@ -100,7 +104,9 @@ func serverCertificateResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 16384),
 			},
-			// PrivateKey is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PrivateKey is a force-new property.
+			},
 		},
 		"server_certificate_name": {
 			// Property: ServerCertificateName
@@ -117,7 +123,9 @@ func serverCertificateResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// ServerCertificateName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServerCertificateName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iam/virtual_mfa_device_resource_gen.go
+++ b/internal/aws/iam/virtual_mfa_device_resource_gen.go
@@ -38,7 +38,9 @@ func virtualMFADeviceResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 512),
 			},
-			// Path is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Path is a force-new property.
+			},
 		},
 		"serial_number": {
 			// Property: SerialNumber
@@ -135,7 +137,9 @@ func virtualMFADeviceResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 226),
 			},
-			// VirtualMfaDeviceName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VirtualMfaDeviceName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/imagebuilder/component_resource_gen.go
+++ b/internal/aws/imagebuilder/component_resource_gen.go
@@ -45,7 +45,9 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ChangeDescription is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ChangeDescription is a force-new property.
+			},
 		},
 		"data": {
 			// Property: Data
@@ -63,8 +65,10 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 16000),
 			},
-			// Data is a force-new attribute.
-			// Data is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Data is a force-new property.
+			},
+			// Data is a write-only property.
 		},
 		"description": {
 			// Property: Description
@@ -77,7 +81,9 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"encrypted": {
 			// Property: Encrypted
@@ -101,7 +107,9 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// KmsKeyId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KmsKeyId is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -113,7 +121,9 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name of the component.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"platform": {
 			// Property: Platform
@@ -135,8 +145,10 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"Linux",
 				}),
 			},
-			// Platform is a force-new attribute.
-			// Platform is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Platform is a force-new property.
+			},
+			// Platform is a write-only property.
 		},
 		"supported_os_versions": {
 			// Property: SupportedOsVersions
@@ -152,7 +164,9 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.ListType{ElemType: types.StringType},
 			Optional:    true,
 			Computed:    true,
-			// SupportedOsVersions is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SupportedOsVersions is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -172,7 +186,9 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"type": {
 			// Property: Type
@@ -200,8 +216,10 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Uri is a force-new attribute.
-			// Uri is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Uri is a force-new property.
+			},
+			// Uri is a write-only property.
 		},
 		"version": {
 			// Property: Version
@@ -213,7 +231,9 @@ func componentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The version of the component.",
 			Type:        types.StringType,
 			Required:    true,
-			// Version is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Version is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/imagebuilder/container_recipe_resource_gen.go
+++ b/internal/aws/imagebuilder/container_recipe_resource_gen.go
@@ -66,7 +66,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			),
 			Optional: true,
 			Computed: true,
-			// Components is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Components is a force-new property.
+			},
 		},
 		"container_type": {
 			// Property: ContainerType
@@ -87,7 +89,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 					"DOCKER",
 				}),
 			},
-			// ContainerType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ContainerType is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -100,7 +104,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"dockerfile_template_data": {
 			// Property: DockerfileTemplateData
@@ -113,8 +119,10 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// DockerfileTemplateData is a force-new attribute.
-			// DockerfileTemplateData is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DockerfileTemplateData is a force-new property.
+			},
+			// DockerfileTemplateData is a write-only property.
 		},
 		"dockerfile_template_uri": {
 			// Property: DockerfileTemplateUri
@@ -127,8 +135,10 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// DockerfileTemplateUri is a force-new attribute.
-			// DockerfileTemplateUri is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DockerfileTemplateUri is a force-new property.
+			},
+			// DockerfileTemplateUri is a write-only property.
 		},
 		"image_os_version_override": {
 			// Property: ImageOsVersionOverride
@@ -141,7 +151,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ImageOsVersionOverride is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ImageOsVersionOverride is a force-new property.
+			},
 		},
 		"instance_configuration": {
 			// Property: InstanceConfiguration
@@ -327,7 +339,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			),
 			Optional: true,
 			Computed: true,
-			// InstanceConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InstanceConfiguration is a force-new property.
+			},
 		},
 		"kms_key_id": {
 			// Property: KmsKeyId
@@ -340,7 +354,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// KmsKeyId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KmsKeyId is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -353,7 +369,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"parent_image": {
 			// Property: ParentImage
@@ -366,7 +384,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ParentImage is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ParentImage is a force-new property.
+			},
 		},
 		"platform_override": {
 			// Property: PlatformOverride
@@ -389,7 +409,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 					"Linux",
 				}),
 			},
-			// PlatformOverride is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PlatformOverride is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -409,7 +431,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"target_repository": {
 			// Property: TargetRepository
@@ -456,7 +480,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			),
 			Optional: true,
 			Computed: true,
-			// TargetRepository is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TargetRepository is a force-new property.
+			},
 		},
 		"version": {
 			// Property: Version
@@ -469,7 +495,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Version is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Version is a force-new property.
+			},
 		},
 		"working_directory": {
 			// Property: WorkingDirectory
@@ -482,7 +510,9 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// WorkingDirectory is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // WorkingDirectory is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/imagebuilder/distribution_configuration_resource_gen.go
+++ b/internal/aws/imagebuilder/distribution_configuration_resource_gen.go
@@ -356,7 +356,9 @@ func distributionConfigurationResourceType(ctx context.Context) (tfsdk.ResourceT
 			Description: "The name of the distribution configuration.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/imagebuilder/image_pipeline_resource_gen.go
+++ b/internal/aws/imagebuilder/image_pipeline_resource_gen.go
@@ -153,7 +153,9 @@ func imagePipelineResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"schedule": {
 			// Property: Schedule

--- a/internal/aws/imagebuilder/image_recipe_resource_gen.go
+++ b/internal/aws/imagebuilder/image_recipe_resource_gen.go
@@ -251,7 +251,9 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// BlockDeviceMappings is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BlockDeviceMappings is a force-new property.
+			},
 		},
 		"components": {
 			// Property: Components
@@ -332,7 +334,9 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				tfsdk.ListNestedAttributesOptions{},
 			),
 			Required: true,
-			// Components is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Components is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -345,7 +349,9 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -357,7 +363,9 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name of the image recipe.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"parent_image": {
 			// Property: ParentImage
@@ -369,7 +377,9 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The parent image of the image recipe.",
 			Type:        types.StringType,
 			Required:    true,
-			// ParentImage is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ParentImage is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -389,7 +399,9 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"version": {
 			// Property: Version
@@ -401,7 +413,9 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The version of the image recipe.",
 			Type:        types.StringType,
 			Required:    true,
-			// Version is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Version is a force-new property.
+			},
 		},
 		"working_directory": {
 			// Property: WorkingDirectory
@@ -414,7 +428,9 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// WorkingDirectory is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // WorkingDirectory is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/imagebuilder/image_resource_gen.go
+++ b/internal/aws/imagebuilder/image_resource_gen.go
@@ -56,7 +56,9 @@ func imageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// DistributionConfigurationArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DistributionConfigurationArn is a force-new property.
+			},
 		},
 		"enhanced_image_metadata_enabled": {
 			// Property: EnhancedImageMetadataEnabled
@@ -69,7 +71,9 @@ func imageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.BoolType,
 			Optional:    true,
 			Computed:    true,
-			// EnhancedImageMetadataEnabled is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EnhancedImageMetadataEnabled is a force-new property.
+			},
 		},
 		"image_id": {
 			// Property: ImageId
@@ -93,7 +97,9 @@ func imageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ImageRecipeArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ImageRecipeArn is a force-new property.
+			},
 		},
 		"image_tests_configuration": {
 			// Property: ImageTestsConfiguration
@@ -136,7 +142,9 @@ func imageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// ImageTestsConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ImageTestsConfiguration is a force-new property.
+			},
 		},
 		"infrastructure_configuration_arn": {
 			// Property: InfrastructureConfigurationArn
@@ -149,7 +157,9 @@ func imageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// InfrastructureConfigurationArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InfrastructureConfigurationArn is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -179,7 +189,9 @@ func imageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/imagebuilder/infrastructure_configuration_resource_gen.go
+++ b/internal/aws/imagebuilder/infrastructure_configuration_resource_gen.go
@@ -142,7 +142,9 @@ func infrastructureConfigurationResourceType(ctx context.Context) (tfsdk.Resourc
 			Description: "The name of the infrastructure configuration.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"resource_tags": {
 			// Property: ResourceTags

--- a/internal/aws/iot/account_audit_configuration_resource_gen.go
+++ b/internal/aws/iot/account_audit_configuration_resource_gen.go
@@ -38,7 +38,9 @@ func accountAuditConfigurationResourceType(ctx context.Context) (tfsdk.ResourceT
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(12, 12),
 			},
-			// AccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AccountId is a force-new property.
+			},
 		},
 		"audit_check_configurations": {
 			// Property: AuditCheckConfigurations

--- a/internal/aws/iot/authorizer_resource_gen.go
+++ b/internal/aws/iot/authorizer_resource_gen.go
@@ -56,7 +56,9 @@ func authorizerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// AuthorizerName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AuthorizerName is a force-new property.
+			},
 		},
 		"signing_disabled": {
 			// Property: SigningDisabled
@@ -67,7 +69,9 @@ func authorizerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.BoolType,
 			Optional: true,
 			Computed: true,
-			// SigningDisabled is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SigningDisabled is a force-new property.
+			},
 		},
 		"status": {
 			// Property: Status

--- a/internal/aws/iot/certificate_resource_gen.go
+++ b/internal/aws/iot/certificate_resource_gen.go
@@ -46,8 +46,10 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 65536),
 			},
-			// CACertificatePem is a force-new attribute.
-			// CACertificatePem is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CACertificatePem is a force-new property.
+			},
+			// CACertificatePem is a write-only property.
 		},
 		"certificate_mode": {
 			// Property: CertificateMode
@@ -68,7 +70,9 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"SNI_ONLY",
 				}),
 			},
-			// CertificateMode is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateMode is a force-new property.
+			},
 		},
 		"certificate_pem": {
 			// Property: CertificatePem
@@ -84,7 +88,9 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 65536),
 			},
-			// CertificatePem is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificatePem is a force-new property.
+			},
 		},
 		"certificate_signing_request": {
 			// Property: CertificateSigningRequest
@@ -95,8 +101,10 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// CertificateSigningRequest is a force-new attribute.
-			// CertificateSigningRequest is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CertificateSigningRequest is a force-new property.
+			},
+			// CertificateSigningRequest is a write-only property.
 		},
 		"id": {
 			// Property: Id

--- a/internal/aws/iot/custom_metric_resource_gen.go
+++ b/internal/aws/iot/custom_metric_resource_gen.go
@@ -68,7 +68,9 @@ func customMetricResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// MetricName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // MetricName is a force-new property.
+			},
 		},
 		"metric_type": {
 			// Property: MetricType
@@ -94,7 +96,9 @@ func customMetricResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"number",
 				}),
 			},
-			// MetricType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // MetricType is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iot/dimension_resource_gen.go
+++ b/internal/aws/iot/dimension_resource_gen.go
@@ -51,7 +51,9 @@ func dimensionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"string_values": {
 			// Property: StringValues
@@ -152,7 +154,9 @@ func dimensionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"TOPIC_FILTER",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/iot/domain_configuration_resource_gen.go
+++ b/internal/aws/iot/domain_configuration_resource_gen.go
@@ -84,7 +84,9 @@ func domainConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// DomainConfigurationName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainConfigurationName is a force-new property.
+			},
 		},
 		"domain_configuration_status": {
 			// Property: DomainConfigurationStatus
@@ -119,7 +121,9 @@ func domainConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 253),
 			},
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"domain_type": {
 			// Property: DomainType
@@ -155,8 +159,10 @@ func domainConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			Validators: []tfsdk.AttributeValidator{
 				validate.ArrayLenBetween(0, 1),
 			},
-			// ServerCertificateArns is a force-new attribute.
-			// ServerCertificateArns is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServerCertificateArns is a force-new property.
+			},
+			// ServerCertificateArns is a write-only property.
 		},
 		"server_certificates": {
 			// Property: ServerCertificates
@@ -238,7 +244,9 @@ func domainConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, e
 					"JOBS",
 				}),
 			},
-			// ServiceType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServiceType is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -289,7 +297,9 @@ func domainConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// ValidationCertificateArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ValidationCertificateArn is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/iot/mitigation_action_resource_gen.go
+++ b/internal/aws/iot/mitigation_action_resource_gen.go
@@ -40,7 +40,9 @@ func mitigationActionResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// ActionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ActionName is a force-new property.
+			},
 		},
 		"action_params": {
 			// Property: ActionParams

--- a/internal/aws/iot/provisioning_template_resource_gen.go
+++ b/internal/aws/iot/provisioning_template_resource_gen.go
@@ -156,7 +156,9 @@ func provisioningTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 36),
 			},
-			// TemplateName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TemplateName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/iot/scheduled_audit_resource_gen.go
+++ b/internal/aws/iot/scheduled_audit_resource_gen.go
@@ -121,7 +121,9 @@ func scheduledAuditResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// ScheduledAuditName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ScheduledAuditName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iot/security_profile_resource_gen.go
+++ b/internal/aws/iot/security_profile_resource_gen.go
@@ -633,7 +633,9 @@ func securityProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// SecurityProfileName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SecurityProfileName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iot/topic_rule_destination_resource_gen.go
+++ b/internal/aws/iot/topic_rule_destination_resource_gen.go
@@ -57,7 +57,9 @@ func topicRuleDestinationResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			),
 			Optional: true,
 			Computed: true,
-			// HttpUrlProperties is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // HttpUrlProperties is a force-new property.
+			},
 		},
 		"status": {
 			// Property: Status
@@ -152,7 +154,9 @@ func topicRuleDestinationResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			),
 			Optional: true,
 			Computed: true,
-			// VpcProperties is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcProperties is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/iot/topic_rule_resource_gen.go
+++ b/internal/aws/iot/topic_rule_resource_gen.go
@@ -41,7 +41,9 @@ func topicRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// RuleName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RuleName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iotevents/detector_model_resource_gen.go
+++ b/internal/aws/iotevents/detector_model_resource_gen.go
@@ -4772,7 +4772,9 @@ func detectorModelResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// DetectorModelName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DetectorModelName is a force-new property.
+			},
 		},
 		"evaluation_method": {
 			// Property: EvaluationMethod
@@ -4812,7 +4814,9 @@ func detectorModelResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// Key is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Key is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn

--- a/internal/aws/iotevents/input_resource_gen.go
+++ b/internal/aws/iotevents/input_resource_gen.go
@@ -125,7 +125,9 @@ func inputResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// InputName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InputName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iotsitewise/dashboard_resource_gen.go
+++ b/internal/aws/iotsitewise/dashboard_resource_gen.go
@@ -87,7 +87,9 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ProjectId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProjectId is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iotsitewise/gateway_resource_gen.go
+++ b/internal/aws/iotsitewise/gateway_resource_gen.go
@@ -142,7 +142,9 @@ func gatewayResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// GatewayPlatform is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GatewayPlatform is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/iotsitewise/portal_resource_gen.go
+++ b/internal/aws/iotsitewise/portal_resource_gen.go
@@ -91,7 +91,9 @@ func portalResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// PortalAuthMode is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PortalAuthMode is a force-new property.
+			},
 		},
 		"portal_client_id": {
 			// Property: PortalClientId
@@ -213,7 +215,7 @@ func portalResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				tfsdk.ListNestedAttributesOptions{},
 			),
 			Optional: true,
-			// Tags is a write-only attribute.
+			// Tags is a write-only property.
 		},
 	}
 

--- a/internal/aws/iotsitewise/project_resource_gen.go
+++ b/internal/aws/iotsitewise/project_resource_gen.go
@@ -31,7 +31,9 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the portal in which to create the project.",
 			Type:        types.StringType,
 			Required:    true,
-			// PortalId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PortalId is a force-new property.
+			},
 		},
 		"project_arn": {
 			// Property: ProjectArn

--- a/internal/aws/iotwireless/destination_resource_gen.go
+++ b/internal/aws/iotwireless/destination_resource_gen.go
@@ -96,7 +96,9 @@ func destinationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn

--- a/internal/aws/ivs/playback_key_pair_resource_gen.go
+++ b/internal/aws/ivs/playback_key_pair_resource_gen.go
@@ -65,7 +65,9 @@ func playbackKeyPairResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"public_key_material": {
 			// Property: PublicKeyMaterial
@@ -77,7 +79,9 @@ func playbackKeyPairResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Description: "The public portion of a customer-generated key pair.",
 			Type:        types.StringType,
 			Required:    true,
-			// PublicKeyMaterial is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PublicKeyMaterial is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/ivs/recording_configuration_resource_gen.go
+++ b/internal/aws/ivs/recording_configuration_resource_gen.go
@@ -81,17 +81,23 @@ func recordingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 									Validators: []tfsdk.AttributeValidator{
 										validate.StringLenBetween(3, 63),
 									},
-									// BucketName is a force-new attribute.
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										tfsdk.RequiresReplace(), // BucketName is a force-new property.
+									},
 								},
 							},
 						),
 						Required: true,
-						// S3 is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // S3 is a force-new property.
+						},
 					},
 				},
 			),
 			Required: true,
-			// DestinationConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DestinationConfiguration is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -110,7 +116,9 @@ func recordingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"state": {
 			// Property: State

--- a/internal/aws/ivs/stream_key_resource_gen.go
+++ b/internal/aws/ivs/stream_key_resource_gen.go
@@ -48,7 +48,9 @@ func streamKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "Channel ARN for the stream.",
 			Type:        types.StringType,
 			Required:    true,
-			// ChannelArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ChannelArn is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/kendra/data_source_resource_gen.go
+++ b/internal/aws/kendra/data_source_resource_gen.go
@@ -3224,7 +3224,9 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"GOOGLEDRIVE",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/kendra/faq_resource_gen.go
+++ b/internal/aws/kendra/faq_resource_gen.go
@@ -49,7 +49,9 @@ func faqResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1000),
 			},
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"file_format": {
 			// Property: FileFormat
@@ -74,7 +76,9 @@ func faqResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"JSON",
 				}),
 			},
-			// FileFormat is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FileFormat is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -104,7 +108,9 @@ func faqResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(36, 36),
 			},
-			// IndexId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // IndexId is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -119,7 +125,9 @@ func faqResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn
@@ -135,7 +143,9 @@ func faqResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1284),
 			},
-			// RoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RoleArn is a force-new property.
+			},
 		},
 		"s3_path": {
 			// Property: S3Path
@@ -182,7 +192,9 @@ func faqResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// S3Path is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // S3Path is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/kendra/index_resource_gen.go
+++ b/internal/aws/kendra/index_resource_gen.go
@@ -327,7 +327,9 @@ func indexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"ENTERPRISE_EDITION",
 				}),
 			},
-			// Edition is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Edition is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -403,7 +405,9 @@ func indexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// ServerSideEncryptionConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServerSideEncryptionConfiguration is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/kinesis/stream_resource_gen.go
+++ b/internal/aws/kinesis/stream_resource_gen.go
@@ -51,7 +51,9 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"retention_period_hours": {
 			// Property: RetentionPeriodHours

--- a/internal/aws/kinesisfirehose/delivery_stream_resource_gen.go
+++ b/internal/aws/kinesisfirehose/delivery_stream_resource_gen.go
@@ -97,7 +97,9 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// DeliveryStreamName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DeliveryStreamName is a force-new property.
+			},
 		},
 		"delivery_stream_type": {
 			// Property: DeliveryStreamType
@@ -118,7 +120,9 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"KinesisStreamAsSource",
 				}),
 			},
-			// DeliveryStreamType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DeliveryStreamType is a force-new property.
+			},
 		},
 		"elasticsearch_destination_configuration": {
 			// Property: ElasticsearchDestinationConfiguration
@@ -733,7 +737,9 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 						),
 						Optional: true,
 						Computed: true,
-						// VpcConfiguration is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // VpcConfiguration is a force-new property.
+						},
 					},
 				},
 			),
@@ -2330,7 +2336,9 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			),
 			Optional: true,
 			Computed: true,
-			// KinesisStreamSourceConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KinesisStreamSourceConfiguration is a force-new property.
+			},
 		},
 		"redshift_destination_configuration": {
 			// Property: RedshiftDestinationConfiguration

--- a/internal/aws/kms/alias_resource_gen.go
+++ b/internal/aws/kms/alias_resource_gen.go
@@ -39,7 +39,9 @@ func aliasResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// AliasName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AliasName is a force-new property.
+			},
 		},
 		"target_key_id": {
 			// Property: TargetKeyId

--- a/internal/aws/kms/key_resource_gen.go
+++ b/internal/aws/kms/key_resource_gen.go
@@ -170,7 +170,7 @@ func keyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(7, 30),
 			},
-			// PendingWindowInDays is a write-only attribute.
+			// PendingWindowInDays is a write-only property.
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/kms/replica_key_resource_gen.go
+++ b/internal/aws/kms/replica_key_resource_gen.go
@@ -94,7 +94,7 @@ func replicaKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(7, 30),
 			},
-			// PendingWindowInDays is a write-only attribute.
+			// PendingWindowInDays is a write-only property.
 		},
 		"primary_key_arn": {
 			// Property: PrimaryKeyArn
@@ -111,7 +111,9 @@ func replicaKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// PrimaryKeyArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PrimaryKeyArn is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/lambda/event_source_mapping_resource_gen.go
+++ b/internal/aws/lambda/event_source_mapping_resource_gen.go
@@ -127,7 +127,9 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(12, 1024),
 			},
-			// EventSourceArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EventSourceArn is a force-new property.
+			},
 		},
 		"function_name": {
 			// Property: FunctionName
@@ -328,7 +330,9 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			),
 			Optional: true,
 			Computed: true,
-			// SelfManagedEventSource is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SelfManagedEventSource is a force-new property.
+			},
 		},
 		"source_access_configurations": {
 			// Property: SourceAccessConfigurations
@@ -422,7 +426,9 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(6, 12),
 			},
-			// StartingPosition is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StartingPosition is a force-new property.
+			},
 		},
 		"starting_position_timestamp": {
 			// Property: StartingPositionTimestamp

--- a/internal/aws/lambda/function_resource_gen.go
+++ b/internal/aws/lambda/function_resource_gen.go
@@ -114,7 +114,7 @@ func functionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// Code is a write-only attribute.
+			// Code is a write-only property.
 		},
 		"code_signing_config_arn": {
 			// Property: CodeSigningConfigArn
@@ -278,7 +278,9 @@ func functionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenAtLeast(1),
 			},
-			// FunctionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FunctionName is a force-new property.
+			},
 		},
 		"handler": {
 			// Property: Handler

--- a/internal/aws/licensemanager/grant_resource_gen.go
+++ b/internal/aws/licensemanager/grant_resource_gen.go
@@ -38,7 +38,7 @@ func grantResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// AllowedOperations is a write-only attribute.
+			// AllowedOperations is a write-only property.
 		},
 		"grant_arn": {
 			// Property: GrantArn
@@ -101,7 +101,7 @@ func grantResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// Principals is a write-only attribute.
+			// Principals is a write-only property.
 		},
 		"status": {
 			// Property: Status

--- a/internal/aws/licensemanager/license_resource_gen.go
+++ b/internal/aws/licensemanager/license_resource_gen.go
@@ -335,7 +335,7 @@ func licenseResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Optional: true,
-			// Status is a write-only attribute.
+			// Status is a write-only property.
 		},
 		"validity": {
 			// Property: Validity

--- a/internal/aws/location/geofence_collection_resource_gen.go
+++ b/internal/aws/location/geofence_collection_resource_gen.go
@@ -48,7 +48,9 @@ func geofenceCollectionResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// CollectionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CollectionName is a force-new property.
+			},
 		},
 		"create_time": {
 			// Property: CreateTime
@@ -76,7 +78,9 @@ func geofenceCollectionResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1000),
 			},
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"kms_key_id": {
 			// Property: KmsKeyId
@@ -112,7 +116,9 @@ func geofenceCollectionResourceType(ctx context.Context) (tfsdk.ResourceType, er
 					"MobileAssetManagement",
 				}),
 			},
-			// PricingPlan is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PricingPlan is a force-new property.
+			},
 		},
 		"pricing_plan_data_source": {
 			// Property: PricingPlanDataSource
@@ -123,7 +129,9 @@ func geofenceCollectionResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// PricingPlanDataSource is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PricingPlanDataSource is a force-new property.
+			},
 		},
 		"update_time": {
 			// Property: UpdateTime

--- a/internal/aws/location/map_resource_gen.go
+++ b/internal/aws/location/map_resource_gen.go
@@ -65,7 +65,9 @@ func mapResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// Configuration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Configuration is a force-new property.
+			},
 		},
 		"create_time": {
 			// Property: CreateTime
@@ -102,7 +104,9 @@ func mapResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1000),
 			},
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"map_arn": {
 			// Property: MapArn
@@ -129,7 +133,9 @@ func mapResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// MapName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // MapName is a force-new property.
+			},
 		},
 		"pricing_plan": {
 			// Property: PricingPlan
@@ -151,7 +157,9 @@ func mapResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"MobileAssetManagement",
 				}),
 			},
-			// PricingPlan is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PricingPlan is a force-new property.
+			},
 		},
 		"update_time": {
 			// Property: UpdateTime

--- a/internal/aws/location/place_index_resource_gen.go
+++ b/internal/aws/location/place_index_resource_gen.go
@@ -54,7 +54,9 @@ func placeIndexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// DataSource is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataSource is a force-new property.
+			},
 		},
 		"data_source_configuration": {
 			// Property: DataSourceConfiguration
@@ -89,7 +91,9 @@ func placeIndexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// DataSourceConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataSourceConfiguration is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -105,7 +109,9 @@ func placeIndexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1000),
 			},
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"index_arn": {
 			// Property: IndexArn
@@ -132,7 +138,9 @@ func placeIndexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// IndexName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // IndexName is a force-new property.
+			},
 		},
 		"pricing_plan": {
 			// Property: PricingPlan
@@ -154,7 +162,9 @@ func placeIndexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"MobileAssetManagement",
 				}),
 			},
-			// PricingPlan is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PricingPlan is a force-new property.
+			},
 		},
 		"update_time": {
 			// Property: UpdateTime

--- a/internal/aws/location/route_calculator_resource_gen.go
+++ b/internal/aws/location/route_calculator_resource_gen.go
@@ -59,7 +59,9 @@ func routeCalculatorResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// CalculatorName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CalculatorName is a force-new property.
+			},
 		},
 		"create_time": {
 			// Property: CreateTime
@@ -81,7 +83,9 @@ func routeCalculatorResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// DataSource is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataSource is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -97,7 +101,9 @@ func routeCalculatorResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1000),
 			},
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"pricing_plan": {
 			// Property: PricingPlan
@@ -117,7 +123,9 @@ func routeCalculatorResourceType(ctx context.Context) (tfsdk.ResourceType, error
 					"MobileAssetManagement",
 				}),
 			},
-			// PricingPlan is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PricingPlan is a force-new property.
+			},
 		},
 		"update_time": {
 			// Property: UpdateTime

--- a/internal/aws/location/tracker_consumer_resource_gen.go
+++ b/internal/aws/location/tracker_consumer_resource_gen.go
@@ -36,7 +36,9 @@ func trackerConsumerResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1600),
 			},
-			// ConsumerArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConsumerArn is a force-new property.
+			},
 		},
 		"tracker_name": {
 			// Property: TrackerName
@@ -52,7 +54,9 @@ func trackerConsumerResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// TrackerName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TrackerName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/location/tracker_resource_gen.go
+++ b/internal/aws/location/tracker_resource_gen.go
@@ -60,7 +60,9 @@ func trackerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1000),
 			},
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"kms_key_id": {
 			// Property: KmsKeyId
@@ -76,7 +78,9 @@ func trackerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// KmsKeyId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KmsKeyId is a force-new property.
+			},
 		},
 		"pricing_plan": {
 			// Property: PricingPlan
@@ -98,7 +102,9 @@ func trackerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"MobileAssetManagement",
 				}),
 			},
-			// PricingPlan is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PricingPlan is a force-new property.
+			},
 		},
 		"pricing_plan_data_source": {
 			// Property: PricingPlanDataSource
@@ -109,7 +115,9 @@ func trackerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// PricingPlanDataSource is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PricingPlanDataSource is a force-new property.
+			},
 		},
 		"tracker_arn": {
 			// Property: TrackerArn
@@ -136,7 +144,9 @@ func trackerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// TrackerName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TrackerName is a force-new property.
+			},
 		},
 		"update_time": {
 			// Property: UpdateTime

--- a/internal/aws/logs/log_group_resource_gen.go
+++ b/internal/aws/logs/log_group_resource_gen.go
@@ -67,7 +67,9 @@ func logGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 512),
 			},
-			// LogGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LogGroupName is a force-new property.
+			},
 		},
 		"retention_in_days": {
 			// Property: RetentionInDays

--- a/internal/aws/logs/resource_policy_resource_gen.go
+++ b/internal/aws/logs/resource_policy_resource_gen.go
@@ -56,7 +56,9 @@ func resourcePolicyResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// PolicyName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PolicyName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/lookoutmetrics/alert_resource_gen.go
+++ b/internal/aws/lookoutmetrics/alert_resource_gen.go
@@ -129,7 +129,9 @@ func alertResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// Action is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Action is a force-new property.
+			},
 		},
 		"alert_description": {
 			// Property: AlertDescription
@@ -147,7 +149,9 @@ func alertResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 256),
 			},
-			// AlertDescription is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AlertDescription is a force-new property.
+			},
 		},
 		"alert_name": {
 			// Property: AlertName
@@ -166,7 +170,9 @@ func alertResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// AlertName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AlertName is a force-new property.
+			},
 		},
 		"alert_sensitivity_threshold": {
 			// Property: AlertSensitivityThreshold
@@ -183,7 +189,9 @@ func alertResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(0, 100),
 			},
-			// AlertSensitivityThreshold is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AlertSensitivityThreshold is a force-new property.
+			},
 		},
 		"anomaly_detector_arn": {
 			// Property: AnomalyDetectorArn
@@ -200,7 +208,9 @@ func alertResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 256),
 			},
-			// AnomalyDetectorArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AnomalyDetectorArn is a force-new property.
+			},
 		},
 		"arn": {
 			// Property: Arn

--- a/internal/aws/lookoutmetrics/anomaly_detector_resource_gen.go
+++ b/internal/aws/lookoutmetrics/anomaly_detector_resource_gen.go
@@ -98,7 +98,9 @@ func anomalyDetectorResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// AnomalyDetectorName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AnomalyDetectorName is a force-new property.
+			},
 		},
 		"arn": {
 			// Property: Arn

--- a/internal/aws/lookoutvision/project_resource_gen.go
+++ b/internal/aws/lookoutvision/project_resource_gen.go
@@ -49,7 +49,9 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// ProjectName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProjectName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/macie/custom_data_identifier_resource_gen.go
+++ b/internal/aws/macie/custom_data_identifier_resource_gen.go
@@ -66,7 +66,9 @@ func customDataIdentifierResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -93,7 +95,9 @@ func customDataIdentifierResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Type:        types.ListType{ElemType: types.StringType},
 			Optional:    true,
 			Computed:    true,
-			// IgnoreWords is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // IgnoreWords is a force-new property.
+			},
 		},
 		"keywords": {
 			// Property: Keywords
@@ -109,7 +113,9 @@ func customDataIdentifierResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Type:        types.ListType{ElemType: types.StringType},
 			Optional:    true,
 			Computed:    true,
-			// Keywords is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Keywords is a force-new property.
+			},
 		},
 		"maximum_match_distance": {
 			// Property: MaximumMatchDistance
@@ -122,7 +128,9 @@ func customDataIdentifierResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Type:        types.NumberType,
 			Optional:    true,
 			Computed:    true,
-			// MaximumMatchDistance is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // MaximumMatchDistance is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -134,7 +142,9 @@ func customDataIdentifierResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Description: "Name of custom data identifier.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"regex": {
 			// Property: Regex
@@ -146,7 +156,9 @@ func customDataIdentifierResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Description: "Regular expression for custom data identifier.",
 			Type:        types.StringType,
 			Required:    true,
-			// Regex is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Regex is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/mediaconnect/flow_entitlement_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_entitlement_resource_gen.go
@@ -34,7 +34,9 @@ func flowEntitlementResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.NumberType,
 			Optional:    true,
 			Computed:    true,
-			// DataTransferSubscriberFeePercent is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataTransferSubscriberFeePercent is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -233,7 +235,9 @@ func flowEntitlementResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Description: "The name of the entitlement.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"subscribers": {
 			// Property: Subscribers

--- a/internal/aws/mediaconnect/flow_output_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_output_resource_gen.go
@@ -174,7 +174,9 @@ func flowOutputResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"output_arn": {
 			// Property: OutputArn

--- a/internal/aws/mediaconnect/flow_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_resource_gen.go
@@ -34,7 +34,9 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// AvailabilityZone is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AvailabilityZone is a force-new property.
+			},
 		},
 		"flow_arn": {
 			// Property: FlowArn
@@ -68,7 +70,9 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name of the flow.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"source": {
 			// Property: Source
@@ -311,7 +315,9 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Type:        types.StringType,
 						Optional:    true,
 						Computed:    true,
-						// Name is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // Name is a force-new property.
+						},
 					},
 					"protocol": {
 						// Property: Protocol

--- a/internal/aws/mediaconnect/flow_source_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_source_resource_gen.go
@@ -243,7 +243,9 @@ func flowSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name of the source.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"protocol": {
 			// Property: Protocol

--- a/internal/aws/mediaconnect/flow_vpc_interface_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_vpc_interface_resource_gen.go
@@ -31,7 +31,9 @@ func flowVpcInterfaceResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Description: "The Amazon Resource Name (ARN), a unique identifier for any AWS resource, of the flow.",
 			Type:        types.StringType,
 			Required:    true,
-			// FlowArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FlowArn is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -43,7 +45,9 @@ func flowVpcInterfaceResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Description: "Immutable and has to be a unique against other VpcInterfaces in this Flow.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"network_interface_ids": {
 			// Property: NetworkInterfaceIds

--- a/internal/aws/mediapackage/channel_resource_gen.go
+++ b/internal/aws/mediapackage/channel_resource_gen.go
@@ -170,7 +170,9 @@ func channelResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// Id is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Id is a force-new property.
+			},
 		},
 		"ingress_access_logs": {
 			// Property: IngressAccessLogs
@@ -248,7 +250,9 @@ func channelResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/mediapackage/origin_endpoint_resource_gen.go
+++ b/internal/aws/mediapackage/origin_endpoint_resource_gen.go
@@ -1253,7 +1253,9 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// Id is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Id is a force-new property.
+			},
 		},
 		"manifest_name": {
 			// Property: ManifestName

--- a/internal/aws/mediapackage/packaging_configuration_resource_gen.go
+++ b/internal/aws/mediapackage/packaging_configuration_resource_gen.go
@@ -872,7 +872,9 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 			Description: "The ID of the PackagingConfiguration.",
 			Type:        types.StringType,
 			Required:    true,
-			// Id is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Id is a force-new property.
+			},
 		},
 		"mss_package": {
 			// Property: MssPackage

--- a/internal/aws/mediapackage/packaging_group_resource_gen.go
+++ b/internal/aws/mediapackage/packaging_group_resource_gen.go
@@ -131,7 +131,9 @@ func packagingGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// Id is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Id is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -178,7 +180,9 @@ func packagingGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/mwaa/environment_resource_gen.go
+++ b/internal/aws/mwaa/environment_resource_gen.go
@@ -128,7 +128,9 @@ func environmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1224),
 			},
-			// KmsKey is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KmsKey is a force-new property.
+			},
 		},
 		"logging_configuration": {
 			// Property: LoggingConfiguration
@@ -513,7 +515,9 @@ func environmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 80),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"network_configuration": {
 			// Property: NetworkConfiguration
@@ -571,7 +575,9 @@ func environmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Validators: []tfsdk.AttributeValidator{
 							validate.ArrayLenBetween(2, 2),
 						},
-						// SubnetIds is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // SubnetIds is a force-new property.
+						},
 					},
 				},
 			),

--- a/internal/aws/networkfirewall/firewall_policy_resource_gen.go
+++ b/internal/aws/networkfirewall/firewall_policy_resource_gen.go
@@ -321,7 +321,9 @@ func firewallPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// FirewallPolicyName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FirewallPolicyName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/networkfirewall/firewall_resource_gen.go
+++ b/internal/aws/networkfirewall/firewall_resource_gen.go
@@ -99,7 +99,9 @@ func firewallResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// FirewallName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FirewallName is a force-new property.
+			},
 		},
 		"firewall_policy_arn": {
 			// Property: FirewallPolicyArn
@@ -238,7 +240,9 @@ func firewallResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// VpcId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/networkfirewall/logging_configuration_resource_gen.go
+++ b/internal/aws/networkfirewall/logging_configuration_resource_gen.go
@@ -39,7 +39,9 @@ func loggingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// FirewallArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FirewallArn is a force-new property.
+			},
 		},
 		"firewall_name": {
 			// Property: FirewallName
@@ -56,7 +58,9 @@ func loggingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// FirewallName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FirewallName is a force-new property.
+			},
 		},
 		"logging_configuration": {
 			// Property: LoggingConfiguration

--- a/internal/aws/networkfirewall/rule_group_resource_gen.go
+++ b/internal/aws/networkfirewall/rule_group_resource_gen.go
@@ -31,7 +31,9 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.NumberType,
 			Required: true,
-			// Capacity is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Capacity is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description
@@ -997,7 +999,9 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// RuleGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RuleGroupName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -1070,7 +1074,9 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"STATEFUL",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/networkmanager/customer_gateway_association_resource_gen.go
+++ b/internal/aws/networkmanager/customer_gateway_association_resource_gen.go
@@ -31,7 +31,9 @@ func customerGatewayAssociationResourceType(ctx context.Context) (tfsdk.Resource
 			Description: "The Amazon Resource Name (ARN) of the customer gateway.",
 			Type:        types.StringType,
 			Required:    true,
-			// CustomerGatewayArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CustomerGatewayArn is a force-new property.
+			},
 		},
 		"device_id": {
 			// Property: DeviceId
@@ -43,7 +45,9 @@ func customerGatewayAssociationResourceType(ctx context.Context) (tfsdk.Resource
 			Description: "The ID of the device",
 			Type:        types.StringType,
 			Required:    true,
-			// DeviceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DeviceId is a force-new property.
+			},
 		},
 		"global_network_id": {
 			// Property: GlobalNetworkId
@@ -55,7 +59,9 @@ func customerGatewayAssociationResourceType(ctx context.Context) (tfsdk.Resource
 			Description: "The ID of the global network.",
 			Type:        types.StringType,
 			Required:    true,
-			// GlobalNetworkId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GlobalNetworkId is a force-new property.
+			},
 		},
 		"link_id": {
 			// Property: LinkId
@@ -68,7 +74,9 @@ func customerGatewayAssociationResourceType(ctx context.Context) (tfsdk.Resource
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// LinkId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LinkId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/networkmanager/device_resource_gen.go
+++ b/internal/aws/networkmanager/device_resource_gen.go
@@ -64,7 +64,9 @@ func deviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the global network.",
 			Type:        types.StringType,
 			Required:    true,
-			// GlobalNetworkId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GlobalNetworkId is a force-new property.
+			},
 		},
 		"location": {
 			// Property: Location

--- a/internal/aws/networkmanager/link_association_resource_gen.go
+++ b/internal/aws/networkmanager/link_association_resource_gen.go
@@ -31,7 +31,9 @@ func linkAssociationResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Description: "The ID of the device",
 			Type:        types.StringType,
 			Required:    true,
-			// DeviceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DeviceId is a force-new property.
+			},
 		},
 		"global_network_id": {
 			// Property: GlobalNetworkId
@@ -43,7 +45,9 @@ func linkAssociationResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Description: "The ID of the global network.",
 			Type:        types.StringType,
 			Required:    true,
-			// GlobalNetworkId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GlobalNetworkId is a force-new property.
+			},
 		},
 		"link_id": {
 			// Property: LinkId
@@ -55,7 +59,9 @@ func linkAssociationResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Description: "The ID of the link",
 			Type:        types.StringType,
 			Required:    true,
-			// LinkId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LinkId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/networkmanager/site_resource_gen.go
+++ b/internal/aws/networkmanager/site_resource_gen.go
@@ -42,7 +42,9 @@ func siteResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The ID of the global network.",
 			Type:        types.StringType,
 			Required:    true,
-			// GlobalNetworkId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GlobalNetworkId is a force-new property.
+			},
 		},
 		"location": {
 			// Property: Location

--- a/internal/aws/networkmanager/transit_gateway_registration_resource_gen.go
+++ b/internal/aws/networkmanager/transit_gateway_registration_resource_gen.go
@@ -31,7 +31,9 @@ func transitGatewayRegistrationResourceType(ctx context.Context) (tfsdk.Resource
 			Description: "The ID of the global network.",
 			Type:        types.StringType,
 			Required:    true,
-			// GlobalNetworkId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GlobalNetworkId is a force-new property.
+			},
 		},
 		"transit_gateway_arn": {
 			// Property: TransitGatewayArn
@@ -43,7 +45,9 @@ func transitGatewayRegistrationResourceType(ctx context.Context) (tfsdk.Resource
 			Description: "The Amazon Resource Name (ARN) of the transit gateway.",
 			Type:        types.StringType,
 			Required:    true,
-			// TransitGatewayArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TransitGatewayArn is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/nimblestudio/launch_profile_resource_gen.go
+++ b/internal/aws/nimblestudio/launch_profile_resource_gen.go
@@ -41,7 +41,9 @@ func launchProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			// }
 			Type:     types.ListType{ElemType: types.StringType},
 			Required: true,
-			// Ec2SubnetIds is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Ec2SubnetIds is a force-new property.
+			},
 		},
 		"launch_profile_id": {
 			// Property: LaunchProfileId
@@ -151,7 +153,9 @@ func launchProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// StudioId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StudioId is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -169,7 +173,9 @@ func launchProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/nimblestudio/streaming_image_resource_gen.go
+++ b/internal/aws/nimblestudio/streaming_image_resource_gen.go
@@ -38,7 +38,9 @@ func streamingImageResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// Ec2ImageId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Ec2ImageId is a force-new property.
+			},
 		},
 		"encryption_configuration": {
 			// Property: EncryptionConfiguration
@@ -130,7 +132,9 @@ func streamingImageResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// StudioId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StudioId is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -148,7 +152,9 @@ func streamingImageResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/nimblestudio/studio_component_resource_gen.go
+++ b/internal/aws/nimblestudio/studio_component_resource_gen.go
@@ -339,7 +339,9 @@ func studioComponentResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// StudioId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StudioId is a force-new property.
+			},
 		},
 		"subtype": {
 			// Property: Subtype
@@ -350,7 +352,9 @@ func studioComponentResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// Subtype is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Subtype is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -368,7 +372,9 @@ func studioComponentResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"type": {
 			// Property: Type

--- a/internal/aws/nimblestudio/studio_resource_gen.go
+++ b/internal/aws/nimblestudio/studio_resource_gen.go
@@ -108,7 +108,9 @@ func studioResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// StudioName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StudioName is a force-new property.
+			},
 		},
 		"studio_url": {
 			// Property: StudioUrl
@@ -135,7 +137,9 @@ func studioResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.MapType{ElemType: types.StringType},
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 		"user_role_arn": {
 			// Property: UserRoleArn

--- a/internal/aws/qldb/stream_resource_gen.go
+++ b/internal/aws/qldb/stream_resource_gen.go
@@ -42,7 +42,9 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// ExclusiveEndTime is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ExclusiveEndTime is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -61,7 +63,9 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// InclusiveStartTime is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InclusiveStartTime is a force-new property.
+			},
 		},
 		"kinesis_configuration": {
 			// Property: KinesisConfiguration
@@ -94,7 +98,9 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// KinesisConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KinesisConfiguration is a force-new property.
+			},
 		},
 		"ledger_name": {
 			// Property: LedgerName
@@ -104,7 +110,9 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// LedgerName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // LedgerName is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn
@@ -115,7 +123,9 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// RoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RoleArn is a force-new property.
+			},
 		},
 		"stream_name": {
 			// Property: StreamName
@@ -125,7 +135,9 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// StreamName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StreamName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/quicksight/analysis_resource_gen.go
+++ b/internal/aws/quicksight/analysis_resource_gen.go
@@ -37,7 +37,9 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// AnalysisId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AnalysisId is a force-new property.
+			},
 		},
 		"arn": {
 			// Property: Arn
@@ -64,7 +66,9 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(12, 12),
 			},
-			// AwsAccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AwsAccountId is a force-new property.
+			},
 		},
 		"created_time": {
 			// Property: CreatedTime
@@ -175,7 +179,7 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "<p>The time that the analysis was last updated.</p>",
 			Type:        types.StringType,
 			Computed:    true,
-			// LastUpdatedTime is a write-only attribute.
+			// LastUpdatedTime is a write-only property.
 		},
 		"name": {
 			// Property: Name
@@ -426,7 +430,7 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// Parameters is a write-only attribute.
+			// Parameters is a write-only property.
 		},
 		"permissions": {
 			// Property: Permissions
@@ -545,7 +549,7 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Computed: true,
-			// Sheets is a write-only attribute.
+			// Sheets is a write-only property.
 		},
 		"source_entity": {
 			// Property: SourceEntity
@@ -642,7 +646,7 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// SourceEntity is a write-only attribute.
+			// SourceEntity is a write-only property.
 		},
 		"status": {
 			// Property: Status
@@ -661,7 +665,7 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// }
 			Type:     types.StringType,
 			Computed: true,
-			// Status is a write-only attribute.
+			// Status is a write-only property.
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/quicksight/dashboard_resource_gen.go
+++ b/internal/aws/quicksight/dashboard_resource_gen.go
@@ -48,7 +48,9 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(12, 12),
 			},
-			// AwsAccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AwsAccountId is a force-new property.
+			},
 		},
 		"created_time": {
 			// Property: CreatedTime
@@ -61,7 +63,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "<p>The time that this dataset was created.</p>",
 			Type:        types.StringType,
 			Computed:    true,
-			// CreatedTime is a write-only attribute.
+			// CreatedTime is a write-only property.
 		},
 		"dashboard_id": {
 			// Property: DashboardId
@@ -77,7 +79,9 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// DashboardId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DashboardId is a force-new property.
+			},
 		},
 		"dashboard_publish_options": {
 			// Property: DashboardPublishOptions
@@ -197,7 +201,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// DashboardPublishOptions is a write-only attribute.
+			// DashboardPublishOptions is a write-only property.
 		},
 		"last_published_time": {
 			// Property: LastPublishedTime
@@ -222,7 +226,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "<p>The last time that this dataset was updated.</p>",
 			Type:        types.StringType,
 			Computed:    true,
-			// LastUpdatedTime is a write-only attribute.
+			// LastUpdatedTime is a write-only property.
 		},
 		"name": {
 			// Property: Name
@@ -473,7 +477,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// Parameters is a write-only attribute.
+			// Parameters is a write-only property.
 		},
 		"permissions": {
 			// Property: Permissions
@@ -634,7 +638,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// SourceEntity is a write-only attribute.
+			// SourceEntity is a write-only property.
 		},
 		"tags": {
 			// Property: Tags
@@ -707,7 +711,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "<p>The Amazon Resource Name (ARN) of the theme that is being used for this dashboard. If\n            you add a value for this field, it overrides the value that is used in the source\n            entity. The theme ARN must exist in the same AWS account where you create the\n            dashboard.</p>",
 			Type:        types.StringType,
 			Optional:    true,
-			// ThemeArn is a write-only attribute.
+			// ThemeArn is a write-only property.
 		},
 		"version": {
 			// Property: Version
@@ -963,7 +967,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Computed: true,
-			// Version is a write-only attribute.
+			// Version is a write-only property.
 		},
 		"version_description": {
 			// Property: VersionDescription
@@ -980,7 +984,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 512),
 			},
-			// VersionDescription is a write-only attribute.
+			// VersionDescription is a write-only property.
 		},
 	}
 

--- a/internal/aws/quicksight/data_set_resource_gen.go
+++ b/internal/aws/quicksight/data_set_resource_gen.go
@@ -49,7 +49,9 @@ func dataSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(12, 12),
 			},
-			// AwsAccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AwsAccountId is a force-new property.
+			},
 		},
 		"column_groups": {
 			// Property: ColumnGroups
@@ -231,7 +233,9 @@ func dataSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// DataSetId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataSetId is a force-new property.
+			},
 		},
 		"field_folders": {
 			// Property: FieldFolders
@@ -282,7 +286,7 @@ func dataSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				tfsdk.MapNestedAttributesOptions{},
 			),
 			Optional: true,
-			// FieldFolders is a write-only attribute.
+			// FieldFolders is a write-only property.
 		},
 		"import_mode": {
 			// Property: ImportMode
@@ -343,7 +347,7 @@ func dataSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// IngestionWaitPolicy is a write-only attribute.
+			// IngestionWaitPolicy is a write-only property.
 		},
 		"last_updated_time": {
 			// Property: LastUpdatedTime

--- a/internal/aws/quicksight/data_source_resource_gen.go
+++ b/internal/aws/quicksight/data_source_resource_gen.go
@@ -1023,7 +1023,9 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(12, 12),
 			},
-			// AwsAccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AwsAccountId is a force-new property.
+			},
 		},
 		"created_time": {
 			// Property: CreatedTime
@@ -2085,7 +2087,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// Credentials is a write-only attribute.
+			// Credentials is a write-only property.
 		},
 		"data_source_id": {
 			// Property: DataSourceId
@@ -2096,7 +2098,9 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// DataSourceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataSourceId is a force-new property.
+			},
 		},
 		"data_source_parameters": {
 			// Property: DataSourceParameters
@@ -3374,7 +3378,9 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"TIMESTREAM",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 		"vpc_connection_properties": {
 			// Property: VpcConnectionProperties

--- a/internal/aws/quicksight/template_resource_gen.go
+++ b/internal/aws/quicksight/template_resource_gen.go
@@ -48,7 +48,9 @@ func templateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(12, 12),
 			},
-			// AwsAccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AwsAccountId is a force-new property.
+			},
 		},
 		"created_time": {
 			// Property: CreatedTime
@@ -61,7 +63,7 @@ func templateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "<p>Time when this was created.</p>",
 			Type:        types.StringType,
 			Computed:    true,
-			// CreatedTime is a write-only attribute.
+			// CreatedTime is a write-only property.
 		},
 		"last_updated_time": {
 			// Property: LastUpdatedTime
@@ -74,7 +76,7 @@ func templateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "<p>Time when this was last updated.</p>",
 			Type:        types.StringType,
 			Computed:    true,
-			// LastUpdatedTime is a write-only attribute.
+			// LastUpdatedTime is a write-only property.
 		},
 		"name": {
 			// Property: Name
@@ -281,7 +283,7 @@ func templateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// SourceEntity is a write-only attribute.
+			// SourceEntity is a write-only property.
 		},
 		"tags": {
 			// Property: Tags
@@ -358,7 +360,9 @@ func templateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// TemplateId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TemplateId is a force-new property.
+			},
 		},
 		"version": {
 			// Property: Version
@@ -754,7 +758,7 @@ func templateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Computed: true,
-			// Version is a write-only attribute.
+			// Version is a write-only property.
 		},
 		"version_description": {
 			// Property: VersionDescription
@@ -771,7 +775,7 @@ func templateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 512),
 			},
-			// VersionDescription is a write-only attribute.
+			// VersionDescription is a write-only property.
 		},
 	}
 

--- a/internal/aws/quicksight/theme_resource_gen.go
+++ b/internal/aws/quicksight/theme_resource_gen.go
@@ -48,7 +48,9 @@ func themeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(12, 12),
 			},
-			// AwsAccountId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AwsAccountId is a force-new property.
+			},
 		},
 		"base_theme_id": {
 			// Property: BaseThemeId
@@ -66,7 +68,7 @@ func themeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// BaseThemeId is a write-only attribute.
+			// BaseThemeId is a write-only property.
 		},
 		"configuration": {
 			// Property: Configuration
@@ -512,7 +514,7 @@ func themeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Optional: true,
-			// Configuration is a write-only attribute.
+			// Configuration is a write-only property.
 		},
 		"created_time": {
 			// Property: CreatedTime
@@ -693,7 +695,9 @@ func themeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// ThemeId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ThemeId is a force-new property.
+			},
 		},
 		"type": {
 			// Property: Type
@@ -1330,7 +1334,7 @@ func themeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 512),
 			},
-			// VersionDescription is a write-only attribute.
+			// VersionDescription is a write-only property.
 		},
 	}
 

--- a/internal/aws/rds/db_proxy_endpoint_resource_gen.go
+++ b/internal/aws/rds/db_proxy_endpoint_resource_gen.go
@@ -50,7 +50,9 @@ func dBProxyEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 64),
 			},
-			// DBProxyEndpointName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DBProxyEndpointName is a force-new property.
+			},
 		},
 		"db_proxy_name": {
 			// Property: DBProxyName
@@ -67,7 +69,9 @@ func dBProxyEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 64),
 			},
-			// DBProxyName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DBProxyName is a force-new property.
+			},
 		},
 		"endpoint": {
 			// Property: Endpoint
@@ -161,7 +165,9 @@ func dBProxyEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error
 					"READ_ONLY",
 				}),
 			},
-			// TargetRole is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TargetRole is a force-new property.
+			},
 		},
 		"vpc_id": {
 			// Property: VpcId
@@ -211,7 +217,9 @@ func dBProxyEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.ArrayLenAtLeast(2),
 			},
-			// VpcSubnetIds is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcSubnetIds is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/rds/db_proxy_resource_gen.go
+++ b/internal/aws/rds/db_proxy_resource_gen.go
@@ -142,7 +142,9 @@ func dBProxyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 64),
 			},
-			// DBProxyName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DBProxyName is a force-new property.
+			},
 		},
 		"debug_logging": {
 			// Property: DebugLogging
@@ -186,7 +188,9 @@ func dBProxyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"POSTGRESQL",
 				}),
 			},
-			// EngineFamily is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EngineFamily is a force-new property.
+			},
 		},
 		"idle_client_timeout": {
 			// Property: IdleClientTimeout
@@ -317,7 +321,9 @@ func dBProxyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.ArrayLenAtLeast(2),
 			},
-			// VpcSubnetIds is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcSubnetIds is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/rds/db_proxy_target_group_resource_gen.go
+++ b/internal/aws/rds/db_proxy_target_group_resource_gen.go
@@ -143,7 +143,9 @@ func dBProxyTargetGroupResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 64),
 			},
-			// DBProxyName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DBProxyName is a force-new property.
+			},
 		},
 		"target_group_arn": {
 			// Property: TargetGroupArn
@@ -174,7 +176,9 @@ func dBProxyTargetGroupResourceType(ctx context.Context) (tfsdk.ResourceType, er
 					"default",
 				}),
 			},
-			// TargetGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TargetGroupName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/rds/global_cluster_resource_gen.go
+++ b/internal/aws/rds/global_cluster_resource_gen.go
@@ -57,7 +57,9 @@ func globalClusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"aurora-postgresql",
 				}),
 			},
-			// Engine is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Engine is a force-new property.
+			},
 		},
 		"engine_version": {
 			// Property: EngineVersion
@@ -70,7 +72,9 @@ func globalClusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// EngineVersion is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EngineVersion is a force-new property.
+			},
 		},
 		"global_cluster_identifier": {
 			// Property: GlobalClusterIdentifier
@@ -84,7 +88,9 @@ func globalClusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// GlobalClusterIdentifier is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // GlobalClusterIdentifier is a force-new property.
+			},
 		},
 		"source_db_cluster_identifier": {
 			// Property: SourceDBClusterIdentifier
@@ -101,7 +107,9 @@ func globalClusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// SourceDBClusterIdentifier is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SourceDBClusterIdentifier is a force-new property.
+			},
 		},
 		"storage_encrypted": {
 			// Property: StorageEncrypted
@@ -114,7 +122,9 @@ func globalClusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Type:        types.BoolType,
 			Optional:    true,
 			Computed:    true,
-			// StorageEncrypted is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StorageEncrypted is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/resourcegroups/group_resource_gen.go
+++ b/internal/aws/resourcegroups/group_resource_gen.go
@@ -125,7 +125,9 @@ func groupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"resource_query": {
 			// Property: ResourceQuery

--- a/internal/aws/robomaker/simulation_application_version_resource_gen.go
+++ b/internal/aws/robomaker/simulation_application_version_resource_gen.go
@@ -32,7 +32,9 @@ func simulationApplicationVersionResourceType(ctx context.Context) (tfsdk.Resour
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// Application is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Application is a force-new property.
+			},
 		},
 		"application_version": {
 			// Property: ApplicationVersion
@@ -70,7 +72,9 @@ func simulationApplicationVersionResourceType(ctx context.Context) (tfsdk.Resour
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 40),
 			},
-			// CurrentRevisionId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CurrentRevisionId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/route53/dnssec_resource_gen.go
+++ b/internal/aws/route53/dnssec_resource_gen.go
@@ -32,7 +32,9 @@ func dNSSECResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The unique string (ID) used to identify a hosted zone.",
 			Type:        types.StringType,
 			Required:    true,
-			// HostedZoneId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // HostedZoneId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/route53/health_check_resource_gen.go
+++ b/internal/aws/route53/health_check_resource_gen.go
@@ -239,7 +239,9 @@ func healthCheckResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Type:     types.BoolType,
 						Optional: true,
 						Computed: true,
-						// MeasureLatency is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // MeasureLatency is a force-new property.
+						},
 					},
 					"port": {
 						// Property: Port
@@ -265,7 +267,9 @@ func healthCheckResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(10, 30),
 						},
-						// RequestInterval is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // RequestInterval is a force-new property.
+						},
 					},
 					"resource_path": {
 						// Property: ResourcePath
@@ -307,7 +311,9 @@ func healthCheckResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"RECOVERY_CONTROL",
 							}),
 						},
-						// Type is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // Type is a force-new property.
+						},
 					},
 				},
 			),

--- a/internal/aws/route53/hosted_zone_resource_gen.go
+++ b/internal/aws/route53/hosted_zone_resource_gen.go
@@ -131,7 +131,9 @@ func hostedZoneResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1024),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"name_servers": {
 			// Property: NameServers

--- a/internal/aws/route53/key_signing_key_resource_gen.go
+++ b/internal/aws/route53/key_signing_key_resource_gen.go
@@ -34,7 +34,9 @@ func keySigningKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Description: "The unique string (ID) used to identify a hosted zone.",
 			Type:        types.StringType,
 			Required:    true,
-			// HostedZoneId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // HostedZoneId is a force-new property.
+			},
 		},
 		"key_management_service_arn": {
 			// Property: KeyManagementServiceArn
@@ -51,7 +53,9 @@ func keySigningKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// KeyManagementServiceArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KeyManagementServiceArn is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -64,7 +68,9 @@ func keySigningKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Description: "An alphanumeric string used to identify a key signing key (KSK). Name must be unique for each key signing key in the same hosted zone.",
 			Type:        types.StringType,
 			Required:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"status": {
 			// Property: Status

--- a/internal/aws/route53recoverycontrol/cluster_resource_gen.go
+++ b/internal/aws/route53recoverycontrol/cluster_resource_gen.go
@@ -100,7 +100,9 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"status": {
 			// Property: Status

--- a/internal/aws/route53recoverycontrol/control_panel_resource_gen.go
+++ b/internal/aws/route53recoverycontrol/control_panel_resource_gen.go
@@ -34,7 +34,9 @@ func controlPanelResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ClusterArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ClusterArn is a force-new property.
+			},
 		},
 		"control_panel_arn": {
 			// Property: ControlPanelArn

--- a/internal/aws/route53recoverycontrol/routing_control_resource_gen.go
+++ b/internal/aws/route53recoverycontrol/routing_control_resource_gen.go
@@ -34,8 +34,10 @@ func routingControlResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ClusterArn is a force-new attribute.
-			// ClusterArn is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ClusterArn is a force-new property.
+			},
+			// ClusterArn is a write-only property.
 		},
 		"control_panel_arn": {
 			// Property: ControlPanelArn
@@ -48,7 +50,9 @@ func routingControlResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ControlPanelArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ControlPanelArn is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name

--- a/internal/aws/route53recoverycontrol/safety_rule_resource_gen.go
+++ b/internal/aws/route53recoverycontrol/safety_rule_resource_gen.go
@@ -79,7 +79,9 @@ func safetyRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ControlPanelArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ControlPanelArn is a force-new property.
+			},
 		},
 		"gating_rule": {
 			// Property: GatingRule
@@ -216,7 +218,9 @@ func safetyRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// RuleConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RuleConfig is a force-new property.
+			},
 		},
 		"safety_rule_arn": {
 			// Property: SafetyRuleArn

--- a/internal/aws/route53recoveryreadiness/cell_resource_gen.go
+++ b/internal/aws/route53recoveryreadiness/cell_resource_gen.go
@@ -50,7 +50,9 @@ func cellResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 64),
 			},
-			// CellName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // CellName is a force-new property.
+			},
 		},
 		"cells": {
 			// Property: Cells

--- a/internal/aws/route53recoveryreadiness/readiness_check_resource_gen.go
+++ b/internal/aws/route53recoveryreadiness/readiness_check_resource_gen.go
@@ -51,7 +51,9 @@ func readinessCheckResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// ReadinessCheckName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ReadinessCheckName is a force-new property.
+			},
 		},
 		"resource_set_name": {
 			// Property: ResourceSetName

--- a/internal/aws/route53recoveryreadiness/recovery_group_resource_gen.go
+++ b/internal/aws/route53recoveryreadiness/recovery_group_resource_gen.go
@@ -72,7 +72,9 @@ func recoveryGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// RecoveryGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RecoveryGroupName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/route53recoveryreadiness/resource_set_resource_gen.go
+++ b/internal/aws/route53recoveryreadiness/resource_set_resource_gen.go
@@ -46,7 +46,9 @@ func resourceSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name of the resource set to create.",
 			Type:        types.StringType,
 			Required:    true,
-			// ResourceSetName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceSetName is a force-new property.
+			},
 		},
 		"resource_set_type": {
 			// Property: ResourceSetType
@@ -58,7 +60,9 @@ func resourceSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The resource type of the resources in the resource set. Enter one of the following values for resource type: \n\nAWS: :AutoScaling: :AutoScalingGroup, AWS: :CloudWatch: :Alarm, AWS: :EC2: :CustomerGateway, AWS: :DynamoDB: :Table, AWS: :EC2: :Volume, AWS: :ElasticLoadBalancing: :LoadBalancer, AWS: :ElasticLoadBalancingV2: :LoadBalancer, AWS: :MSK: :Cluster, AWS: :RDS: :DBCluster, AWS: :Route53: :HealthCheck, AWS: :SQS: :Queue, AWS: :SNS: :Topic, AWS: :SNS: :Subscription, AWS: :EC2: :VPC, AWS: :EC2: :VPNConnection, AWS: :EC2: :VPNGateway, AWS::Route53RecoveryReadiness::DNSTargetResource",
 			Type:        types.StringType,
 			Required:    true,
-			// ResourceSetType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceSetType is a force-new property.
+			},
 		},
 		"resources": {
 			// Property: Resources

--- a/internal/aws/route53resolver/firewall_domain_list_resource_gen.go
+++ b/internal/aws/route53resolver/firewall_domain_list_resource_gen.go
@@ -89,7 +89,7 @@ func firewallDomainListResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 1024),
 			},
-			// DomainFileUrl is a write-only attribute.
+			// DomainFileUrl is a write-only property.
 		},
 		"domains": {
 			// Property: Domains
@@ -111,7 +111,7 @@ func firewallDomainListResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.UniqueItems(),
 			},
-			// Domains is a write-only attribute.
+			// Domains is a write-only property.
 		},
 		"id": {
 			// Property: Id
@@ -169,7 +169,9 @@ func firewallDomainListResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"status": {
 			// Property: Status

--- a/internal/aws/route53resolver/firewall_rule_group_association_resource_gen.go
+++ b/internal/aws/route53resolver/firewall_rule_group_association_resource_gen.go
@@ -77,7 +77,9 @@ func firewallRuleGroupAssociationResourceType(ctx context.Context) (tfsdk.Resour
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// FirewallRuleGroupId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FirewallRuleGroupId is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -268,7 +270,9 @@ func firewallRuleGroupAssociationResourceType(ctx context.Context) (tfsdk.Resour
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// VpcId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/route53resolver/firewall_rule_group_resource_gen.go
+++ b/internal/aws/route53resolver/firewall_rule_group_resource_gen.go
@@ -251,7 +251,9 @@ func firewallRuleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"owner_id": {
 			// Property: OwnerId

--- a/internal/aws/route53resolver/resolver_dnssec_config_resource_gen.go
+++ b/internal/aws/route53resolver/resolver_dnssec_config_resource_gen.go
@@ -65,7 +65,9 @@ func resolverDNSSECConfigResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// ResourceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceId is a force-new property.
+			},
 		},
 		"validation_status": {
 			// Property: ValidationStatus

--- a/internal/aws/route53resolver/resolver_query_logging_config_association_resource_gen.go
+++ b/internal/aws/route53resolver/resolver_query_logging_config_association_resource_gen.go
@@ -92,7 +92,9 @@ func resolverQueryLoggingConfigAssociationResourceType(ctx context.Context) (tfs
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// ResolverQueryLogConfigId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResolverQueryLogConfigId is a force-new property.
+			},
 		},
 		"resource_id": {
 			// Property: ResourceId
@@ -110,7 +112,9 @@ func resolverQueryLoggingConfigAssociationResourceType(ctx context.Context) (tfs
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// ResourceId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceId is a force-new property.
+			},
 		},
 		"status": {
 			// Property: Status

--- a/internal/aws/route53resolver/resolver_query_logging_config_resource_gen.go
+++ b/internal/aws/route53resolver/resolver_query_logging_config_resource_gen.go
@@ -89,7 +89,9 @@ func resolverQueryLoggingConfigResourceType(ctx context.Context) (tfsdk.Resource
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 600),
 			},
-			// DestinationArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DestinationArn is a force-new property.
+			},
 		},
 		"id": {
 			// Property: Id
@@ -121,7 +123,9 @@ func resolverQueryLoggingConfigResourceType(ctx context.Context) (tfsdk.Resource
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"owner_id": {
 			// Property: OwnerId

--- a/internal/aws/s3/access_point_resource_gen.go
+++ b/internal/aws/s3/access_point_resource_gen.go
@@ -63,7 +63,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(3, 255),
 			},
-			// Bucket is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Bucket is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -78,7 +80,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.",
 			Type:        types.StringType,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"network_origin": {
 			// Property: NetworkOrigin
@@ -194,7 +198,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// PublicAccessBlockConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PublicAccessBlockConfiguration is a force-new property.
+			},
 		},
 		"vpc_configuration": {
 			// Property: VpcConfiguration
@@ -227,7 +233,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// VpcConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcConfiguration is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/s3/storage_lens_resource_gen.go
+++ b/internal/aws/s3/storage_lens_resource_gen.go
@@ -469,7 +469,9 @@ func storageLensResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 						Validators: []tfsdk.AttributeValidator{
 							validate.StringLenBetween(1, 64),
 						},
-						// Id is a force-new attribute.
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							tfsdk.RequiresReplace(), // Id is a force-new property.
+						},
 					},
 					"include": {
 						// Property: Include

--- a/internal/aws/s3objectlambda/access_point_policy_resource_gen.go
+++ b/internal/aws/s3objectlambda/access_point_policy_resource_gen.go
@@ -39,7 +39,9 @@ func accessPointPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(3, 45),
 			},
-			// ObjectLambdaAccessPoint is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ObjectLambdaAccessPoint is a force-new property.
+			},
 		},
 		"policy_document": {
 			// Property: PolicyDocument

--- a/internal/aws/s3objectlambda/access_point_resource_gen.go
+++ b/internal/aws/s3objectlambda/access_point_resource_gen.go
@@ -60,7 +60,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(3, 45),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"object_lambda_configuration": {
 			// Property: ObjectLambdaConfiguration

--- a/internal/aws/s3outposts/access_point_resource_gen.go
+++ b/internal/aws/s3outposts/access_point_resource_gen.go
@@ -53,7 +53,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// Bucket is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Bucket is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -71,7 +73,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(3, 50),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"policy": {
 			// Property: Policy
@@ -113,7 +117,9 @@ func accessPointResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// VpcConfiguration is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcConfiguration is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/s3outposts/bucket_policy_resource_gen.go
+++ b/internal/aws/s3outposts/bucket_policy_resource_gen.go
@@ -39,7 +39,9 @@ func bucketPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// Bucket is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Bucket is a force-new property.
+			},
 		},
 		"policy_document": {
 			// Property: PolicyDocument

--- a/internal/aws/sagemaker/app_image_config_resource_gen.go
+++ b/internal/aws/sagemaker/app_image_config_resource_gen.go
@@ -53,7 +53,9 @@ func appImageConfigResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// AppImageConfigName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AppImageConfigName is a force-new property.
+			},
 		},
 		"kernel_gateway_image_config": {
 			// Property: KernelGatewayImageConfig
@@ -252,8 +254,10 @@ func appImageConfigResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
-			// Tags is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
+			// Tags is a write-only property.
 		},
 	}
 

--- a/internal/aws/sagemaker/app_resource_gen.go
+++ b/internal/aws/sagemaker/app_resource_gen.go
@@ -53,7 +53,9 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// AppName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AppName is a force-new property.
+			},
 		},
 		"app_type": {
 			// Property: AppType
@@ -75,7 +77,9 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"KernelGateway",
 				}),
 			},
-			// AppType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AppType is a force-new property.
+			},
 		},
 		"domain_id": {
 			// Property: DomainId
@@ -92,7 +96,9 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// DomainId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainId is a force-new property.
+			},
 		},
 		"resource_spec": {
 			// Property: ResourceSpec
@@ -278,8 +284,10 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
-			// Tags is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
+			// Tags is a write-only property.
 		},
 		"user_profile_name": {
 			// Property: UserProfileName
@@ -297,7 +305,9 @@ func appResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// UserProfileName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // UserProfileName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sagemaker/data_quality_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/data_quality_job_definition_resource_gen.go
@@ -160,7 +160,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 				},
 			),
 			Required: true,
-			// DataQualityAppSpecification is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataQualityAppSpecification is a force-new property.
+			},
 		},
 		"data_quality_baseline_config": {
 			// Property: DataQualityBaselineConfig
@@ -257,7 +259,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 			),
 			Optional: true,
 			Computed: true,
-			// DataQualityBaselineConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataQualityBaselineConfig is a force-new property.
+			},
 		},
 		"data_quality_job_input": {
 			// Property: DataQualityJobInput
@@ -368,7 +372,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 				},
 			),
 			Required: true,
-			// DataQualityJobInput is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataQualityJobInput is a force-new property.
+			},
 		},
 		"data_quality_job_output_config": {
 			// Property: DataQualityJobOutputConfig
@@ -500,7 +506,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 				},
 			),
 			Required: true,
-			// DataQualityJobOutputConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DataQualityJobOutputConfig is a force-new property.
+			},
 		},
 		"job_definition_arn": {
 			// Property: JobDefinitionArn
@@ -531,7 +539,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 63),
 			},
-			// JobDefinitionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // JobDefinitionName is a force-new property.
+			},
 		},
 		"job_resources": {
 			// Property: JobResources
@@ -625,7 +635,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 				},
 			),
 			Required: true,
-			// JobResources is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // JobResources is a force-new property.
+			},
 		},
 		"network_config": {
 			// Property: NetworkConfig
@@ -724,7 +736,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 			),
 			Optional: true,
 			Computed: true,
-			// NetworkConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkConfig is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn
@@ -742,7 +756,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// RoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RoleArn is a force-new property.
+			},
 		},
 		"stopping_condition": {
 			// Property: StoppingCondition
@@ -779,7 +795,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 			),
 			Optional: true,
 			Computed: true,
-			// StoppingCondition is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StoppingCondition is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -841,7 +859,9 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sagemaker/device_fleet_resource_gen.go
+++ b/internal/aws/sagemaker/device_fleet_resource_gen.go
@@ -56,7 +56,9 @@ func deviceFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// DeviceFleetName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DeviceFleetName is a force-new property.
+			},
 		},
 		"output_config": {
 			// Property: OutputConfig

--- a/internal/aws/sagemaker/device_resource_gen.go
+++ b/internal/aws/sagemaker/device_resource_gen.go
@@ -106,7 +106,9 @@ func deviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// DeviceFleetName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DeviceFleetName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/sagemaker/domain_resource_gen.go
+++ b/internal/aws/sagemaker/domain_resource_gen.go
@@ -44,7 +44,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"VpcOnly",
 				}),
 			},
-			// AppNetworkAccessType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AppNetworkAccessType is a force-new property.
+			},
 		},
 		"auth_mode": {
 			// Property: AuthMode
@@ -66,7 +68,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"IAM",
 				}),
 			},
-			// AuthMode is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // AuthMode is a force-new property.
+			},
 		},
 		"default_user_settings": {
 			// Property: DefaultUserSettings
@@ -584,7 +588,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 63),
 			},
-			// DomainName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainName is a force-new property.
+			},
 		},
 		"home_efs_file_system_id": {
 			// Property: HomeEfsFileSystemId
@@ -614,7 +620,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 2048),
 			},
-			// KmsKeyId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KmsKeyId is a force-new property.
+			},
 		},
 		"single_sign_on_managed_application_instance_id": {
 			// Property: SingleSignOnManagedApplicationInstanceId
@@ -649,7 +657,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.ArrayLenBetween(1, 16),
 			},
-			// SubnetIds is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SubnetIds is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -708,8 +718,10 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
-			// Tags is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
+			// Tags is a write-only property.
 		},
 		"url": {
 			// Property: Url
@@ -738,7 +750,9 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 32),
 			},
-			// VpcId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VpcId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sagemaker/feature_group_resource_gen.go
+++ b/internal/aws/sagemaker/feature_group_resource_gen.go
@@ -38,7 +38,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 128),
 			},
-			// Description is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Description is a force-new property.
+			},
 		},
 		"event_time_feature_name": {
 			// Property: EventTimeFeatureName
@@ -56,7 +58,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// EventTimeFeatureName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // EventTimeFeatureName is a force-new property.
+			},
 		},
 		"feature_definitions": {
 			// Property: FeatureDefinitions
@@ -122,7 +126,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// FeatureDefinitions is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FeatureDefinitions is a force-new property.
+			},
 		},
 		"feature_group_name": {
 			// Property: FeatureGroupName
@@ -140,7 +146,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// FeatureGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // FeatureGroupName is a force-new property.
+			},
 		},
 		"offline_store_config": {
 			// Property: OfflineStoreConfig
@@ -271,7 +279,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// OfflineStoreConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // OfflineStoreConfig is a force-new property.
+			},
 		},
 		"online_store_config": {
 			// Property: OnlineStoreConfig
@@ -322,7 +332,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// OnlineStoreConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // OnlineStoreConfig is a force-new property.
+			},
 		},
 		"record_identifier_feature_name": {
 			// Property: RecordIdentifierFeatureName
@@ -340,7 +352,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// RecordIdentifierFeatureName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RecordIdentifierFeatureName is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn
@@ -359,7 +373,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// RoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RoleArn is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -407,7 +423,9 @@ func featureGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sagemaker/image_resource_gen.go
+++ b/internal/aws/sagemaker/image_resource_gen.go
@@ -87,7 +87,9 @@ func imageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// ImageName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ImageName is a force-new property.
+			},
 		},
 		"image_role_arn": {
 			// Property: ImageRoleArn

--- a/internal/aws/sagemaker/image_version_resource_gen.go
+++ b/internal/aws/sagemaker/image_version_resource_gen.go
@@ -39,7 +39,9 @@ func imageVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// BaseImage is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BaseImage is a force-new property.
+			},
 		},
 		"container_image": {
 			// Property: ContainerImage
@@ -85,7 +87,9 @@ func imageVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// ImageName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ImageName is a force-new property.
+			},
 		},
 		"image_version_arn": {
 			// Property: ImageVersionArn

--- a/internal/aws/sagemaker/model_bias_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_bias_job_definition_resource_gen.go
@@ -63,7 +63,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 63),
 			},
-			// JobDefinitionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // JobDefinitionName is a force-new property.
+			},
 		},
 		"job_resources": {
 			// Property: JobResources
@@ -157,7 +159,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 				},
 			),
 			Required: true,
-			// JobResources is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // JobResources is a force-new property.
+			},
 		},
 		"model_bias_app_specification": {
 			// Property: ModelBiasAppSpecification
@@ -233,7 +237,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 				},
 			),
 			Required: true,
-			// ModelBiasAppSpecification is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelBiasAppSpecification is a force-new property.
+			},
 		},
 		"model_bias_baseline_config": {
 			// Property: ModelBiasBaselineConfig
@@ -299,7 +305,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 			),
 			Optional: true,
 			Computed: true,
-			// ModelBiasBaselineConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelBiasBaselineConfig is a force-new property.
+			},
 		},
 		"model_bias_job_input": {
 			// Property: ModelBiasJobInput
@@ -528,7 +536,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 				},
 			),
 			Required: true,
-			// ModelBiasJobInput is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelBiasJobInput is a force-new property.
+			},
 		},
 		"model_bias_job_output_config": {
 			// Property: ModelBiasJobOutputConfig
@@ -660,7 +670,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 				},
 			),
 			Required: true,
-			// ModelBiasJobOutputConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelBiasJobOutputConfig is a force-new property.
+			},
 		},
 		"network_config": {
 			// Property: NetworkConfig
@@ -759,7 +771,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 			),
 			Optional: true,
 			Computed: true,
-			// NetworkConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkConfig is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn
@@ -777,7 +791,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// RoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RoleArn is a force-new property.
+			},
 		},
 		"stopping_condition": {
 			// Property: StoppingCondition
@@ -814,7 +830,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 			),
 			Optional: true,
 			Computed: true,
-			// StoppingCondition is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StoppingCondition is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -876,7 +894,9 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sagemaker/model_explainability_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_explainability_job_definition_resource_gen.go
@@ -63,7 +63,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 63),
 			},
-			// JobDefinitionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // JobDefinitionName is a force-new property.
+			},
 		},
 		"job_resources": {
 			// Property: JobResources
@@ -157,7 +159,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 				},
 			),
 			Required: true,
-			// JobResources is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // JobResources is a force-new property.
+			},
 		},
 		"model_explainability_app_specification": {
 			// Property: ModelExplainabilityAppSpecification
@@ -233,7 +237,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 				},
 			),
 			Required: true,
-			// ModelExplainabilityAppSpecification is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelExplainabilityAppSpecification is a force-new property.
+			},
 		},
 		"model_explainability_baseline_config": {
 			// Property: ModelExplainabilityBaselineConfig
@@ -299,7 +305,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 			),
 			Optional: true,
 			Computed: true,
-			// ModelExplainabilityBaselineConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelExplainabilityBaselineConfig is a force-new property.
+			},
 		},
 		"model_explainability_job_input": {
 			// Property: ModelExplainabilityJobInput
@@ -452,7 +460,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 				},
 			),
 			Required: true,
-			// ModelExplainabilityJobInput is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelExplainabilityJobInput is a force-new property.
+			},
 		},
 		"model_explainability_job_output_config": {
 			// Property: ModelExplainabilityJobOutputConfig
@@ -584,7 +594,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 				},
 			),
 			Required: true,
-			// ModelExplainabilityJobOutputConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelExplainabilityJobOutputConfig is a force-new property.
+			},
 		},
 		"network_config": {
 			// Property: NetworkConfig
@@ -683,7 +695,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 			),
 			Optional: true,
 			Computed: true,
-			// NetworkConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkConfig is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn
@@ -701,7 +715,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// RoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RoleArn is a force-new property.
+			},
 		},
 		"stopping_condition": {
 			// Property: StoppingCondition
@@ -738,7 +754,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 			),
 			Optional: true,
 			Computed: true,
-			// StoppingCondition is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StoppingCondition is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -800,7 +818,9 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sagemaker/model_package_group_resource_gen.go
+++ b/internal/aws/sagemaker/model_package_group_resource_gen.go
@@ -64,7 +64,9 @@ func modelPackageGroupResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1024),
 			},
-			// ModelPackageGroupDescription is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelPackageGroupDescription is a force-new property.
+			},
 		},
 		"model_package_group_name": {
 			// Property: ModelPackageGroupName
@@ -81,7 +83,9 @@ func modelPackageGroupResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 63),
 			},
-			// ModelPackageGroupName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelPackageGroupName is a force-new property.
+			},
 		},
 		"model_package_group_policy": {
 			// Property: ModelPackageGroupPolicy

--- a/internal/aws/sagemaker/model_quality_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_quality_job_definition_resource_gen.go
@@ -63,7 +63,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 63),
 			},
-			// JobDefinitionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // JobDefinitionName is a force-new property.
+			},
 		},
 		"job_resources": {
 			// Property: JobResources
@@ -157,7 +159,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 				},
 			),
 			Required: true,
-			// JobResources is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // JobResources is a force-new property.
+			},
 		},
 		"model_quality_app_specification": {
 			// Property: ModelQualityAppSpecification
@@ -308,7 +312,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 				},
 			),
 			Required: true,
-			// ModelQualityAppSpecification is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelQualityAppSpecification is a force-new property.
+			},
 		},
 		"model_quality_baseline_config": {
 			// Property: ModelQualityBaselineConfig
@@ -374,7 +380,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 			),
 			Optional: true,
 			Computed: true,
-			// ModelQualityBaselineConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelQualityBaselineConfig is a force-new property.
+			},
 		},
 		"model_quality_job_input": {
 			// Property: ModelQualityJobInput
@@ -589,7 +597,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 				},
 			),
 			Required: true,
-			// ModelQualityJobInput is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelQualityJobInput is a force-new property.
+			},
 		},
 		"model_quality_job_output_config": {
 			// Property: ModelQualityJobOutputConfig
@@ -721,7 +731,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 				},
 			),
 			Required: true,
-			// ModelQualityJobOutputConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ModelQualityJobOutputConfig is a force-new property.
+			},
 		},
 		"network_config": {
 			// Property: NetworkConfig
@@ -820,7 +832,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 			),
 			Optional: true,
 			Computed: true,
-			// NetworkConfig is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NetworkConfig is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn
@@ -838,7 +852,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// RoleArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // RoleArn is a force-new property.
+			},
 		},
 		"stopping_condition": {
 			// Property: StoppingCondition
@@ -875,7 +891,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 			),
 			Optional: true,
 			Computed: true,
-			// StoppingCondition is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StoppingCondition is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -937,7 +955,9 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sagemaker/monitoring_schedule_resource_gen.go
+++ b/internal/aws/sagemaker/monitoring_schedule_resource_gen.go
@@ -1054,7 +1054,9 @@ func monitoringScheduleResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 63),
 			},
-			// MonitoringScheduleName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // MonitoringScheduleName is a force-new property.
+			},
 		},
 		"monitoring_schedule_status": {
 			// Property: MonitoringScheduleStatus

--- a/internal/aws/sagemaker/pipeline_resource_gen.go
+++ b/internal/aws/sagemaker/pipeline_resource_gen.go
@@ -93,7 +93,9 @@ func pipelineResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// PipelineName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PipelineName is a force-new property.
+			},
 		},
 		"role_arn": {
 			// Property: RoleArn

--- a/internal/aws/sagemaker/project_resource_gen.go
+++ b/internal/aws/sagemaker/project_resource_gen.go
@@ -64,7 +64,9 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1024),
 			},
-			// ProjectDescription is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProjectDescription is a force-new property.
+			},
 		},
 		"project_id": {
 			// Property: ProjectId
@@ -95,7 +97,9 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 32),
 			},
-			// ProjectName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProjectName is a force-new property.
+			},
 		},
 		"project_status": {
 			// Property: ProjectStatus
@@ -280,7 +284,9 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				},
 			),
 			Required: true,
-			// ServiceCatalogProvisioningDetails is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServiceCatalogProvisioningDetails is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -342,7 +348,9 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sagemaker/user_profile_resource_gen.go
+++ b/internal/aws/sagemaker/user_profile_resource_gen.go
@@ -38,7 +38,9 @@ func userProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// DomainId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DomainId is a force-new property.
+			},
 		},
 		"single_sign_on_user_identifier": {
 			// Property: SingleSignOnUserIdentifier
@@ -52,7 +54,9 @@ func userProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// SingleSignOnUserIdentifier is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SingleSignOnUserIdentifier is a force-new property.
+			},
 		},
 		"single_sign_on_user_value": {
 			// Property: SingleSignOnUserValue
@@ -70,7 +74,9 @@ func userProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 256),
 			},
-			// SingleSignOnUserValue is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SingleSignOnUserValue is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -129,8 +135,10 @@ func userProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
-			// Tags is a write-only attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
+			// Tags is a write-only property.
 		},
 		"user_profile_arn": {
 			// Property: UserProfileArn
@@ -160,7 +168,9 @@ func userProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 63),
 			},
-			// UserProfileName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // UserProfileName is a force-new property.
+			},
 		},
 		"user_settings": {
 			// Property: UserSettings

--- a/internal/aws/servicecatalog/cloudformation_provisioned_product_resource_gen.go
+++ b/internal/aws/servicecatalog/cloudformation_provisioned_product_resource_gen.go
@@ -73,7 +73,9 @@ func cloudFormationProvisionedProductResourceType(ctx context.Context) (tfsdk.Re
 				validate.ArrayLenBetween(0, 5),
 				validate.UniqueItems(),
 			},
-			// NotificationArns is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // NotificationArns is a force-new property.
+			},
 		},
 		"outputs": {
 			// Property: Outputs
@@ -174,7 +176,9 @@ func cloudFormationProvisionedProductResourceType(ctx context.Context) (tfsdk.Re
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 128),
 			},
-			// ProvisionedProductName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProvisionedProductName is a force-new property.
+			},
 		},
 		"provisioning_artifact_id": {
 			// Property: ProvisioningArtifactId

--- a/internal/aws/servicecatalog/service_action_association_resource_gen.go
+++ b/internal/aws/servicecatalog/service_action_association_resource_gen.go
@@ -37,7 +37,9 @@ func serviceActionAssociationResourceType(ctx context.Context) (tfsdk.ResourceTy
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// ProductId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProductId is a force-new property.
+			},
 		},
 		"provisioning_artifact_id": {
 			// Property: ProvisioningArtifactId
@@ -53,7 +55,9 @@ func serviceActionAssociationResourceType(ctx context.Context) (tfsdk.ResourceTy
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// ProvisioningArtifactId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProvisioningArtifactId is a force-new property.
+			},
 		},
 		"service_action_id": {
 			// Property: ServiceActionId
@@ -69,7 +73,9 @@ func serviceActionAssociationResourceType(ctx context.Context) (tfsdk.ResourceTy
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 100),
 			},
-			// ServiceActionId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ServiceActionId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ses/configuration_set_resource_gen.go
+++ b/internal/aws/ses/configuration_set_resource_gen.go
@@ -40,7 +40,9 @@ func configurationSetResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ses/contact_list_resource_gen.go
+++ b/internal/aws/ses/contact_list_resource_gen.go
@@ -35,7 +35,9 @@ func contactListResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// ContactListName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ContactListName is a force-new property.
+			},
 		},
 		"description": {
 			// Property: Description

--- a/internal/aws/signer/profile_permission_resource_gen.go
+++ b/internal/aws/signer/profile_permission_resource_gen.go
@@ -29,7 +29,9 @@ func profilePermissionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// Action is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Action is a force-new property.
+			},
 		},
 		"principal": {
 			// Property: Principal
@@ -39,7 +41,9 @@ func profilePermissionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// Principal is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Principal is a force-new property.
+			},
 		},
 		"profile_name": {
 			// Property: ProfileName
@@ -49,7 +53,9 @@ func profilePermissionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// ProfileName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProfileName is a force-new property.
+			},
 		},
 		"profile_version": {
 			// Property: ProfileVersion
@@ -61,7 +67,9 @@ func profilePermissionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			// ProfileVersion is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ProfileVersion is a force-new property.
+			},
 		},
 		"statement_id": {
 			// Property: StatementId
@@ -71,7 +79,9 @@ func profilePermissionResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			// }
 			Type:     types.StringType,
 			Required: true,
-			// StatementId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StatementId is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/signer/signing_profile_resource_gen.go
+++ b/internal/aws/signer/signing_profile_resource_gen.go
@@ -49,7 +49,9 @@ func signingProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"AWSLambda-SHA384-ECDSA",
 				}),
 			},
-			// PlatformId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PlatformId is a force-new property.
+			},
 		},
 		"profile_name": {
 			// Property: ProfileName
@@ -125,7 +127,9 @@ func signingProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			),
 			Optional: true,
 			Computed: true,
-			// SignatureValidityPeriod is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SignatureValidityPeriod is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/ssm/document_resource_gen.go
+++ b/internal/aws/ssm/document_resource_gen.go
@@ -107,7 +107,9 @@ func documentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Attachments is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Attachments is a force-new property.
+			},
 		},
 		"content": {
 			// Property: Content
@@ -119,7 +121,9 @@ func documentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The content for the Systems Manager document in JSON, YAML or String format.",
 			Type:        types.StringType,
 			Required:    true,
-			// Content is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Content is a force-new property.
+			},
 		},
 		"document_format": {
 			// Property: DocumentFormat
@@ -144,7 +148,9 @@ func documentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"TEXT",
 				}),
 			},
-			// DocumentFormat is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DocumentFormat is a force-new property.
+			},
 		},
 		"document_type": {
 			// Property: DocumentType
@@ -189,7 +195,9 @@ func documentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"Session",
 				}),
 			},
-			// DocumentType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DocumentType is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -203,7 +211,9 @@ func documentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"requires": {
 			// Property: Requires
@@ -259,7 +269,9 @@ func documentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			),
 			Optional: true,
 			Computed: true,
-			// Requires is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Requires is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -329,7 +341,9 @@ func documentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// TargetType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TargetType is a force-new property.
+			},
 		},
 		"version_name": {
 			// Property: VersionName
@@ -343,7 +357,9 @@ func documentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// VersionName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // VersionName is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ssm/resource_data_sync_resource_gen.go
+++ b/internal/aws/ssm/resource_data_sync_resource_gen.go
@@ -37,7 +37,9 @@ func resourceDataSyncResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// BucketName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BucketName is a force-new property.
+			},
 		},
 		"bucket_prefix": {
 			// Property: BucketPrefix
@@ -53,7 +55,9 @@ func resourceDataSyncResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 64),
 			},
-			// BucketPrefix is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BucketPrefix is a force-new property.
+			},
 		},
 		"bucket_region": {
 			// Property: BucketRegion
@@ -69,7 +73,9 @@ func resourceDataSyncResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// BucketRegion is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // BucketRegion is a force-new property.
+			},
 		},
 		"kms_key_arn": {
 			// Property: KMSKeyArn
@@ -85,7 +91,9 @@ func resourceDataSyncResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 512),
 			},
-			// KMSKeyArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // KMSKeyArn is a force-new property.
+			},
 		},
 		"s3_destination": {
 			// Property: S3Destination
@@ -172,7 +180,9 @@ func resourceDataSyncResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			),
 			Optional: true,
 			Computed: true,
-			// S3Destination is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // S3Destination is a force-new property.
+			},
 		},
 		"sync_format": {
 			// Property: SyncFormat
@@ -188,7 +198,9 @@ func resourceDataSyncResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(0, 1024),
 			},
-			// SyncFormat is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SyncFormat is a force-new property.
+			},
 		},
 		"sync_name": {
 			// Property: SyncName
@@ -203,7 +215,9 @@ func resourceDataSyncResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// SyncName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SyncName is a force-new property.
+			},
 		},
 		"sync_source": {
 			// Property: SyncSource
@@ -313,7 +327,9 @@ func resourceDataSyncResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 64),
 			},
-			// SyncType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // SyncType is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ssmcontacts/contact_channel_resource_gen.go
+++ b/internal/aws/ssmcontacts/contact_channel_resource_gen.go
@@ -85,7 +85,9 @@ func contactChannelResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"EMAIL",
 				}),
 			},
-			// ChannelType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ChannelType is a force-new property.
+			},
 		},
 		"contact_id": {
 			// Property: ContactId
@@ -104,7 +106,9 @@ func contactChannelResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 2048),
 			},
-			// ContactId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ContactId is a force-new property.
+			},
 		},
 		"defer_activation": {
 			// Property: DeferActivation

--- a/internal/aws/ssmcontacts/contact_resource_gen.go
+++ b/internal/aws/ssmcontacts/contact_resource_gen.go
@@ -39,7 +39,9 @@ func contactResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// Alias is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Alias is a force-new property.
+			},
 		},
 		"arn": {
 			// Property: Arn
@@ -228,7 +230,7 @@ func contactResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				tfsdk.ListNestedAttributesOptions{},
 			),
 			Required: true,
-			// Plan is a write-only attribute.
+			// Plan is a write-only property.
 		},
 		"type": {
 			// Property: Type
@@ -254,7 +256,9 @@ func contactResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"ESCALATION",
 				}),
 			},
-			// Type is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Type is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/ssmincidents/response_plan_resource_gen.go
+++ b/internal/aws/ssmincidents/response_plan_resource_gen.go
@@ -421,7 +421,9 @@ func responsePlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 200),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/sso/assignment_resource_gen.go
+++ b/internal/aws/sso/assignment_resource_gen.go
@@ -39,7 +39,9 @@ func assignmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(10, 1224),
 			},
-			// InstanceArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InstanceArn is a force-new property.
+			},
 		},
 		"permission_set_arn": {
 			// Property: PermissionSetArn
@@ -57,7 +59,9 @@ func assignmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(10, 1224),
 			},
-			// PermissionSetArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PermissionSetArn is a force-new property.
+			},
 		},
 		"principal_id": {
 			// Property: PrincipalId
@@ -75,7 +79,9 @@ func assignmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 47),
 			},
-			// PrincipalId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PrincipalId is a force-new property.
+			},
 		},
 		"principal_type": {
 			// Property: PrincipalType
@@ -97,7 +103,9 @@ func assignmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"GROUP",
 				}),
 			},
-			// PrincipalType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // PrincipalType is a force-new property.
+			},
 		},
 		"target_id": {
 			// Property: TargetId
@@ -110,7 +118,9 @@ func assignmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The account id to be provisioned.",
 			Type:        types.StringType,
 			Required:    true,
-			// TargetId is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TargetId is a force-new property.
+			},
 		},
 		"target_type": {
 			// Property: TargetType
@@ -130,7 +140,9 @@ func assignmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"AWS_ACCOUNT",
 				}),
 			},
-			// TargetType is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TargetType is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sso/instance_access_control_attribute_configuration_resource_gen.go
+++ b/internal/aws/sso/instance_access_control_attribute_configuration_resource_gen.go
@@ -208,7 +208,9 @@ func instanceAccessControlAttributeConfigurationResourceType(ctx context.Context
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(10, 1224),
 			},
-			// InstanceArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InstanceArn is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/sso/permission_set_resource_gen.go
+++ b/internal/aws/sso/permission_set_resource_gen.go
@@ -67,7 +67,9 @@ func permissionSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(10, 1224),
 			},
-			// InstanceArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // InstanceArn is a force-new property.
+			},
 		},
 		"managed_policies": {
 			// Property: ManagedPolicies
@@ -105,7 +107,9 @@ func permissionSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 32),
 			},
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"permission_set_arn": {
 			// Property: PermissionSetArn

--- a/internal/aws/stepfunctions/state_machine_resource_gen.go
+++ b/internal/aws/stepfunctions/state_machine_resource_gen.go
@@ -248,7 +248,9 @@ func stateMachineResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 80),
 			},
-			// StateMachineName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // StateMachineName is a force-new property.
+			},
 		},
 		"state_machine_type": {
 			// Property: StateMachineType

--- a/internal/aws/timestream/database_resource_gen.go
+++ b/internal/aws/timestream/database_resource_gen.go
@@ -44,7 +44,9 @@ func databaseResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// DatabaseName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DatabaseName is a force-new property.
+			},
 		},
 		"kms_key_id": {
 			// Property: KmsKeyId

--- a/internal/aws/timestream/table_resource_gen.go
+++ b/internal/aws/timestream/table_resource_gen.go
@@ -43,7 +43,9 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Description: "The name for the database which the table to be created belongs to.",
 			Type:        types.StringType,
 			Required:    true,
-			// DatabaseName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // DatabaseName is a force-new property.
+			},
 		},
 		"name": {
 			// Property: Name
@@ -105,7 +107,9 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// TableName is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // TableName is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/wafv2/ip_set_resource_gen.go
+++ b/internal/aws/wafv2/ip_set_resource_gen.go
@@ -108,7 +108,9 @@ func iPSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"scope": {
 			// Property: Scope
@@ -130,7 +132,9 @@ func iPSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"REGIONAL",
 				}),
 			},
-			// Scope is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Scope is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/wafv2/logging_configuration_resource_gen.go
+++ b/internal/aws/wafv2/logging_configuration_resource_gen.go
@@ -450,7 +450,9 @@ func loggingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			Description: "The Amazon Resource Name (ARN) of the web ACL that you want to associate with LogDestinationConfigs.",
 			Type:        types.StringType,
 			Required:    true,
-			// ResourceArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceArn is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/wafv2/regex_pattern_set_resource_gen.go
+++ b/internal/aws/wafv2/regex_pattern_set_resource_gen.go
@@ -70,7 +70,9 @@ func regexPatternSetResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Type:        types.StringType,
 			Optional:    true,
 			Computed:    true,
-			// Name is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Name is a force-new property.
+			},
 		},
 		"regular_expression_list": {
 			// Property: RegularExpressionList
@@ -104,7 +106,9 @@ func regexPatternSetResourceType(ctx context.Context) (tfsdk.ResourceType, error
 					"REGIONAL",
 				}),
 			},
-			// Scope is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Scope is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags

--- a/internal/aws/wafv2/web_acl_association_resource_gen.go
+++ b/internal/aws/wafv2/web_acl_association_resource_gen.go
@@ -36,7 +36,9 @@ func webACLAssociationResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// ResourceArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ResourceArn is a force-new property.
+			},
 		},
 		"web_acl_arn": {
 			// Property: WebACLArn
@@ -51,7 +53,9 @@ func webACLAssociationResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(20, 2048),
 			},
-			// WebACLArn is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // WebACLArn is a force-new property.
+			},
 		},
 	}
 

--- a/internal/aws/workspaces/connection_alias_resource_gen.go
+++ b/internal/aws/workspaces/connection_alias_resource_gen.go
@@ -144,7 +144,9 @@ func connectionAliasResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			Validators: []tfsdk.AttributeValidator{
 				validate.StringLenBetween(1, 255),
 			},
-			// ConnectionString is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // ConnectionString is a force-new property.
+			},
 		},
 		"tags": {
 			// Property: Tags
@@ -186,7 +188,9 @@ func connectionAliasResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			),
 			Optional: true,
 			Computed: true,
-			// Tags is a force-new attribute.
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				tfsdk.RequiresReplace(), // Tags is a force-new property.
+			},
 		},
 	}
 

--- a/internal/provider/generators/shared/codegen/emitter.go
+++ b/internal/provider/generators/shared/codegen/emitter.go
@@ -582,11 +582,13 @@ func (e Emitter) emitAttribute(attributeNameMap map[string]string, path []string
 	}
 
 	if createOnly {
-		e.printf("// %s is a force-new attribute.\n", name)
+		e.printf("PlanModifiers:[]tfsdk.AttributePlanModifier{\n")
+		e.printf("tfsdk.RequiresReplace(),// %s is a force-new property.\n", name)
+		e.printf("},\n")
 	}
 
 	if writeOnly {
-		e.printf("// %s is a write-only attribute.\n", name)
+		e.printf("// %s is a write-only property.\n", name)
 	}
 
 	if !createOnly && !readOnly {


### PR DESCRIPTION
Closes #44.

```console
% terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/aws in /Users/ewbankkit/go/bin
│  - hashicorp/awscc in /Users/ewbankkit/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
awscc_ec2_dhcp_options.test: Refreshing state... [id=dopt-05a7fb7a31572314d]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # awscc_ec2_dhcp_options.test must be replaced
-/+ resource "awscc_ec2_dhcp_options" "test" {
      ~ dhcp_options_id      = "dopt-05a7fb7a31572314d" -> (known after apply)
      ~ domain_name          = "service.tf" -> "service2.tf" # forces replacement
      ~ id                   = "dopt-05a7fb7a31572314d" -> (known after apply)
        tags                 = [
            {          },
          # (1 unchanged element hidden)
        ]
        # (4 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

awscc_ec2_dhcp_options.test: Destroying... [id=dopt-05a7fb7a31572314d]
awscc_ec2_dhcp_options.test: Destruction complete after 7s
awscc_ec2_dhcp_options.test: Creating...
awscc_ec2_dhcp_options.test: Creation complete after 8s [id=dopt-0624c6a74f169a44b]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```