### PR TITLE
Fix generators/import-examples from failing w/ too many open files

### DIFF
--- a/internal/provider/generators/import-examples/main.go
+++ b/internal/provider/generators/import-examples/main.go
@@ -24,49 +24,54 @@ func main() {
 	resources, _ := provider.GetResources(context.Background())
 
 	for resource := range resources {
-
-		templateData := TemplateData{
-			ResourceType: resource,
-		}
-
-		tmpl, err := template.New("function").Parse(importExampleTemplateBody)
-
-		if err != nil {
-			ui.Error(fmt.Sprintf("error parsing function template: %s", err))
-		}
-
-		var buffer bytes.Buffer
-		err = tmpl.Execute(&buffer, templateData)
-
-		if err != nil {
-			ui.Error(fmt.Sprintf("error executing template: %s", err))
-		}
-
-		examplesPath := "./examples/resources"
-
-		dirname := fmt.Sprintf("%s/%s", examplesPath, resource)
-		err = os.MkdirAll(dirname, shared.DirPerm)
-
-		if err != nil {
-			ui.Error(fmt.Sprintf("creating target directory %s: %s", dirname, err))
-		}
-
-		filename := fmt.Sprintf("%s/import.sh", dirname)
-
-		f, err := os.Create(filename)
-
-		if err != nil {
-			ui.Error(fmt.Sprintf("error creating file (%s): %s", filename, err))
-		}
-
-		defer f.Close()
-
-		_, err = f.Write(buffer.Bytes())
-
-		if err != nil {
-			ui.Error(fmt.Sprintf("error writing to file (%s): %s", filename, err))
-		}
+		GenerateExample(resource, ui)
 	}
+}
+
+func GenerateExample(resourceName string, ui *cli.BasicUi) {
+
+	templateData := TemplateData{
+		ResourceType: resourceName,
+	}
+
+	tmpl, err := template.New("function").Parse(importExampleTemplateBody)
+
+	if err != nil {
+		ui.Error(fmt.Sprintf("error parsing function template: %s", err))
+	}
+
+	var buffer bytes.Buffer
+	err = tmpl.Execute(&buffer, templateData)
+
+	if err != nil {
+		ui.Error(fmt.Sprintf("error executing template: %s", err))
+	}
+
+	examplesPath := "./examples/resources"
+
+	dirname := fmt.Sprintf("%s/%s", examplesPath, resourceName)
+	err = os.MkdirAll(dirname, shared.DirPerm)
+
+	if err != nil {
+		ui.Error(fmt.Sprintf("creating target directory %s: %s", dirname, err))
+	}
+
+	filename := fmt.Sprintf("%s/import.sh", dirname)
+
+	f, err := os.Create(filename)
+
+	if err != nil {
+		ui.Error(fmt.Sprintf("error creating file (%s): %s", filename, err))
+	}
+
+	defer f.Close()
+
+	_, err = f.Write(buffer.Bytes())
+
+	if err != nil {
+		ui.Error(fmt.Sprintf("error writing to file (%s): %s", filename, err))
+	}
+
 }
 
 type TemplateData struct {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-awscc/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the Cloudformation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #272.
