### PR TITLE
Encapsulating `diag.Diagnostic`s

### DIFF
--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -1,4 +1,4 @@
-package diags
+package diag
 
 import (
 	"fmt"

--- a/internal/diags/diags.go
+++ b/internal/diags/diags.go
@@ -1,18 +1,52 @@
 package diags
 
 import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 const (
-	summaryInvalidValue = "Invalid value"
+	summaryInvalidValue     = "Invalid value"
+	summaryInvalidValueType = "Invalid value type"
 )
 
-func NewInvalidValueError(path *tftypes.AttributePath, detail string) diag.Diagnostic {
+func NewInvalidValueAttributeError(path *tftypes.AttributePath, detail string) diag.Diagnostic {
 	return diag.NewAttributeErrorDiagnostic(
 		path,
 		summaryInvalidValue,
 		detail,
+	)
+}
+
+func NewIncorrectValueTypeAttributeError(path *tftypes.AttributePath, v attr.Value) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidValueType,
+		fmt.Sprintf("received incorrect value type (%T)", v),
+	)
+}
+
+func NewIncorrectValueTypeResourceConfigError(t tftypes.Type) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		summaryInvalidValueType,
+		fmt.Sprintf("received incorrect value type (%s)", t),
+	)
+}
+
+func NewUnableToConvertValueTypeAttributeError(path *tftypes.AttributePath, err error) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidValueType,
+		fmt.Sprintf("unable to convert value type:\n\n%s", err),
+	)
+}
+
+func NewUnableToConvertValueTypeResourceConfigError(err error) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		summaryInvalidValueType,
+		fmt.Sprintf("unable to convert value type:\n\n%s", err),
 	)
 }

--- a/internal/diags/diags.go
+++ b/internal/diags/diags.go
@@ -1,0 +1,18 @@
+package diags
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+const (
+	summaryInvalidValue = "Invalid value"
+)
+
+func NewInvalidValueError(path *tftypes.AttributePath, detail string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidValue,
+		detail,
+	)
+}

--- a/internal/diags/diags.go
+++ b/internal/diags/diags.go
@@ -12,6 +12,7 @@ const (
 	summaryInvalidValue     = "Invalid value"
 	summaryInvalidValueType = "Invalid value type"
 	summaryNoTerraformValue = "No Terraform value"
+	summaryInvalidLength    = "Invalid length"
 )
 
 func NewInvalidValueAttributeError(path *tftypes.AttributePath, detail string) diag.Diagnostic {
@@ -57,5 +58,29 @@ func NewUnableToObtainValueAttributeError(path *tftypes.AttributePath, err error
 		path,
 		summaryNoTerraformValue,
 		fmt.Sprintf("unable to obtain Terraform value:\n\n%s", err),
+	)
+}
+
+func NewInvalidLengthBetweenAttributeError(path *tftypes.AttributePath, min, max, len int) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidLength,
+		fmt.Sprintf("expected length to be in the range [%d, %d], got %d", min, max, len),
+	)
+}
+
+func NewInvalidLengthAtLeastAttributeError(path *tftypes.AttributePath, min, len int) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidLength,
+		fmt.Sprintf("expected length to be at least %d, got %d", min, len),
+	)
+}
+
+func NewInvalidLengthAtMostAttributeError(path *tftypes.AttributePath, max, len int) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidLength,
+		fmt.Sprintf("expected length to be at most %d, got %d", max, len),
 	)
 }

--- a/internal/diags/diags.go
+++ b/internal/diags/diags.go
@@ -11,6 +11,7 @@ import (
 const (
 	summaryInvalidValue     = "Invalid value"
 	summaryInvalidValueType = "Invalid value type"
+	summaryNoTerraformValue = "No Terraform value"
 )
 
 func NewInvalidValueAttributeError(path *tftypes.AttributePath, detail string) diag.Diagnostic {
@@ -48,5 +49,13 @@ func NewUnableToConvertValueTypeResourceConfigError(err error) diag.Diagnostic {
 	return diag.NewErrorDiagnostic(
 		summaryInvalidValueType,
 		fmt.Sprintf("unable to convert value type:\n\n%s", err),
+	)
+}
+
+func NewUnableToObtainValueAttributeError(path *tftypes.AttributePath, err error) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		summaryNoTerraformValue,
+		fmt.Sprintf("unable to obtain Terraform value:\n\n%s", err),
 	)
 }

--- a/internal/diags/diags.go
+++ b/internal/diags/diags.go
@@ -84,3 +84,11 @@ func NewInvalidLengthAtMostAttributeError(path *tftypes.AttributePath, max, len 
 		fmt.Sprintf("expected length to be at most %d, got %d", max, len),
 	)
 }
+
+func NewInvalidFormatAttributeError(path *tftypes.AttributePath, detail string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		path,
+		summaryInvalidLength,
+		detail,
+	)
+}

