### PR TITLE
fix: remove changelog configuration override in goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,8 +28,6 @@ builds:
     ldflags:
       - -s -w -X internal/provider.Version={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
-changelog:
-  skip: true
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-awscc/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the Cloudformation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #248 

* Changelog generation (for the github release object) should not be skipped as we intend to pass in the release notes as an argument (e.g. `goreleaser release --release-notes <file>`); `v0.179.0` of goreleaser ignored our previous configuration but with later versions the `skip` directive is correctly interpreted, thus explaining the missing release note generation 

Reference:
```
func (Pipe) Skip(ctx *context.Context) bool { return ctx.Config.Changelog.Skip || ctx.Snapshot }
```
in  `internal/pipe/changelog/changelog.go` of https://github.com/goreleaser/goreleaser/pull/2480/files#diff-54787ac5a69d7c234c8d1f05d421f3921f2a4ce9d6127893135a8c570bcb7d45