### PR TITLE
Improve setting of Unknown values in State after Create/Update to support "complex types"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.10.0 (Unreleased)
+
+BUG FIXES:
+
+* Prevent errors like `Unable to set Terraform State Unknown values from Cloud Control API Properties.` during `terraform apply` ([#331](https://github.com/hashicorp/terraform-provider-awscc/issues/331))
+
 ## [0.9.0](https://github.com/hashicorp/terraform-provider-awscc/releases/tag/v0.9.0) (December 16, 2021)
 
 FEATURES:

--- a/internal/generic/resource.go
+++ b/internal/generic/resource.go
@@ -755,7 +755,7 @@ func (r *resource) setId(ctx context.Context, val string, state *tfsdk.State) er
 func (r *resource) populateUnknownValues(ctx context.Context, id string, state *tfsdk.State) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	unknowns, err := Unknowns(ctx, state.Raw)
+	unknowns, err := UnknownValuePaths(ctx, state.Raw)
 
 	if err != nil {
 		diags.AddError(

--- a/internal/generic/resource.go
+++ b/internal/generic/resource.go
@@ -755,7 +755,7 @@ func (r *resource) setId(ctx context.Context, val string, state *tfsdk.State) er
 func (r *resource) populateUnknownValues(ctx context.Context, id string, state *tfsdk.State) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	unknowns, err := Unknowns(ctx, state.Raw, r.resourceType.tfToCfNameMap)
+	unknowns, err := Unknowns(ctx, state.Raw)
 
 	if err != nil {
 		diags.AddError(
@@ -790,7 +790,7 @@ func (r *resource) populateUnknownValues(ctx context.Context, id string, state *
 		return diags
 	}
 
-	err = unknowns.SetValuesFromString(ctx, state, aws.ToString(description.Properties))
+	err = unknowns.SetValuesFromString(ctx, state, aws.ToString(description.Properties), r.resourceType.cfToTfNameMap)
 
 	if err != nil {
 		diags.AddError(

--- a/internal/generic/resource.go
+++ b/internal/generic/resource.go
@@ -790,7 +790,7 @@ func (r *resource) populateUnknownValues(ctx context.Context, id string, state *
 		return diags
 	}
 
-	err = unknowns.SetValuesFromString(ctx, state, aws.ToString(description.Properties), r.resourceType.cfToTfNameMap)
+	err = SetUnknownValuesFromResourceModel(ctx, state, unknowns, aws.ToString(description.Properties), r.resourceType.cfToTfNameMap)
 
 	if err != nil {
 		diags.AddError(

--- a/internal/generic/unknown.go
+++ b/internal/generic/unknown.go
@@ -2,27 +2,21 @@ package generic
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-provider-awscc/internal/tfresource"
 )
 
-// unknownValuePath represents the path to an unknown (!val.IsKnown()) value.
-// It holds paths in both the Terraform State and Cloud Control ResourceModel (raw map[string]interface{}).
+// unknownValuePath represents the path to an unknown (!val.IsKnown()) value in Terraform State.
 type unknownValuePath struct {
-	InTerraformState            *tftypes.AttributePath
-	InCloudControlResourceModel *tftypes.AttributePath
+	InTerraformState *tftypes.AttributePath
 }
 
 type unknowns []unknownValuePath
 
 // Unknowns returns all the unknowns in the specified Terraform Value.
-func Unknowns(ctx context.Context, val tftypes.Value, tfToCfNameMap map[string]string) (unknowns, error) {
-	unknowns, err := unknownValuePaths(ctx, nil, nil, val, tfToCfNameMap)
+func Unknowns(ctx context.Context, val tftypes.Value) (unknowns, error) {
+	unknowns, err := unknownValuePaths(ctx, nil, val)
 
 	if err != nil {
 		return nil, err
@@ -32,12 +26,11 @@ func Unknowns(ctx context.Context, val tftypes.Value, tfToCfNameMap map[string]s
 }
 
 // unknownValuePaths returns all the unknownValuePaths for the specified Terraform Value.
-func unknownValuePaths(ctx context.Context, inTerraformState, inCloudControlResourceModel *tftypes.AttributePath, val tftypes.Value, tfToCfNameMap map[string]string) ([]unknownValuePath, error) { //nolint:unparam
+func unknownValuePaths(ctx context.Context, inTerraformState *tftypes.AttributePath, val tftypes.Value) ([]unknownValuePath, error) { //nolint:unparam
 	if !val.IsKnown() {
 		return []unknownValuePath{
 			{
-				InTerraformState:            inTerraformState,
-				InCloudControlResourceModel: inCloudControlResourceModel,
+				InTerraformState: inTerraformState,
 			},
 		}, nil
 	}
@@ -55,18 +48,15 @@ func unknownValuePaths(ctx context.Context, inTerraformState, inCloudControlReso
 		for idx, val := range vals {
 			if typ.Is(tftypes.Set{}) {
 				inTerraformState = inTerraformState.WithElementKeyValue(val)
-				inCloudControlResourceModel = inCloudControlResourceModel.WithElementKeyValue(val)
 			} else {
 				inTerraformState = inTerraformState.WithElementKeyInt(idx)
-				inCloudControlResourceModel = inCloudControlResourceModel.WithElementKeyInt(idx)
 			}
-			paths, err := unknownValuePaths(ctx, inTerraformState, inCloudControlResourceModel, val, tfToCfNameMap)
+			paths, err := unknownValuePaths(ctx, inTerraformState, val)
 			if err != nil {
 				return nil, err
 			}
 			unknowns = append(unknowns, paths...)
 			inTerraformState = inTerraformState.WithoutLastStep()
-			inCloudControlResourceModel = inCloudControlResourceModel.WithoutLastStep()
 		}
 
 	case typ.Is(tftypes.Map{}), typ.Is(tftypes.Object{}):
@@ -78,22 +68,15 @@ func unknownValuePaths(ctx context.Context, inTerraformState, inCloudControlReso
 		for key, val := range vals {
 			if typ.Is(tftypes.Map{}) {
 				inTerraformState = inTerraformState.WithElementKeyString(key)
-				inCloudControlResourceModel = inCloudControlResourceModel.WithElementKeyString(key)
 			} else if typ.Is(tftypes.Object{}) {
 				inTerraformState = inTerraformState.WithAttributeName(key)
-				propertyName, ok := tfToCfNameMap[key]
-				if !ok {
-					return nil, fmt.Errorf("attribute name mapping not found: %s", key)
-				}
-				inCloudControlResourceModel = inCloudControlResourceModel.WithAttributeName(propertyName)
 			}
-			paths, err := unknownValuePaths(ctx, inTerraformState, inCloudControlResourceModel, val, tfToCfNameMap)
+			paths, err := unknownValuePaths(ctx, inTerraformState, val)
 			if err != nil {
 				return nil, err
 			}
 			unknowns = append(unknowns, paths...)
 			inTerraformState = inTerraformState.WithoutLastStep()
-			inCloudControlResourceModel = inCloudControlResourceModel.WithoutLastStep()
 		}
 	}
 
@@ -101,65 +84,88 @@ func unknownValuePaths(ctx context.Context, inTerraformState, inCloudControlReso
 }
 
 // SetValuesFromRaw fills any unknown State values from a Cloud Control ResourceModel (raw map[string]interface{}).
-func (u unknowns) SetValuesFromRaw(ctx context.Context, state *tfsdk.State, resourceModel map[string]interface{}) error {
+// func (u unknowns) SetValuesFromRaw(ctx context.Context, state *tfsdk.State, resourceModel map[string]interface{}) error {
+// 	for _, path := range u {
+// 		// Get the value from the Cloud Control ResourceModel.
+// 		val, _, err := tftypes.WalkAttributePath(resourceModel, path.InCloudControlResourceModel)
+
+// 		if errors.Is(err, tftypes.ErrInvalidStep) {
+// 			// Value not found in Cloud Control ResourceModel. Set to Nil in State.
+
+// 			// TODO
+// 			// TODO State.SetAttribute does not support passing `nil` to set a Null value.
+// 			// TODO https://github.com/hashicorp/terraform-plugin-framework/issues/66.
+// 			// TODO
+
+// 			attrType, err := state.Schema.AttributeTypeAtPath(path.InTerraformState)
+
+// 			if err != nil {
+// 				return fmt.Errorf("error getting attribute type at %s: %w", path.InTerraformState, err)
+// 			}
+
+// 			state.Raw, err = tftypes.Transform(state.Raw, func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
+// 				if p.Equal(path.InTerraformState) {
+// 					return tftypes.NewValue(attrType.TerraformType(ctx), nil), nil
+// 				}
+// 				return v, nil
+// 			})
+
+// 			if err != nil {
+// 				return fmt.Errorf("error setting attribute in state: %w", err)
+// 			}
+
+// 			continue
+// 		}
+
+// 		if err != nil {
+// 			return fmt.Errorf("error getting value at %s: %w", path.InCloudControlResourceModel, err)
+// 		}
+
+// 		// Set it in the Terraform State.
+// 		diags := state.SetAttribute(ctx, path.InTerraformState, val)
+
+// 		if diags.HasError() {
+// 			return fmt.Errorf("error setting value at %s: %w", path.InTerraformState, tfresource.DiagsError(diags))
+// 		}
+// 	}
+
+// 	return nil
+// }
+
+// SetValuesFromRaw fills any unknown State values from a Cloud Control ResourceModel (string).
+func (u unknowns) SetValuesFromString(ctx context.Context, state *tfsdk.State, resourceModel string, cfToTfNameMap map[string]string) error {
+	translator := toTerraform{cfToTfNameMap: cfToTfNameMap}
+	schema := &state.Schema
+	val, err := translator.FromString(ctx, schema, resourceModel)
+
+	if err != nil {
+		return err
+	}
+
+	src := tfsdk.State{
+		Schema: *schema,
+		Raw:    val,
+	}
+
 	for _, path := range u {
-		// Get the value from the Cloud Control ResourceModel.
-		val, _, err := tftypes.WalkAttributePath(resourceModel, path.InCloudControlResourceModel)
-
-		if errors.Is(err, tftypes.ErrInvalidStep) {
-			// Value not found in Cloud Control ResourceModel. Set to Nil in State.
-
-			// TODO
-			// TODO State.SetAttribute does not support passing `nil` to set a Null value.
-			// TODO https://github.com/hashicorp/terraform-plugin-framework/issues/66.
-			// TODO
-
-			attrType, err := state.Schema.AttributeTypeAtPath(path.InTerraformState)
-
-			if err != nil {
-				return fmt.Errorf("error getting attribute type at %s: %w", path.InTerraformState, err)
-			}
-
-			state.Raw, err = tftypes.Transform(state.Raw, func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
-				if p.Equal(path.InTerraformState) {
-					return tftypes.NewValue(attrType.TerraformType(ctx), nil), nil
-				}
-				return v, nil
-			})
-
-			if err != nil {
-				return fmt.Errorf("error setting attribute in state: %w", err)
-			}
-
-			continue
-		}
+		err = CopyValueAtPath(ctx, state, &src, path.InTerraformState)
 
 		if err != nil {
-			return fmt.Errorf("error getting value at %s: %w", path.InCloudControlResourceModel, err)
-		}
-
-		// Set it in the Terraform State.
-		diags := state.SetAttribute(ctx, path.InTerraformState, val)
-
-		if diags.HasError() {
-			return fmt.Errorf("error setting value at %s: %w", path.InTerraformState, tfresource.DiagsError(diags))
+			return err
 		}
 	}
 
 	return nil
-}
 
-// SetValuesFromRaw fills any unknown State values from a Cloud Control ResourceModel (string).
-func (u unknowns) SetValuesFromString(ctx context.Context, state *tfsdk.State, resourceModel string) error {
-	var v interface{}
+	// var v interface{}
 
-	if err := json.Unmarshal([]byte(resourceModel), &v); err != nil {
-		return err
-	}
+	// if err := json.Unmarshal([]byte(resourceModel), &v); err != nil {
+	// 	return err
+	// }
 
-	if v, ok := v.(map[string]interface{}); ok {
-		return u.SetValuesFromRaw(ctx, state, v)
-	}
+	// if v, ok := v.(map[string]interface{}); ok {
+	// 	return u.SetValuesFromRaw(ctx, state, v)
+	// }
 
-	return fmt.Errorf("unexpected raw type: %T", v)
+	// return fmt.Errorf("unexpected raw type: %T", v)
 }

--- a/internal/generic/unknown_test.go
+++ b/internal/generic/unknown_test.go
@@ -56,7 +56,7 @@ func TestUnknowns(t *testing.T) {
 			}
 
 			if err == nil {
-				if diff := cmp.Diff(got, unknowns(testCase.ExpectedPaths), opts); diff != "" {
+				if diff := cmp.Diff(got, testCase.ExpectedPaths, opts); diff != "" {
 					t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 				}
 			}
@@ -108,7 +108,7 @@ func TestUnknowsSetValue(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			err = unknowns.SetValuesFromString(context.TODO(), &testCase.State, testCase.ResourceModel, testCase.CfToTfNameMap)
+			err = SetUnknownValuesFromResourceModel(context.TODO(), &testCase.State, unknowns, testCase.ResourceModel, testCase.CfToTfNameMap)
 
 			if err == nil && testCase.ExpectedError {
 				t.Fatalf("expected error")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #330.
Closes #266.

The previous implementation of setting Unknown values after Create or Update only worked for primitive types.
We can reuse the functionality in `CopyValueAtPath`, used for copying over write-only attributes during Read, to copy values of arbitrary type.
