### PR TITLE
`make all` fails unless you first run `make tools`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,13 +4,15 @@ PKG_NAME=internal/aws/...
 ACCTEST_TIMEOUT?=180m
 ACCTEST_PARALLELISM?=20
 
-default: build
+default: install
 
-.PHONY: all build default docs golangci-lint lint plural-data-sources resources schemas singular-data-sources test testacc tools
+.PHONY: all install default docs golangci-lint lint plural-data-sources resources schemas singular-data-sources test testacc tools
 
-all: schemas resources singular-data-sources plural-data-sources build docs
+all: tools schemas resources singular-data-sources plural-data-sources install docs
 
-build:
+build: schemas resources singular-data-sources plural-data-sources install docs
+
+install:
 	go install
 
 plural-data-sources:

--- a/contributing/DEVELOPMENT.md
+++ b/contributing/DEVELOPMENT.md
@@ -19,13 +19,7 @@ $ git clone git@github.com:terraform-providers/terraform-provider-awscc
 ...
 ```
 
-Enter the provider directory and run `make tools`. This will install the needed tools for the provider.
-
-```sh
-$ make tools
-```
-
-To compile the provider, run `make all`. This will generate the resources and datasources, build the provider and put the provider binary in the `$GOPATH/bin` directory.
+To compile the provider and install tool dependencies, run `make all`. This will generate the resources and datasources, build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
 $ make all
@@ -56,7 +50,7 @@ $ make testacc
 
 [Development overrides for provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers) can be leveraged in order to use the provider built from source.
 
-To do this, populate a Terraform CLI configuration file (`~/.terraformrc` for all platforms other than Windows; `terraform.rc` in the `%APPDATA%` directory when using Windows) with at least the following options:
+To do this, populate a [Terraform CLI configuration file](https://www.terraform.io/docs/cli/config/config-file.html) (`~/.terraformrc` for all platforms other than Windows; `terraform.rc` in the `%APPDATA%` directory when using Windows) with at least the following options:
 
 ```hcl
 provider_installation {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-awscc/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the Cloudformation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

### Background

`make all` failed at documentation build because i had not run `make tools`. 

solved by updating `make all` to include `tools`. I also change `build` to be `install` and made `build` behave how `all` used to behave.

