### PR TITLE
Update release workflow for goreleaser extra_files remap support and remove other protocol handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ on:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  PROTOCOL_VERSION: "6.0"
-  PROTOCOL_VERSIONS: "6.0"
   SIGNER: interim_signing_subkey_7685B676
 
 jobs:
@@ -41,17 +39,6 @@ jobs:
           signer: interim_signing_subkey_768B676
       - name: Release Notes
         run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# \[$(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > /tmp/RELEASE-NOTES.md
-      - name: Release Protocol Versions
-        run: |
-          manifestFile=${{ github.event.repository.name }}_manifest.json
-          if [[ -f  $manifestFile ]] && [[ $(jq '.metadata.protocol_versions' $manifestFile | jq length) -gt 0 ]]; then
-            versions=`jq '.metadata.protocol_versions' $manifestFile | jq 'sort'`
-            protoV=`echo $versions | jq '.[0]'`
-            protoVs=`echo $versions | jq 'join(", ")'`
-
-            echo "PROTOCOL_VERSION=${protoV}" >> $GITHUB_ENV
-            echo "PROTOCOL_VERSIONS=${protoVs}" >> $GITHUB_ENV
-          fi
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.TF_PROVIDER_RELEASE_AWS_ACCESS_KEY_ID }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,13 +29,16 @@ builds:
       - -s -w -X internal/provider.Version={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
+  extra_files:
+    - glob: '{{ .ProjectName }}_manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 publishers:
   - name: hc-releases
     checksum: true
     signature: true
-    cmd: hc-releases upload-file -header="x-terraform-protocol-version={{ .Env.PROTOCOL_VERSION }}" -header="x-terraform-protocol-versions={{ .Env.PROTOCOL_VERSIONS }}" {{ abs .ArtifactPath }}
+    cmd: hc-releases upload-file {{ abs .ArtifactPath }}
     env:
       - AWS_DEFAULT_REGION={{ .Env.AWS_DEFAULT_REGION }}
       - AWS_REGION={{ .Env.AWS_REGION }}
@@ -43,6 +46,9 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_SESSION_TOKEN={{ .Env.AWS_SESSION_TOKEN }}
 release:
+  extra_files:
+    - glob: '{{ .ProjectName }}_manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   ids:
     - none
 signs:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-awscc/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the Cloudformation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/goreleaser/goreleaser/issues/2656
Reference: https://www.terraform.io/docs/plugin/framework/publishing.html

`goreleaser` can now automatically remap file names natively during the checksum and release pipes. This new configuration will add the manifest JSON file to the checksum file and release assets, where it is ingested by the Terraform Registry.

Other Terraform protocol version handling is removed from the release workflow as the Terraform Registry is the source of truth, rather than object metadata in S3.