--- a/internal/generic/default_value.go
+++ b/internal/generic/default_value.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 type defaultValueAttributePlanModifier struct {
@@ -32,7 +32,7 @@ func (attributePlanModifier defaultValueAttributePlanModifier) Modify(ctx contex
 	// If the planned value is Null and there is a current value and the current value is the default
 	// then return the current value, else return the planned value.
 	if v, err := request.AttributePlan.ToTerraformValue(ctx); err != nil {
-		response.Diagnostics.Append(diags.NewUnableToObtainValueAttributeError(
+		response.Diagnostics.Append(diag.NewUnableToObtainValueAttributeError(
 			request.AttributePath,
 			err,
 		))

--- a/internal/generic/default_value.go
+++ b/internal/generic/default_value.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
 )
 
 type defaultValueAttributePlanModifier struct {
@@ -31,11 +32,10 @@ func (attributePlanModifier defaultValueAttributePlanModifier) Modify(ctx contex
 	// If the planned value is Null and there is a current value and the current value is the default
 	// then return the current value, else return the planned value.
 	if v, err := request.AttributePlan.ToTerraformValue(ctx); err != nil {
-		response.AddAttributeError(
+		response.Diagnostics.Append(diags.NewUnableToObtainValueAttributeError(
 			request.AttributePath,
-			"No Terraform value",
-			"unable to obtain Terraform value:\n\n"+err.Error(),
-		)
+			err,
+		))
 
 		return
 	} else if v == nil && request.AttributeState != nil && request.AttributeState.Equal(attributePlanModifier.val) {

--- a/internal/validate/arn.go
+++ b/internal/validate/arn.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 // arnValidator validates that a string is an Amazon Resource Name (ARN).
@@ -33,7 +33,7 @@ func (validator arnValidator) Validate(ctx context.Context, request tfsdk.Valida
 	}
 
 	if !arn.IsARN(s) {
-		response.Diagnostics.Append(diags.NewInvalidFormatAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidFormatAttributeError(
 			request.AttributePath,
 			"expected value to be an ARN",
 		))
@@ -62,7 +62,7 @@ func (validator iamPolicyARNValidator) MarkdownDescription(ctx context.Context) 
 }
 
 func (validator iamPolicyARNValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	errDiag := diags.NewInvalidFormatAttributeError(
+	errDiag := ccdiag.NewInvalidFormatAttributeError(
 		request.AttributePath,
 		"expected an IAM policy ARN",
 	)

--- a/internal/validate/array.go
+++ b/internal/validate/array.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
 )
 
 // arrayLenBetweenValidator validates that an array (List/Set) Attribute's length is in a range.
@@ -190,11 +191,10 @@ func validateArray(request tfsdk.ValidateAttributeRequest, response *tfsdk.Valid
 		elems = v.Elems
 
 	default:
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", v),
-		)
+			v,
+		))
 
 		return elems, elemKeyer, false
 	}

--- a/internal/validate/array.go
+++ b/internal/validate/array.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 // arrayLenBetweenValidator validates that an array (List/Set) Attribute's length is in a range.
@@ -37,7 +37,7 @@ func (validator arrayLenBetweenValidator) Validate(ctx context.Context, request 
 	}
 
 	if l := len(elems); l < validator.minItems || l > validator.maxItems {
-		response.Diagnostics.Append(diags.NewInvalidLengthBetweenAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidLengthBetweenAttributeError(
 			request.AttributePath, validator.minItems, validator.maxItems, l,
 		))
 
@@ -82,7 +82,7 @@ func (validator arrayLenAtLeastValidator) Validate(ctx context.Context, request 
 	}
 
 	if l := len(elems); l < validator.minItems {
-		response.Diagnostics.Append(diags.NewInvalidLengthAtLeastAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidLengthAtLeastAttributeError(
 			request.AttributePath, validator.minItems, l,
 		))
 
@@ -156,7 +156,7 @@ func listKeyer(ctx context.Context, path *tftypes.AttributePath, i int, v attr.V
 func setKeyer(ctx context.Context, path *tftypes.AttributePath, i int, v attr.Value) (*tftypes.AttributePath, diag.Diagnostic) {
 	val, err := v.ToTerraformValue(ctx)
 	if err != nil {
-		return nil, diags.NewUnableToObtainValueAttributeError(path, err)
+		return nil, ccdiag.NewUnableToObtainValueAttributeError(path, err)
 	}
 
 	return path.WithElementKeyValue(tftypes.NewValue(v.Type(ctx).TerraformType(ctx), val)), nil
@@ -183,7 +183,7 @@ func validateArray(request tfsdk.ValidateAttributeRequest, response *tfsdk.Valid
 		elems = v.Elems
 
 	default:
-		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
+		response.Diagnostics.Append(ccdiag.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			v,
 		))

--- a/internal/validate/array.go
+++ b/internal/validate/array.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // arrayLenBetweenValidator validates that an array (List/Set) Attribute's length is in a range.
@@ -27,33 +30,12 @@ func (validator arrayLenBetweenValidator) MarkdownDescription(ctx context.Contex
 
 // Validate performs the validation.
 func (validator arrayLenBetweenValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	var l int
-	switch v := request.AttributeConfig.(type) {
-	case types.List:
-		if v.Null || v.Unknown {
-			return
-		}
-
-		l = len(v.Elems)
-
-	case types.Set:
-		if v.Null || v.Unknown {
-			return
-		}
-
-		l = len(v.Elems)
-
-	default:
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", v),
-		)
-
+	elems, _, ok := validateArray(request, response)
+	if !ok {
 		return
 	}
 
-	if l < validator.minItems || l > validator.maxItems {
+	if l := len(elems); l < validator.minItems || l > validator.maxItems {
 		response.Diagnostics.AddAttributeError(
 			request.AttributePath,
 			"Invalid length",
@@ -95,33 +77,12 @@ func (validator arrayLenAtLeastValidator) MarkdownDescription(ctx context.Contex
 
 // Validate performs the validation.
 func (validator arrayLenAtLeastValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	var l int
-	switch v := request.AttributeConfig.(type) {
-	case types.List:
-		if v.Null || v.Unknown {
-			return
-		}
-
-		l = len(v.Elems)
-
-	case types.Set:
-		if v.Null || v.Unknown {
-			return
-		}
-
-		l = len(v.Elems)
-
-	default:
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", v),
-		)
-
+	elems, _, ok := validateArray(request, response)
+	if !ok {
 		return
 	}
 
-	if l < validator.minItems {
+	if l := len(elems); l < validator.minItems {
 		response.Diagnostics.AddAttributeError(
 			request.AttributePath,
 			"Invalid length",
@@ -162,33 +123,12 @@ func (validator arrayLenAtMostValidator) MarkdownDescription(ctx context.Context
 
 // Validate performs the validation.
 func (validator arrayLenAtMostValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	var l int
-	switch v := request.AttributeConfig.(type) {
-	case types.List:
-		if v.Null || v.Unknown {
-			return
-		}
-
-		l = len(v.Elems)
-
-	case types.Set:
-		if v.Null || v.Unknown {
-			return
-		}
-
-		l = len(v.Elems)
-
-	default:
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", v),
-		)
-
+	elems, _, ok := validateArray(request, response)
+	if !ok {
 		return
 	}
 
-	if l > validator.maxItems {
+	if l := len(elems); l > validator.maxItems {
 		response.Diagnostics.AddAttributeError(
 			request.AttributePath,
 			"Invalid length",
@@ -208,4 +148,56 @@ func ArrayLenAtMost(maxItems int) tfsdk.AttributeValidator {
 	return arrayLenAtMostValidator{
 		maxItems: maxItems,
 	}
+}
+
+type arrayKeyer func(context.Context, *tftypes.AttributePath, int, attr.Value) (*tftypes.AttributePath, diag.Diagnostic)
+
+func listKeyer(ctx context.Context, path *tftypes.AttributePath, i int, v attr.Value) (*tftypes.AttributePath, diag.Diagnostic) {
+	return path.WithElementKeyInt(i), nil
+}
+
+func setKeyer(ctx context.Context, path *tftypes.AttributePath, i int, v attr.Value) (*tftypes.AttributePath, diag.Diagnostic) {
+	val, err := v.ToTerraformValue(ctx)
+	if err != nil {
+		return nil, diag.NewAttributeErrorDiagnostic(
+			path,
+			"No Terraform value",
+			"unable to obtain Terraform value:\n\n"+err.Error(),
+		)
+	}
+
+	return path.WithElementKeyValue(tftypes.NewValue(v.Type(ctx).TerraformType(ctx), val)), nil
+}
+
+func validateArray(request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) ([]attr.Value, arrayKeyer, bool) {
+	var elemKeyer arrayKeyer
+	var elems []attr.Value
+	switch v := request.AttributeConfig.(type) {
+	case types.List:
+		if v.Null || v.Unknown {
+			return elems, elemKeyer, false
+		}
+
+		elemKeyer = listKeyer
+		elems = v.Elems
+
+	case types.Set:
+		if v.Null || v.Unknown {
+			return elems, elemKeyer, false
+		}
+
+		elemKeyer = setKeyer
+		elems = v.Elems
+
+	default:
+		response.Diagnostics.AddAttributeError(
+			request.AttributePath,
+			"Invalid value type",
+			fmt.Sprintf("received incorrect value type (%T)", v),
+		)
+
+		return elems, elemKeyer, false
+	}
+
+	return elems, elemKeyer, true
 }

--- a/internal/validate/array.go
+++ b/internal/validate/array.go
@@ -160,11 +160,7 @@ func listKeyer(ctx context.Context, path *tftypes.AttributePath, i int, v attr.V
 func setKeyer(ctx context.Context, path *tftypes.AttributePath, i int, v attr.Value) (*tftypes.AttributePath, diag.Diagnostic) {
 	val, err := v.ToTerraformValue(ctx)
 	if err != nil {
-		return nil, diag.NewAttributeErrorDiagnostic(
-			path,
-			"No Terraform value",
-			"unable to obtain Terraform value:\n\n"+err.Error(),
-		)
+		return nil, diags.NewUnableToObtainValueAttributeError(path, err)
 	}
 
 	return path.WithElementKeyValue(tftypes.NewValue(v.Type(ctx).TerraformType(ctx), val)), nil

--- a/internal/validate/array.go
+++ b/internal/validate/array.go
@@ -37,11 +37,9 @@ func (validator arrayLenBetweenValidator) Validate(ctx context.Context, request 
 	}
 
 	if l := len(elems); l < validator.minItems || l > validator.maxItems {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid length",
-			fmt.Sprintf("expected length to be in the range [%d, %d], got %d", validator.minItems, validator.maxItems, l),
-		)
+		response.Diagnostics.Append(diags.NewInvalidLengthBetweenAttributeError(
+			request.AttributePath, validator.minItems, validator.maxItems, l,
+		))
 
 		return
 	}
@@ -84,11 +82,9 @@ func (validator arrayLenAtLeastValidator) Validate(ctx context.Context, request 
 	}
 
 	if l := len(elems); l < validator.minItems {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid length",
-			fmt.Sprintf("expected length to be at least %d, got %d", validator.minItems, l),
-		)
+		response.Diagnostics.Append(diags.NewInvalidLengthAtLeastAttributeError(
+			request.AttributePath, validator.minItems, l,
+		))
 
 		return
 	}

--- a/internal/validate/float.go
+++ b/internal/validate/float.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
 )
 
 // floatBetweenValidator validates that an float Attribute's value is in a range.
@@ -46,11 +47,10 @@ func (validator floatBetweenValidator) Validate(ctx context.Context, request tfs
 	f, _ := n.Value.Float64()
 
 	if f < validator.min || f > validator.max {
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewInvalidValueError(
 			request.AttributePath,
-			"Invalid value",
 			fmt.Sprintf("expected value to be in the range [%f, %f], got %f", validator.min, validator.max, f),
-		)
+		))
 
 		return
 	}
@@ -106,11 +106,10 @@ func (validator floatAtLeastValidator) Validate(ctx context.Context, request tfs
 	f, _ := n.Value.Float64()
 
 	if f < validator.min {
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewInvalidValueError(
 			request.AttributePath,
-			"Invalid value",
 			fmt.Sprintf("expected value to be at least %f, got %f", validator.min, f),
-		)
+		))
 
 		return
 	}

--- a/internal/validate/float.go
+++ b/internal/validate/float.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
@@ -28,23 +29,10 @@ func (validator floatBetweenValidator) MarkdownDescription(ctx context.Context) 
 
 // Validate performs the validation.
 func (validator floatBetweenValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	n, ok := request.AttributeConfig.(types.Number)
-
+	f, ok := validateFloat(request, response)
 	if !ok {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", request.AttributeConfig),
-		)
-
 		return
 	}
-
-	if n.Unknown || n.Null {
-		return
-	}
-
-	f, _ := n.Value.Float64()
 
 	if f < validator.min || f > validator.max {
 		response.Diagnostics.Append(diags.NewInvalidValueError(
@@ -87,23 +75,10 @@ func (validator floatAtLeastValidator) MarkdownDescription(ctx context.Context) 
 
 // Validate performs the validation.
 func (validator floatAtLeastValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	n, ok := request.AttributeConfig.(types.Number)
-
+	f, ok := validateFloat(request, response)
 	if !ok {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", request.AttributeConfig),
-		)
-
 		return
 	}
-
-	if n.Unknown || n.Null {
-		return
-	}
-
-	f, _ := n.Value.Float64()
 
 	if f < validator.min {
 		response.Diagnostics.Append(diags.NewInvalidValueError(
@@ -141,30 +116,16 @@ func (validator floatAtMostValidator) MarkdownDescription(ctx context.Context) s
 
 // Validate performs the validation.
 func (validator floatAtMostValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	n, ok := request.AttributeConfig.(types.Number)
-
+	f, ok := validateFloat(request, response)
 	if !ok {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", request.AttributeConfig),
-		)
-
 		return
 	}
-
-	if n.Unknown || n.Null {
-		return
-	}
-
-	f, _ := n.Value.Float64()
 
 	if f > validator.max {
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewInvalidValueError(
 			request.AttributePath,
-			"Invalid value",
 			fmt.Sprintf("expected value to be at most %f, got %f", validator.max, f),
-		)
+		))
 
 		return
 	}
@@ -175,4 +136,25 @@ func FloatAtMost(max float64) tfsdk.AttributeValidator {
 	return floatAtMostValidator{
 		max: max,
 	}
+}
+
+func validateFloat(request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) (float64, bool) {
+	n, ok := request.AttributeConfig.(types.Number)
+
+	if !ok {
+		response.Diagnostics.Append(diag.NewIncorrectValueTypeAttributeError(
+			request.AttributePath,
+			request.AttributeConfig,
+		))
+
+		return 0, false
+	}
+
+	if n.Unknown || n.Null {
+		return 0, false
+	}
+
+	f, _ := n.Value.Float64()
+
+	return f, true
 }

--- a/internal/validate/float.go
+++ b/internal/validate/float.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
@@ -35,7 +34,7 @@ func (validator floatBetweenValidator) Validate(ctx context.Context, request tfs
 	}
 
 	if f < validator.min || f > validator.max {
-		response.Diagnostics.Append(diags.NewInvalidValueError(
+		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be in the range [%f, %f], got %f", validator.min, validator.max, f),
 		))
@@ -81,7 +80,7 @@ func (validator floatAtLeastValidator) Validate(ctx context.Context, request tfs
 	}
 
 	if f < validator.min {
-		response.Diagnostics.Append(diags.NewInvalidValueError(
+		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be at least %f, got %f", validator.min, f),
 		))
@@ -142,7 +141,7 @@ func validateFloat(request tfsdk.ValidateAttributeRequest, response *tfsdk.Valid
 	n, ok := request.AttributeConfig.(types.Number)
 
 	if !ok {
-		response.Diagnostics.Append(diag.NewIncorrectValueTypeAttributeError(
+		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			request.AttributeConfig,
 		))

--- a/internal/validate/float.go
+++ b/internal/validate/float.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 // floatBetweenValidator validates that an float Attribute's value is in a range.
@@ -34,7 +34,7 @@ func (validator floatBetweenValidator) Validate(ctx context.Context, request tfs
 	}
 
 	if f < validator.min || f > validator.max {
-		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
+		response.Diagnostics.Append(diag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be in the range [%f, %f], got %f", validator.min, validator.max, f),
 		))
@@ -80,7 +80,7 @@ func (validator floatAtLeastValidator) Validate(ctx context.Context, request tfs
 	}
 
 	if f < validator.min {
-		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
+		response.Diagnostics.Append(diag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be at least %f, got %f", validator.min, f),
 		))
@@ -141,7 +141,7 @@ func validateFloat(request tfsdk.ValidateAttributeRequest, response *tfsdk.Valid
 	n, ok := request.AttributeConfig.(types.Number)
 
 	if !ok {
-		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
+		response.Diagnostics.Append(diag.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			request.AttributeConfig,
 		))

--- a/internal/validate/float.go
+++ b/internal/validate/float.go
@@ -121,7 +121,7 @@ func (validator floatAtMostValidator) Validate(ctx context.Context, request tfsd
 	}
 
 	if f > validator.max {
-		response.Diagnostics.Append(diags.NewInvalidValueError(
+		response.Diagnostics.Append(diag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be at most %f, got %f", validator.max, f),
 		))

--- a/internal/validate/for_each.go
+++ b/internal/validate/for_each.go
@@ -4,11 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // arrayForEachValidator validates that a List Attribute's contents all satisfy the included validator.
@@ -30,32 +26,8 @@ func (validator arrayForEachValidator) MarkdownDescription(ctx context.Context) 
 
 // Validate performs the validation.
 func (validator arrayForEachValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	var elemKeyer keyer
-	var elems []attr.Value
-	switch v := request.AttributeConfig.(type) {
-	case types.List:
-		if v.Null || v.Unknown {
-			return
-		}
-
-		elemKeyer = listKeyer
-		elems = v.Elems
-
-	case types.Set:
-		if v.Null || v.Unknown {
-			return
-		}
-
-		elemKeyer = setKeyer
-		elems = v.Elems
-
-	default:
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", v),
-		)
-
+	elems, elemKeyer, ok := validateArray(request, response)
+	if !ok {
 		return
 	}
 
@@ -75,25 +47,6 @@ func (validator arrayForEachValidator) Validate(ctx context.Context, request tfs
 		validator.validator.Validate(ctx, elemRequest, &elemResponse)
 		response.Diagnostics.Append(elemResponse.Diagnostics...)
 	}
-}
-
-type keyer func(context.Context, *tftypes.AttributePath, int, attr.Value) (*tftypes.AttributePath, diag.Diagnostic)
-
-func listKeyer(ctx context.Context, path *tftypes.AttributePath, i int, v attr.Value) (*tftypes.AttributePath, diag.Diagnostic) {
-	return path.WithElementKeyInt(i), nil
-}
-
-func setKeyer(ctx context.Context, path *tftypes.AttributePath, i int, v attr.Value) (*tftypes.AttributePath, diag.Diagnostic) {
-	val, err := v.ToTerraformValue(ctx)
-	if err != nil {
-		return nil, diag.NewAttributeErrorDiagnostic(
-			path,
-			"No Terraform value",
-			"unable to obtain Terraform value:\n\n"+err.Error(),
-		)
-	}
-
-	return path.WithElementKeyValue(tftypes.NewValue(v.Type(ctx).TerraformType(ctx), val)), nil
 }
 
 // ArrayForEach returns a new array for each validator.

--- a/internal/validate/for_each_test.go
+++ b/internal/validate/for_each_test.go
@@ -69,10 +69,10 @@ func TestArrayForEachValidator(t *testing.T) {
 			}),
 			f:         types.ListType{ElemType: types.StringType}.ValueFromTerraform,
 			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
-			expectedDiag: diag.NewAttributeErrorDiagnostic(
+			expectedDiag: newStringNotInSliceError(
 				rootPath.WithElementKeyInt(3),
-				"Invalid value",
-				"expected value to be one of [alpha beta gamma], got delta",
+				[]string{"alpha", "beta", "gamma"},
+				"delta",
 			),
 		},
 	}

--- a/internal/validate/for_each_test.go
+++ b/internal/validate/for_each_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
 )
 
 func TestArrayForEachValidator(t *testing.T) {
@@ -29,10 +30,9 @@ func TestArrayForEachValidator(t *testing.T) {
 			val:       tftypes.NewValue(tftypes.Bool, true),
 			f:         types.BoolType.ValueFromTerraform,
 			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
-			expectedDiag: diag.NewAttributeErrorDiagnostic(
+			expectedDiag: diags.NewIncorrectValueTypeAttributeError(
 				rootPath,
-				"Invalid value type",
-				"received incorrect value type (types.Bool)",
+				types.Bool{},
 			),
 		},
 

--- a/internal/validate/for_each_test.go
+++ b/internal/validate/for_each_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 func TestArrayForEachValidator(t *testing.T) {
@@ -30,7 +30,7 @@ func TestArrayForEachValidator(t *testing.T) {
 			val:       tftypes.NewValue(tftypes.Bool, true),
 			f:         types.BoolType.ValueFromTerraform,
 			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
-			expectedDiag: diags.NewIncorrectValueTypeAttributeError(
+			expectedDiag: ccdiag.NewIncorrectValueTypeAttributeError(
 				rootPath,
 				types.Bool{},
 			),

--- a/internal/validate/for_each_test.go
+++ b/internal/validate/for_each_test.go
@@ -75,6 +75,64 @@ func TestArrayForEachValidator(t *testing.T) {
 				"delta",
 			),
 		},
+		"list of string with unknown element": {
+			val: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "alpha"),
+				tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				tftypes.NewValue(tftypes.String, "gamma"),
+			}),
+			f:         types.ListType{ElemType: types.StringType}.ValueFromTerraform,
+			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
+		},
+
+		"unknown set": {
+			val:       tftypes.NewValue(tftypes.Set{ElementType: tftypes.Number}, tftypes.UnknownValue),
+			f:         types.SetType{ElemType: types.NumberType}.ValueFromTerraform,
+			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
+		},
+		"null set": {
+			val:       tftypes.NewValue(tftypes.Set{ElementType: tftypes.Number}, nil),
+			f:         types.SetType{ElemType: types.NumberType}.ValueFromTerraform,
+			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
+		},
+		"empty set": {
+			val:       tftypes.NewValue(tftypes.Set{ElementType: tftypes.Number}, []tftypes.Value{}),
+			f:         types.SetType{ElemType: types.NumberType}.ValueFromTerraform,
+			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
+		},
+		"valid set of string": {
+			val: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "alpha"),
+				tftypes.NewValue(tftypes.String, "beta"),
+				tftypes.NewValue(tftypes.String, "gamma"),
+			}),
+			f:         types.SetType{ElemType: types.StringType}.ValueFromTerraform,
+			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
+		},
+		"invalid set of string": {
+			val: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "alpha"),
+				tftypes.NewValue(tftypes.String, "beta"),
+				tftypes.NewValue(tftypes.String, "gamma"),
+				tftypes.NewValue(tftypes.String, "delta"),
+			}),
+			f:         types.SetType{ElemType: types.StringType}.ValueFromTerraform,
+			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
+			expectedDiag: newStringNotInSliceError(
+				rootPath.WithElementKeyValue(tftypes.NewValue(tftypes.String, "delta")),
+				[]string{"alpha", "beta", "gamma"},
+				"delta",
+			),
+		},
+		"set of string with unknown element": {
+			val: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "alpha"),
+				tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				tftypes.NewValue(tftypes.String, "gamma"),
+			}),
+			f:         types.SetType{ElemType: types.StringType}.ValueFromTerraform,
+			validator: StringInSlice([]string{"alpha", "beta", "gamma"}),
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/validate/int.go
+++ b/internal/validate/int.go
@@ -36,7 +36,7 @@ func (validator intBetweenValidator) Validate(ctx context.Context, request tfsdk
 	}
 
 	if i < int64(validator.min) || i > int64(validator.max) {
-		response.Diagnostics.Append(diags.NewInvalidValueError(
+		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be in the range [%d, %d], got %d", validator.min, validator.max, i),
 		))
@@ -82,7 +82,7 @@ func (validator intAtLeastValidator) Validate(ctx context.Context, request tfsdk
 	}
 
 	if i < int64(validator.min) {
-		response.Diagnostics.Append(diags.NewInvalidValueError(
+		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be at least %d, got %d", validator.min, i),
 		))
@@ -205,7 +205,7 @@ func (validator intInSliceValidator) Validate(ctx context.Context, request tfsdk
 }
 
 func newIntNotInSliceError(path *tftypes.AttributePath, valid []int, value int64) diag.Diagnostic {
-	return diags.NewInvalidValueError(
+	return diags.NewInvalidValueAttributeError(
 		path,
 		fmt.Sprintf("expected value to be one of %v, got %d", valid, value),
 	)
@@ -219,17 +219,16 @@ func IntInSlice(valid []int) tfsdk.AttributeValidator {
 }
 
 func newNotAnIntegerValueError(path *tftypes.AttributePath) diag.Diagnostic {
-	return diags.NewInvalidValueError(path, "Not an integer")
+	return diags.NewInvalidValueAttributeError(path, "Not an integer")
 }
 
 func validateInt(request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) (int64, bool) {
 	n, ok := request.AttributeConfig.(types.Number)
 
 	if !ok {
-		response.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", request.AttributeConfig),
+			request.AttributeConfig,
 		))
 
 		return 0, false

--- a/internal/validate/int.go
+++ b/internal/validate/int.go
@@ -117,43 +117,16 @@ func (validator intAtMostValidator) MarkdownDescription(ctx context.Context) str
 
 // Validate performs the validation.
 func (validator intAtMostValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
-	n, ok := request.AttributeConfig.(types.Number)
-
+	i, ok := validateInt(request, response)
 	if !ok {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", request.AttributeConfig),
-		)
-
 		return
 	}
 
-	if n.Unknown || n.Null {
-		return
-	}
-
-	val := n.Value
-
-	if !val.IsInt() {
-		response.Diagnostics.AddAttributeError(
+	if i > int64(validator.max) {
+		response.Diagnostics.Append(ccdiag.NewInvalidValueAttributeError(
 			request.AttributePath,
-			"Invalid value",
-			"Not an integer",
-		)
-
-		return
-	}
-
-	var i big.Int
-	_, _ = val.Int(&i)
-
-	if i := i.Int64(); i > int64(validator.max) {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid value",
 			fmt.Sprintf("expected value to be at most %d, got %d", validator.max, i),
-		)
+		))
 
 		return
 	}

--- a/internal/validate/int.go
+++ b/internal/validate/int.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 // intBetweenValidator validates that an integer Attribute's value is in a range.
@@ -36,7 +36,7 @@ func (validator intBetweenValidator) Validate(ctx context.Context, request tfsdk
 	}
 
 	if i < int64(validator.min) || i > int64(validator.max) {
-		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be in the range [%d, %d], got %d", validator.min, validator.max, i),
 		))
@@ -82,7 +82,7 @@ func (validator intAtLeastValidator) Validate(ctx context.Context, request tfsdk
 	}
 
 	if i < int64(validator.min) {
-		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be at least %d, got %d", validator.min, i),
 		))
@@ -205,7 +205,7 @@ func (validator intInSliceValidator) Validate(ctx context.Context, request tfsdk
 }
 
 func newIntNotInSliceError(path *tftypes.AttributePath, valid []int, value int64) diag.Diagnostic {
-	return diags.NewInvalidValueAttributeError(
+	return ccdiag.NewInvalidValueAttributeError(
 		path,
 		fmt.Sprintf("expected value to be one of %v, got %d", valid, value),
 	)
@@ -219,14 +219,14 @@ func IntInSlice(valid []int) tfsdk.AttributeValidator {
 }
 
 func newNotAnIntegerValueError(path *tftypes.AttributePath) diag.Diagnostic {
-	return diags.NewInvalidValueAttributeError(path, "Not an integer")
+	return ccdiag.NewInvalidValueAttributeError(path, "Not an integer")
 }
 
 func validateInt(request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) (int64, bool) {
 	n, ok := request.AttributeConfig.(types.Number)
 
 	if !ok {
-		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
+		response.Diagnostics.Append(ccdiag.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			request.AttributeConfig,
 		))

--- a/internal/validate/meta_test.go
+++ b/internal/validate/meta_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 func TestAllValidator(t *testing.T) {
@@ -56,7 +56,7 @@ func TestAllValidator(t *testing.T) {
 				StringLenAtMost(4),
 			},
 			expectedDiags: []diag.Diagnostic{
-				diags.NewInvalidLengthAtMostAttributeError(rootPath, 4, 5),
+				ccdiag.NewInvalidLengthAtMostAttributeError(rootPath, 4, 5),
 			},
 		},
 		"invalid string multiple matches": {
@@ -67,7 +67,7 @@ func TestAllValidator(t *testing.T) {
 				StringLenAtMost(4),
 			},
 			expectedDiags: []diag.Diagnostic{
-				diags.NewInvalidLengthAtMostAttributeError(rootPath, 4, 5),
+				ccdiag.NewInvalidLengthAtMostAttributeError(rootPath, 4, 5),
 				newStringNotInSliceError(
 					rootPath,
 					[]string{"alpha", "beta", "gamma"},

--- a/internal/validate/meta_test.go
+++ b/internal/validate/meta_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
 )
 
 func TestAllValidator(t *testing.T) {
@@ -55,11 +56,7 @@ func TestAllValidator(t *testing.T) {
 				StringLenAtMost(4),
 			},
 			expectedDiags: []diag.Diagnostic{
-				diag.NewAttributeErrorDiagnostic(
-					rootPath,
-					"Invalid length",
-					"expected length to be at most 4, got 5",
-				),
+				diags.NewInvalidLengthAtMostAttributeError(rootPath, 4, 5),
 			},
 		},
 		"invalid string multiple matches": {
@@ -70,11 +67,7 @@ func TestAllValidator(t *testing.T) {
 				StringLenAtMost(4),
 			},
 			expectedDiags: []diag.Diagnostic{
-				diag.NewAttributeErrorDiagnostic(
-					rootPath,
-					"Invalid length",
-					"expected length to be at most 4, got 5",
-				),
+				diags.NewInvalidLengthAtMostAttributeError(rootPath, 4, 5),
 				newStringNotInSliceError(
 					rootPath,
 					[]string{"alpha", "beta", "gamma"},

--- a/internal/validate/meta_test.go
+++ b/internal/validate/meta_test.go
@@ -75,11 +75,12 @@ func TestAllValidator(t *testing.T) {
 					"Invalid length",
 					"expected length to be at most 4, got 5",
 				),
-				diag.NewAttributeErrorDiagnostic(
+				newStringNotInSliceError(
 					rootPath,
-					"Invalid value",
-					"expected value to be one of [alpha beta gamma], got delta",
-				)},
+					[]string{"alpha", "beta", "gamma"},
+					"delta",
+				),
+			},
 		},
 	}
 

--- a/internal/validate/required.go
+++ b/internal/validate/required.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
 	ccdiags "github.com/hashicorp/terraform-provider-awscc/internal/diags"
 )
 
@@ -157,11 +158,10 @@ func (validator requiredAttributesValidator) Validate(ctx context.Context, reque
 	val, err := request.AttributeConfig.ToTerraformValue(ctx)
 
 	if err != nil {
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewUnableToObtainValueAttributeError(
 			request.AttributePath,
-			"No Terraform value",
-			"unable to obtain Terraform value:\n\n"+err.Error(),
-		)
+			err,
+		))
 
 		return
 	}

--- a/internal/validate/required.go
+++ b/internal/validate/required.go
@@ -8,8 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
-	ccdiags "github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 type RequiredAttributesFunc func(names []string) tfdiag.Diagnostics
@@ -147,7 +146,7 @@ func (validator requiredAttributesValidator) Validate(ctx context.Context, reque
 		}
 
 	default:
-		response.Diagnostics.Append(ccdiags.NewIncorrectValueTypeAttributeError(
+		response.Diagnostics.Append(ccdiag.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			v,
 		))
@@ -158,7 +157,7 @@ func (validator requiredAttributesValidator) Validate(ctx context.Context, reque
 	val, err := request.AttributeConfig.ToTerraformValue(ctx)
 
 	if err != nil {
-		response.Diagnostics.Append(diags.NewUnableToObtainValueAttributeError(
+		response.Diagnostics.Append(ccdiag.NewUnableToObtainValueAttributeError(
 			request.AttributePath,
 			err,
 		))
@@ -190,7 +189,7 @@ func (validator requiredAttributesValidator) Validate(ctx context.Context, reque
 			// Each array element must be an Object.
 			var vals map[string]tftypes.Value
 			if err := val.As(&vals); err != nil {
-				response.Diagnostics.Append(ccdiags.NewUnableToConvertValueTypeAttributeError(
+				response.Diagnostics.Append(ccdiag.NewUnableToConvertValueTypeAttributeError(
 					request.AttributePath.WithElementKeyInt(i),
 					err,
 				))
@@ -247,7 +246,7 @@ func (validator resourceConfigRequiredAttributesValidator) Validate(ctx context.
 	}
 
 	if typ := val.Type(); !typ.Is(tftypes.Object{}) {
-		response.Diagnostics.Append(ccdiags.NewIncorrectValueTypeResourceConfigError(typ))
+		response.Diagnostics.Append(ccdiag.NewIncorrectValueTypeResourceConfigError(typ))
 
 		return
 	}
@@ -255,7 +254,7 @@ func (validator resourceConfigRequiredAttributesValidator) Validate(ctx context.
 	var vals map[string]tftypes.Value
 
 	if err := val.As(&vals); err != nil {
-		response.Diagnostics.Append(ccdiags.NewUnableToConvertValueTypeResourceConfigError(err))
+		response.Diagnostics.Append(ccdiag.NewUnableToConvertValueTypeResourceConfigError(err))
 
 		return
 	}

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -189,7 +189,7 @@ func (validator stringInSliceValidator) Validate(ctx context.Context, request tf
 }
 
 func newStringNotInSliceError(path *tftypes.AttributePath, valid []string, value string) diag.Diagnostic {
-	return diags.NewInvalidValueError(
+	return diags.NewInvalidValueAttributeError(
 		path,
 		fmt.Sprintf("expected value to be one of %v, got %s", valid, value),
 	)
@@ -226,7 +226,7 @@ func (validator stringIsJsonObjectValidator) Validate(ctx context.Context, reque
 
 	// A JSON object starts with a '{'
 	if s[:1] != "{" {
-		response.Diagnostics.Append(diags.NewInvalidValueError(
+		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
 			request.AttributePath,
 			"expected value to be a valid JSON object",
 		))
@@ -237,7 +237,7 @@ func (validator stringIsJsonObjectValidator) Validate(ctx context.Context, reque
 	var i interface{}
 	err := json.Unmarshal([]byte(s), &i)
 	if err != nil {
-		response.Diagnostics.Append(diags.NewInvalidValueError(
+		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be valid JSON: %s", err),
 		))
@@ -253,10 +253,9 @@ func validateString(request tfsdk.ValidateAttributeRequest, response *tfsdk.Vali
 	s, ok := request.AttributeConfig.(types.String)
 
 	if !ok {
-		response.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", request.AttributeConfig),
+			request.AttributeConfig,
 		))
 
 		return "", false

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -37,11 +37,9 @@ func (validator stringLenBetweenValidator) Validate(ctx context.Context, request
 	}
 
 	if l := len(s); l < validator.minLength || l > validator.maxLength {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid length",
-			fmt.Sprintf("expected length to be in the range [%d, %d], got %d", validator.minLength, validator.maxLength, l),
-		)
+		response.Diagnostics.Append(diags.NewInvalidLengthBetweenAttributeError(
+			request.AttributePath, validator.minLength, validator.maxLength, l,
+		))
 
 		return
 	}
@@ -84,11 +82,9 @@ func (validator stringLenAtLeastValidator) Validate(ctx context.Context, request
 	}
 
 	if l := len(s); l < validator.minLength {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid length",
-			fmt.Sprintf("expected length to be at least %d, got %d", validator.minLength, l),
-		)
+		response.Diagnostics.Append(diags.NewInvalidLengthAtLeastAttributeError(
+			request.AttributePath, validator.minLength, l,
+		))
 
 		return
 	}
@@ -130,11 +126,9 @@ func (validator stringLenAtMostValidator) Validate(ctx context.Context, request 
 	}
 
 	if l := len(s); l > validator.maxLength {
-		response.Diagnostics.AddAttributeError(
-			request.AttributePath,
-			"Invalid length",
-			fmt.Sprintf("expected length to be at most %d, got %d", validator.maxLength, l),
-		)
+		response.Diagnostics.Append(diags.NewInvalidLengthAtMostAttributeError(
+			request.AttributePath, validator.maxLength, l,
+		))
 
 		return
 	}

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 // stringLenBetweenValidator validates that a string Attribute's length is in a range.
@@ -37,7 +37,7 @@ func (validator stringLenBetweenValidator) Validate(ctx context.Context, request
 	}
 
 	if l := len(s); l < validator.minLength || l > validator.maxLength {
-		response.Diagnostics.Append(diags.NewInvalidLengthBetweenAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidLengthBetweenAttributeError(
 			request.AttributePath, validator.minLength, validator.maxLength, l,
 		))
 
@@ -82,7 +82,7 @@ func (validator stringLenAtLeastValidator) Validate(ctx context.Context, request
 	}
 
 	if l := len(s); l < validator.minLength {
-		response.Diagnostics.Append(diags.NewInvalidLengthAtLeastAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidLengthAtLeastAttributeError(
 			request.AttributePath, validator.minLength, l,
 		))
 
@@ -126,7 +126,7 @@ func (validator stringLenAtMostValidator) Validate(ctx context.Context, request 
 	}
 
 	if l := len(s); l > validator.maxLength {
-		response.Diagnostics.Append(diags.NewInvalidLengthAtMostAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidLengthAtMostAttributeError(
 			request.AttributePath, validator.maxLength, l,
 		))
 
@@ -183,7 +183,7 @@ func (validator stringInSliceValidator) Validate(ctx context.Context, request tf
 }
 
 func newStringNotInSliceError(path *tftypes.AttributePath, valid []string, value string) diag.Diagnostic {
-	return diags.NewInvalidValueAttributeError(
+	return ccdiag.NewInvalidValueAttributeError(
 		path,
 		fmt.Sprintf("expected value to be one of %v, got %s", valid, value),
 	)
@@ -220,7 +220,7 @@ func (validator stringIsJsonObjectValidator) Validate(ctx context.Context, reque
 
 	// A JSON object starts with a '{'
 	if s[:1] != "{" {
-		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			"expected value to be a valid JSON object",
 		))
@@ -231,7 +231,7 @@ func (validator stringIsJsonObjectValidator) Validate(ctx context.Context, reque
 	var i interface{}
 	err := json.Unmarshal([]byte(s), &i)
 	if err != nil {
-		response.Diagnostics.Append(diags.NewInvalidValueAttributeError(
+		response.Diagnostics.Append(ccdiag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be valid JSON: %s", err),
 		))
@@ -247,7 +247,7 @@ func validateString(request tfsdk.ValidateAttributeRequest, response *tfsdk.Vali
 	s, ok := request.AttributeConfig.(types.String)
 
 	if !ok {
-		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
+		response.Diagnostics.Append(ccdiag.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			request.AttributeConfig,
 		))

--- a/internal/validate/time.go
+++ b/internal/validate/time.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
 )
 
 // isRFC3339TimeValidator validates that a string Attribute's length is a valid RFC33349Time.
@@ -29,11 +30,10 @@ func (validator isRFC3339TimeValidator) Validate(ctx context.Context, request tf
 	s, ok := request.AttributeConfig.(types.String)
 
 	if !ok {
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", request.AttributeConfig),
-		)
+			request.AttributeConfig,
+		))
 
 		return
 	}

--- a/internal/validate/time.go
+++ b/internal/validate/time.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 // isRFC3339TimeValidator validates that a string Attribute's length is a valid RFC33349Time.
@@ -30,7 +30,7 @@ func (validator isRFC3339TimeValidator) Validate(ctx context.Context, request tf
 	s, ok := request.AttributeConfig.(types.String)
 
 	if !ok {
-		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
+		response.Diagnostics.Append(diag.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			request.AttributeConfig,
 		))
@@ -43,7 +43,7 @@ func (validator isRFC3339TimeValidator) Validate(ctx context.Context, request tf
 	}
 
 	if _, err := time.Parse(time.RFC3339, s.Value); err != nil {
-		response.Diagnostics.Append(diags.NewInvalidFormatAttributeError(
+		response.Diagnostics.Append(diag.NewInvalidFormatAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be a valid RFC3339 date, got %s: %+v", s.Value, err),
 		))

--- a/internal/validate/time.go
+++ b/internal/validate/time.go
@@ -43,11 +43,10 @@ func (validator isRFC3339TimeValidator) Validate(ctx context.Context, request tf
 	}
 
 	if _, err := time.Parse(time.RFC3339, s.Value); err != nil {
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewInvalidFormatAttributeError(
 			request.AttributePath,
-			"Invalid format",
 			fmt.Sprintf("expected value to be a valid RFC3339 date, got %s: %+v", s.Value, err),
-		)
+		))
 
 		return
 	}

--- a/internal/validate/unique_items.go
+++ b/internal/validate/unique_items.go
@@ -2,11 +2,11 @@ package validate
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
 )
 
 // uniqueItemsValidator validates that an Attribute's list items have unique values.
@@ -29,11 +29,10 @@ func (v uniqueItemsValidator) Validate(ctx context.Context, request tfsdk.Valida
 	list, ok := request.AttributeConfig.(types.List)
 
 	if !ok {
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
-			"Invalid value type",
-			fmt.Sprintf("received incorrect value type (%T)", request.AttributeConfig),
-		)
+			request.AttributeConfig,
+		))
 
 		return
 	}

--- a/internal/validate/unique_items.go
+++ b/internal/validate/unique_items.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-awscc/internal/diags"
+	"github.com/hashicorp/terraform-provider-awscc/internal/diag"
 )
 
 // uniqueItemsValidator validates that an Attribute's list items have unique values.
@@ -29,7 +29,7 @@ func (v uniqueItemsValidator) Validate(ctx context.Context, request tfsdk.Valida
 	list, ok := request.AttributeConfig.(types.List)
 
 	if !ok {
-		response.Diagnostics.Append(diags.NewIncorrectValueTypeAttributeError(
+		response.Diagnostics.Append(diag.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			request.AttributeConfig,
 		))
@@ -44,7 +44,7 @@ func (v uniqueItemsValidator) Validate(ctx context.Context, request tfsdk.Valida
 	val, err := list.ToTerraformValue(ctx)
 
 	if err != nil {
-		response.Diagnostics.Append(diags.NewUnableToObtainValueAttributeError(
+		response.Diagnostics.Append(diag.NewUnableToObtainValueAttributeError(
 			request.AttributePath,
 			err,
 		))

--- a/internal/validate/unique_items.go
+++ b/internal/validate/unique_items.go
@@ -44,11 +44,10 @@ func (v uniqueItemsValidator) Validate(ctx context.Context, request tfsdk.Valida
 	val, err := list.ToTerraformValue(ctx)
 
 	if err != nil {
-		response.Diagnostics.AddAttributeError(
+		response.Diagnostics.Append(diags.NewUnableToObtainValueAttributeError(
 			request.AttributePath,
-			"No Terraform value",
-			"unable to obtain Terraform value:\n\n"+err.Error(),
-		)
+			err,
+		))
 
 		return
 	}


### PR DESCRIPTION
There's a lot of repetition in our `diag.Diagnostic` errors, and they're free-form instead of using pre-defined constants, etc. This PR packages many of the repeated Diagnostics