### PR TITLE
Add Multiset test for list of objects

### DIFF
--- a/internal/generic/multiset_test.go
+++ b/internal/generic/multiset_test.go
@@ -15,6 +15,12 @@ import (
 func TestMultiset(t *testing.T) {
 	t.Parallel()
 
+	tagAttrTypes := map[string]attr.Type{
+		"key":   types.StringType,
+		"value": types.StringType,
+	}
+	tagElemType := types.ObjectType{AttrTypes: tagAttrTypes}
+
 	type testCase struct {
 		plannedValue  attr.Value
 		currentValue  attr.Value
@@ -71,6 +77,38 @@ func TestMultiset(t *testing.T) {
 				types.String{Value: "gamma"},
 				types.String{Value: "beta"},
 				types.String{Value: "gamma"},
+			}},
+		},
+		"list of objects": {
+			plannedValue: types.List{ElemType: tagElemType, Elems: []attr.Value{
+				types.Object{AttrTypes: tagAttrTypes, Attrs: map[string]attr.Value{
+					"key":   types.String{Value: "k2"},
+					"value": types.String{Value: "v2"},
+				}},
+				types.Object{AttrTypes: tagAttrTypes, Attrs: map[string]attr.Value{
+					"key":   types.String{Value: "k1"},
+					"value": types.String{Value: "v1"},
+				}},
+			}},
+			currentValue: types.List{ElemType: tagElemType, Elems: []attr.Value{
+				types.Object{AttrTypes: tagAttrTypes, Attrs: map[string]attr.Value{
+					"key":   types.String{Value: "k1"},
+					"value": types.String{Value: "v1"},
+				}},
+				types.Object{AttrTypes: tagAttrTypes, Attrs: map[string]attr.Value{
+					"key":   types.String{Value: "k2"},
+					"value": types.String{Value: "v2"},
+				}},
+			}},
+			expectedValue: types.List{ElemType: tagElemType, Elems: []attr.Value{
+				types.Object{AttrTypes: tagAttrTypes, Attrs: map[string]attr.Value{
+					"key":   types.String{Value: "k1"},
+					"value": types.String{Value: "v1"},
+				}},
+				types.Object{AttrTypes: tagAttrTypes, Attrs: map[string]attr.Value{
+					"key":   types.String{Value: "k2"},
+					"value": types.String{Value: "v2"},
+				}},
 			}},
 		},
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

```
% go test -v ./internal/generic '-run=TestMultiset'     
=== RUN   TestMultiset
=== PAUSE TestMultiset
=== CONT  TestMultiset
=== RUN   TestMultiset/not_lists
=== RUN   TestMultiset/null_lists
=== RUN   TestMultiset/single_item
=== RUN   TestMultiset/different_lengths
=== RUN   TestMultiset/equivalent
=== RUN   TestMultiset/list_of_objects
--- PASS: TestMultiset (0.00s)
    --- PASS: TestMultiset/not_lists (0.00s)
    --- PASS: TestMultiset/null_lists (0.00s)
    --- PASS: TestMultiset/single_item (0.00s)
    --- PASS: TestMultiset/different_lengths (0.00s)
    --- PASS: TestMultiset/equivalent (0.00s)
    --- PASS: TestMultiset/list_of_objects (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-awscc/internal/generic	(cached)
```