### PR TITLE
goreleaser: add "plain" signature file creation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,21 @@ release:
   ids:
     - none
 signs:
-  - signature: ${artifact}.72D7468F.sig
+  # Default Signature file (i.e. terraform-provider-awscc_VERSION_SHA256SUMS.sig)
+  - cmd: sh
+    args:
+    - -c
+    - >-
+      signore
+      sign
+      --dearmor
+      --file ${artifact}
+      --signer {{ .Env.SIGNER }}
+      --out ${signature}
+    artifacts: checksum
+  # Signature file with GPG Public Key ID in filename (i.e. terraform-provider-awscc_VERSION_SHA256SUMS.7685B676.sig)
+  - id: sig-with-gpg-public-key-id
+    signature: ${artifact}.72D7468F.sig
     cmd: sh
     args:
     - -c


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-awscc/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the Cloudformation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Update per slack convo with @shore to add consistency to artifacts found in releases.hashicorp.com

Gorelaser test output:
```
$ goreleaser check
   • loading config file       file=.goreleaser.yml
   • checking config:
      • snapshotting
      • github/gitlab/gitea releases
      • project name
      • loading go mod information
      • building binaries
         • DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check https://goreleaser.com/deprecations/#builds-for-windowsarm64 for more info.
      • universal binaries
      • creating source archive
      • archives
      • linux packages
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • signing docker images
      • docker images
      • docker manifests
      • artifactory
      • blobs
      • homebrew tap formula
      • gofish fish food cookbook
      • scoop manifests
      • discord
      • reddit
      • slack
      • teams
      • twitter
      • smtp
      • mattermost
      • milestones
      • telegram
   • config is valid
```
```
$ goreleaser release --snapshot --rm-dist
   • releasing...
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=e464e9f8e615644452c00ae542af356c16a1c15c latest tag=v0.6.0
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag
   • setting defaults
      • snapshotting
      • github/gitlab/gitea releases
      • project name
      • loading go mod information
      • building binaries
         • DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check https://goreleaser.com/deprecations/#builds-for-windowsarm64 for more info.
      • universal binaries
      • creating source archive
      • archives
      • linux packages
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • signing docker images
      • docker images
      • docker manifests
      • artifactory
      • blobs
      • homebrew tap formula
      • gofish fish food cookbook
      • scoop manifests
      • discord
      • reddit
      • slack
      • teams
      • twitter
      • smtp
      • mattermost
      • milestones
      • telegram
   • snapshotting
      • building snapshot...      version=v0.6.0-next
   • checking ./dist
   • loading go mod information
   • writing effective config file
      • writing                   config=dist/config.yaml
   • building binaries
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_windows_arm_6/terraform-provider-awscc.exe
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_freebsd_amd64/terraform-provider-awscc
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_darwin_amd64/terraform-provider-awscc
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_freebsd_386/terraform-provider-awscc
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_linux_arm64/terraform-provider-awscc
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_linux_amd64/terraform-provider-awscc
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_windows_386/terraform-provider-awscc.exe
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_linux_arm_6/terraform-provider-awscc
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_windows_amd64/terraform-provider-awscc.exe
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_freebsd_arm_6/terraform-provider-awscc
      • building                  binary=/Users/apinilla/go/src/github.com/hashicorp/terraform-provider-awscc/dist/terraform-provider-awscc_linux_386/terraform-provider-awscc
   • archives
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_linux_arm64.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_freebsd_386.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_freebsd_arm.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_linux_arm.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_linux_amd64.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_freebsd_amd64.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_windows_386.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_darwin_amd64.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_linux_386.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_windows_amd64.zip
      • creating                  archive=dist/terraform-provider-awscc_v0.6.0-next_windows_arm.zip
   • calculating checksums
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_freebsd_amd64.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_windows_arm.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_windows_amd64.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_windows_386.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_linux_amd64.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_linux_arm64.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_freebsd_arm.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_linux_arm.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_linux_386.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_freebsd_386.zip
      • checksumming              file=terraform-provider-awscc_v0.6.0-next_darwin_amd64.zip
   • signing artifacts
      • signing                   artifact=terraform-provider-awscc_v0.6.0-next_SHA256SUMS cmd=sh
      • signing                   artifact=terraform-provider-awscc_v0.6.0-next_SHA256SUMS cmd=sh
   • release succeeded after 80.45s

$ ls dist
config.yaml                                                  terraform-provider-awscc_v0.6.0-next_freebsd_386.zip
terraform-provider-awscc_darwin_amd64                        terraform-provider-awscc_v0.6.0-next_freebsd_amd64.zip
terraform-provider-awscc_freebsd_386                         terraform-provider-awscc_v0.6.0-next_freebsd_arm.zip
terraform-provider-awscc_freebsd_amd64                       terraform-provider-awscc_v0.6.0-next_linux_386.zip
terraform-provider-awscc_freebsd_arm_6                       terraform-provider-awscc_v0.6.0-next_linux_amd64.zip
terraform-provider-awscc_linux_386                           terraform-provider-awscc_v0.6.0-next_linux_arm.zip
terraform-provider-awscc_linux_amd64                         terraform-provider-awscc_v0.6.0-next_linux_arm64.zip
terraform-provider-awscc_linux_arm64                         terraform-provider-awscc_v0.6.0-next_windows_386.zip
terraform-provider-awscc_linux_arm_6                         terraform-provider-awscc_v0.6.0-next_windows_amd64.zip
terraform-provider-awscc_v0.6.0-next_SHA256SUMS              terraform-provider-awscc_v0.6.0-next_windows_arm.zip
terraform-provider-awscc_v0.6.0-next_SHA256SUMS.72D7468F.sig terraform-provider-awscc_windows_386
terraform-provider-awscc_v0.6.0-next_SHA256SUMS.sig          terraform-provider-awscc_windows_amd64
terraform-provider-awscc_v0.6.0-next_darwin_amd64.zip        terraform-provider-awscc_windows_arm_6
```