### PR TITLE
Improve readme and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -23,7 +23,7 @@ If you are running into one of these scenarios, we recommend opening an issue in
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
 * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
 * If you are interested in working on this issue or have submitted a pull request, please leave a comment
-* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the Cloudformation Open Coverage Roadmap.
+* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.
 
 <!--- Thank you for keeping this note for the community --->
 

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -11,7 +11,7 @@ labels: enhancement
 * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
 * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
 * If you are interested in working on this issue or have submitted a pull request, please leave a comment
-* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the Cloudformation Open Coverage Roadmap.
+* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.
 
 <!--- Thank you for keeping this note for the community --->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-awscc/blob/main/docs/CONTRIBUTING.md --->
+<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->
 
 <!--- Please keep this note for the community --->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 * Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
 * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
-* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the Cloudformation Open Coverage Roadmap.
+* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.
 
 <!--- Thank you for keeping this note for the community --->
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://terraform.io">
-    <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/hashicorp-logo.svg" alt="Terraform logo" title="Terraform" align="right" height="50" />
+    <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-terraform-main.svg" alt="Terraform logo" title="Terraform" align="right" height="50" />
 </a>
 
 # Terraform AWS Cloud Control Provider

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The AWS Cloud Control API supports **C**reate, **R**ead, **U**pdate, **D**elete 
 
 #### Coverage
 
-At launch a subset of AWS resources which can be managed by CloudFormation are supported, some services use an older CloudFormation schema and cannot be used with Cloud Control. AWS are updating all of the older CloudFormation schemas to conform to the new standard, and are actively pursuing full coverage for CloudFormation. For the latest coverage information please refer to the AWS Cloudformation public [roadmap](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/projects/1).
+At launch a subset of AWS resources which can be managed by CloudFormation are supported, some services use an older CloudFormation schema and cannot be used with Cloud Control. AWS are updating all of the older CloudFormation schemas to conform to the new standard, and are actively pursuing full coverage for CloudFormation. For the latest coverage information please refer to the AWS CloudFormation public [roadmap](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/projects/1).
 
 To see the list of supported resources within this provider please refer to the registry.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://terraform.io">
-    <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" alt="Terraform logo" title="Terraform" align="right" height="50" />
+    <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/hashicorp-logo.svg" alt="Terraform logo" title="Terraform" align="right" height="50" />
 </a>
 
 # Terraform AWS Cloud Control Provider
@@ -22,7 +22,7 @@ The AWS Cloud Control API supports **C**reate, **R**ead, **U**pdate, **D**elete 
 
 #### Coverage
 
-At launch a subset of AWS resources which can be managed by CloudFormation are supported, some services use an older CloudFormation schema and cannot be used with Cloud Control. AWS are updating all of the older CloudFormation schemas to conform to the new standard, and are actively pursuing full coverage for CloudFormation. For the latest coverage information please refer to the AWS Cloudformation public (roadmap)[https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/projects/1]
+At launch a subset of AWS resources which can be managed by CloudFormation are supported, some services use an older CloudFormation schema and cannot be used with Cloud Control. AWS are updating all of the older CloudFormation schemas to conform to the new standard, and are actively pursuing full coverage for CloudFormation. For the latest coverage information please refer to the AWS Cloudformation public [roadmap](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/projects/1).
 
 To see the list of supported resources within this provider please refer to the registry.
 

--- a/contributing/FAQ.md
+++ b/contributing/FAQ.md
@@ -46,7 +46,7 @@ It's possible that as AWS release new services, the code which generates the pro
 
 We release weekly on Thursday rolling up the preceding week's CloudFormation additions/enhancements. For this reason there may be a delay of up to a week before a feature available in AWS can be usable in the provider. We do plan to narrow this gap as the provider reaches GA status.
 
-### Cloudformation doesn't support the service or resource I want to use, how do I request coverage?
+### CloudFormation doesn't support the service or resource I want to use, how do I request coverage?
 
 AWS are aiming for 100% coverage of their AWS service area in CloudFormation. New services will nearly always launch with CloudFormation support, and older services will be updated in time. Please refer to the [CloudFormation](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/projects/1) Open Coverage roadmap for more details or to upvote the service you would like to see coverage for.
 


### PR DESCRIPTION
This pull request fixes a few small things:

* broken link to contributing page
* broken url to Terraform logo
* broken Markdown for link to AWS CloudFormation public roadmap
* spelling for CloudFormation

<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
