### PR TITLE
Restore use of `tflog`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     ignore:
       # terraform-plugin-go should only be updated via terraform-plugin-framework
       - dependency-name: "github.com/hashicorp/terraform-plugin-go"
+      # terraform-plugin-log should only be updated via terraform-plugin-framework
+      - dependency-name: "github.com/hashicorp/terraform-plugin-log"
+      # go-hclog should only be updated via terraform-plugin-log
+      - dependency-name: "github.com/hashicorp/go-hclog"
     schedule:
       # Check for updates to Go modules every weekday
       interval: "daily"

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,12 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.15.0
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.3
+	github.com/hashicorp/go-hclog v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-plugin-framework v0.5.1-0.20220105213120-5f18d804a22b
 	github.com/hashicorp/terraform-plugin-go v0.5.0
+	github.com/hashicorp/terraform-plugin-log v0.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/jinzhu/inflection v1.0.0
 	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24

--- a/internal/acctest/testchecks.go
+++ b/internal/acctest/testchecks.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	tfcloudcontrol "github.com/hashicorp/terraform-provider-awscc/internal/service/cloudcontrol"
@@ -60,7 +62,7 @@ func (td TestData) DeleteResource() resource.TestCheckFunc {
 			return fmt.Errorf("unable to convert %T to CloudControlApiProvider", td.provider)
 		}
 
-		ctx := context.TODO()
+		ctx := getTestContext()
 
 		return tfcloudcontrol.DeleteResource(ctx, provider.CloudControlApiClient(ctx), provider.RoleARN(ctx), td.CloudFormationResourceType, id, deleteResourceTimeout)
 	}
@@ -73,7 +75,7 @@ func (td TestData) checkExists(shouldExist bool) resource.TestCheckFunc {
 			return fmt.Errorf("unable to convert %T to CloudControlApiProvider", td.provider)
 		}
 
-		ctx := context.TODO()
+		ctx := getTestContext()
 
 		return existsFunc(shouldExist)(
 			ctx,
@@ -123,4 +125,8 @@ func existsFunc(shouldExist bool) func(context.Context, *cloudcontrol.Client, st
 			return nil
 		}
 	}
+}
+
+func getTestContext() context.Context {
+	return tfsdklog.NewRootProviderLogger(context.TODO(), tflog.WithLevelFromEnv("TF_LOG"), tflog.WithoutLocation())
 }

--- a/internal/generic/logging.go
+++ b/internal/generic/logging.go
@@ -1,0 +1,20 @@
+package generic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	LoggingKeyCFNType = "cfn_type"
+)
+
+func traceEntry(ctx context.Context, n string) {
+	tflog.Trace(ctx, fmt.Sprintf("%s entry", n))
+}
+
+func traceExit(ctx context.Context, n string) {
+	tflog.Trace(ctx, fmt.Sprintf("%s exit", n))
+}

--- a/internal/generic/plural_data_source.go
+++ b/internal/generic/plural_data_source.go
@@ -3,14 +3,15 @@ package generic
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	tfcloudcontrol "github.com/hashicorp/terraform-provider-awscc/internal/service/cloudcontrol"
 )
 
@@ -68,7 +69,7 @@ func (pd *pluralDataSource) Read(ctx context.Context, _ tfsdk.ReadDataSourceRequ
 	cfTypeName := pd.dataSourceType.cfTypeName
 	tfTypeName := pd.dataSourceType.tfTypeName
 
-	log.Printf("[TRACE] DataSource.Read enter. cfTypeName: %s, tfTypeName: %s", cfTypeName, tfTypeName)
+	tflog.Debug(ctx, "DataSource.Read enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 
 	conn := pd.provider.CloudControlApiClient(ctx)
 
@@ -87,9 +88,9 @@ func (pd *pluralDataSource) Read(ctx context.Context, _ tfsdk.ReadDataSourceRequ
 		Raw:    val,
 	}
 
-	log.Printf("[DEBUG] Response.State.Raw. value: %v", response.State.Raw)
+	tflog.Debug(ctx, "Response.State.Raw", "value", hclog.Fmt("%v", response.State.Raw))
 
-	log.Printf("[TRACE] DataSource.Read exit. cfTypeName: %s, tfTypeName: %s", cfTypeName, tfTypeName)
+	tflog.Debug(ctx, "DataSource.Read exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 }
 
 // list returns the ResourceDescriptions of the specified CloudFormation type.

--- a/internal/generic/resource.go
+++ b/internal/generic/resource.go
@@ -398,7 +398,7 @@ func (r *resource) Create(ctx context.Context, request tfsdk.CreateResourceReque
 	cfTypeName := r.resourceType.cfTypeName
 	tfTypeName := r.resourceType.tfTypeName
 
-	tflog.Trace(ctx, "Resource.Create enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	tflog.Debug(ctx, "Resource.Create enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 
 	conn := r.provider.CloudControlApiClient(ctx)
 
@@ -487,14 +487,14 @@ func (r *resource) Create(ctx context.Context, request tfsdk.CreateResourceReque
 
 	tflog.Debug(ctx, "Response.State.Raw", "value", hclog.Fmt("%v", response.State.Raw))
 
-	tflog.Trace(ctx, "Resource.Create exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	tflog.Debug(ctx, "Resource.Create exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 }
 
 func (r *resource) Read(ctx context.Context, request tfsdk.ReadResourceRequest, response *tfsdk.ReadResourceResponse) {
 	cfTypeName := r.resourceType.cfTypeName
 	tfTypeName := r.resourceType.tfTypeName
 
-	tflog.Trace(ctx, "Resource.Read enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	tflog.Debug(ctx, "Resource.Read enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 
 	tflog.Debug(ctx, "Request.State.Raw", "value", hclog.Fmt("%v", request.State.Raw))
 
@@ -570,14 +570,14 @@ func (r *resource) Read(ctx context.Context, request tfsdk.ReadResourceRequest, 
 
 	tflog.Debug(ctx, "Response.State.Raw", "value", hclog.Fmt("%v", response.State.Raw))
 
-	tflog.Trace(ctx, "Resource.Read exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	tflog.Debug(ctx, "Resource.Read exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 }
 
 func (r *resource) Update(ctx context.Context, request tfsdk.UpdateResourceRequest, response *tfsdk.UpdateResourceResponse) {
 	cfTypeName := r.resourceType.cfTypeName
 	tfTypeName := r.resourceType.tfTypeName
 
-	tflog.Trace(ctx, "Resource.Update enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	tflog.Debug(ctx, "Resource.Update enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 
 	conn := r.provider.CloudControlApiClient(ctx)
 
@@ -668,14 +668,14 @@ func (r *resource) Update(ctx context.Context, request tfsdk.UpdateResourceReque
 		return
 	}
 
-	tflog.Trace(ctx, "Resource.Update exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	tflog.Debug(ctx, "Resource.Update exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 }
 
 func (r *resource) Delete(ctx context.Context, request tfsdk.DeleteResourceRequest, response *tfsdk.DeleteResourceResponse) {
 	cfTypeName := r.resourceType.cfTypeName
 	tfTypeName := r.resourceType.tfTypeName
 
-	tflog.Trace(ctx, "Resource.Delete enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	tflog.Debug(ctx, "Resource.Delete enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 
 	conn := r.provider.CloudControlApiClient(ctx)
 
@@ -697,17 +697,17 @@ func (r *resource) Delete(ctx context.Context, request tfsdk.DeleteResourceReque
 
 	response.State.RemoveResource(ctx)
 
-	tflog.Trace(ctx, "Resource.Delete exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	tflog.Debug(ctx, "Resource.Delete exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 }
 
 func (r *resource) ImportState(ctx context.Context, request tfsdk.ImportResourceStateRequest, response *tfsdk.ImportResourceStateResponse) {
-	tflog.Trace(ctx, "Resource.ImportState enter", "cfTypeName", r.resourceType.cfTypeName, "tfTypeName", r.resourceType.tfTypeName)
+	tflog.Debug(ctx, "Resource.ImportState enter", "cfTypeName", r.resourceType.cfTypeName, "tfTypeName", r.resourceType.tfTypeName)
 
 	tflog.Debug(ctx, "Request.ID", "value", hclog.Fmt("%v", request.ID))
 
 	tfsdk.ResourceImportStatePassthroughID(ctx, idAttributePath, request, response)
 
-	tflog.Trace(ctx, "Resource.ImportState exit", "cfTypeName", r.resourceType.cfTypeName, "tfTypeName", r.resourceType.tfTypeName)
+	tflog.Debug(ctx, "Resource.ImportState exit", "cfTypeName", r.resourceType.cfTypeName, "tfTypeName", r.resourceType.tfTypeName)
 }
 
 // ConfigValidators returns a list of functions which will all be performed during validation.

--- a/internal/generic/singular_data_source.go
+++ b/internal/generic/singular_data_source.go
@@ -3,13 +3,14 @@ package generic
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	tfcloudcontrol "github.com/hashicorp/terraform-provider-awscc/internal/service/cloudcontrol"
 	"github.com/hashicorp/terraform-provider-awscc/internal/tfresource"
 )
@@ -68,7 +69,7 @@ func (sd *singularDataSource) Read(ctx context.Context, request tfsdk.ReadDataSo
 	cfTypeName := sd.dataSourceType.cfTypeName
 	tfTypeName := sd.dataSourceType.tfTypeName
 
-	log.Printf("[TRACE] DataSource.Read enter. cfTypeName: %s, tfTypeName: %s", cfTypeName, tfTypeName)
+	tflog.Debug(ctx, "DataSource.Read enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 
 	conn := sd.provider.CloudControlApiClient(ctx)
 
@@ -122,9 +123,9 @@ func (sd *singularDataSource) Read(ctx context.Context, request tfsdk.ReadDataSo
 		return
 	}
 
-	log.Printf("[DEBUG] Response.State.Raw. value: %v", response.State.Raw)
+	tflog.Debug(ctx, "Response.State.Raw", "value", hclog.Fmt("%v", response.State.Raw))
 
-	log.Printf("[TRACE] DataSource.Read exit. cfTypeName: %s, tfTypeName: %s", cfTypeName, tfTypeName)
+	tflog.Debug(ctx, "DataSource.Read exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
 }
 
 // describe returns the live state of the specified resource.

--- a/internal/generic/singular_data_source.go
+++ b/internal/generic/singular_data_source.go
@@ -66,10 +66,9 @@ func newGenericSingularDataSource(provider tfsdk.Provider, singularDataSourceTyp
 }
 
 func (sd *singularDataSource) Read(ctx context.Context, request tfsdk.ReadDataSourceRequest, response *tfsdk.ReadDataSourceResponse) {
-	cfTypeName := sd.dataSourceType.cfTypeName
-	tfTypeName := sd.dataSourceType.tfTypeName
+	ctx = sd.cfnTypeContext(ctx)
 
-	tflog.Debug(ctx, "DataSource.Read enter", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	traceEntry(ctx, "SingularDataSource.Read")
 
 	conn := sd.provider.CloudControlApiClient(ctx)
 
@@ -125,7 +124,7 @@ func (sd *singularDataSource) Read(ctx context.Context, request tfsdk.ReadDataSo
 
 	tflog.Debug(ctx, "Response.State.Raw", "value", hclog.Fmt("%v", response.State.Raw))
 
-	tflog.Debug(ctx, "DataSource.Read exit", "cfTypeName", cfTypeName, "tfTypeName", tfTypeName)
+	traceExit(ctx, "SingularDataSource.Read")
 }
 
 // describe returns the live state of the specified resource.
@@ -154,4 +153,11 @@ func (sd *singularDataSource) setId(ctx context.Context, val string, state *tfsd
 	}
 
 	return nil
+}
+
+// cfnTypeContext injects the CloudFormation type name into logger contexts.
+func (sd *singularDataSource) cfnTypeContext(ctx context.Context) context.Context {
+	ctx = tflog.With(ctx, LoggingKeyCFNType, sd.dataSourceType.cfTypeName)
+
+	return ctx
 }

--- a/internal/generic/translate.go
+++ b/internal/generic/translate.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Translates a Terraform Value to Cloud Control DesiredState.
@@ -235,7 +235,7 @@ func (t toTerraform) valueFromRaw(ctx context.Context, schema *tfsdk.Schema, pat
 			if isObject {
 				attributeName, ok := t.cfToTfNameMap[key]
 				if !ok {
-					log.Printf("[INFO] attribute name mapping not found. key: %s", key)
+					tflog.Info(ctx, "attribute name mapping not found", "key", key)
 					continue
 				}
 				path = path.WithAttributeName(attributeName)
@@ -245,7 +245,7 @@ func (t toTerraform) valueFromRaw(ctx context.Context, schema *tfsdk.Schema, pat
 			val, err := t.valueFromRaw(ctx, schema, path, v)
 			if err != nil {
 				if isObject {
-					log.Printf("[INFO] not found in Terraform schema. key: %s, path: %s, error: %s", key, path, err.Error())
+					tflog.Info(ctx, "not found in Terraform schema", "key", key, "path", path, "error", err.Error())
 					path = path.WithoutLastStep()
 					continue
 				}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -432,7 +431,7 @@ type awsSdkContextLogger struct {
 }
 
 func (l awsSdkLogger) Logf(classification logging.Classification, format string, v ...interface{}) {
-	log.Printf("[%s] [aws-sdk-go-v2] %s", classification, fmt.Sprintf(format, v...))
+	hclog.Default().Info("[%s] [aws-sdk-go-v2] %s", classification, fmt.Sprintf(format, v...))
 }
 
 func (l awsSdkLogger) WithContext(ctx context.Context) logging.Logger {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,9 +11,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/smithy-go/logging"
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-awscc/internal/registry"
 	cctypes "github.com/hashicorp/terraform-provider-awscc/internal/types"
 	"github.com/hashicorp/terraform-provider-awscc/internal/validate"
@@ -425,27 +427,26 @@ func newCloudControlClient(ctx context.Context, pd *providerData) (*cloudcontrol
 }
 
 type awsSdkLogger struct{}
+type awsSdkContextLogger struct {
+	ctx context.Context
+}
 
 func (l awsSdkLogger) Logf(classification logging.Classification, format string, v ...interface{}) {
 	log.Printf("[%s] [aws-sdk-go-v2] %s", classification, fmt.Sprintf(format, v...))
 }
 
-// func (l awsSdkLogger) WithContext(ctx context.Context) logging.Logger {
-// 	return awsSdkContextLogger{ctx: ctx}
-// }
+func (l awsSdkLogger) WithContext(ctx context.Context) logging.Logger {
+	return awsSdkContextLogger{ctx: ctx}
+}
 
-// type awsSdkContextLogger struct {
-// 	ctx context.Context
-// }
-
-// func (l awsSdkContextLogger) Logf(classification logging.Classification, format string, v ...interface{}) {
-// 	switch classification {
-// 	case logging.Warn:
-// 		tflog.Warn(l.ctx, "[aws-sdk-go-v2]", "message", hclog.Fmt(format, v...))
-// 	default:
-// 		tflog.Debug(l.ctx, "[aws-sdk-go-v2]", "message", hclog.Fmt(format, v...))
-// 	}
-// }
+func (l awsSdkContextLogger) Logf(classification logging.Classification, format string, v ...interface{}) {
+	switch classification {
+	case logging.Warn:
+		tflog.Warn(l.ctx, "[aws-sdk-go-v2]", "message", hclog.Fmt(format, v...))
+	default:
+		tflog.Debug(l.ctx, "[aws-sdk-go-v2]", "message", hclog.Fmt(format, v...))
+	}
+}
 
 func userAgentProducts(products []userAgentProduct) []awsbase.UserAgentProduct {
 	results := make([]awsbase.UserAgentProduct, len(products))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -431,7 +431,12 @@ type awsSdkContextLogger struct {
 }
 
 func (l awsSdkLogger) Logf(classification logging.Classification, format string, v ...interface{}) {
-	hclog.Default().Info("[%s] [aws-sdk-go-v2] %s", classification, fmt.Sprintf(format, v...))
+	switch classification {
+	case logging.Warn:
+		hclog.Default().Warn("[aws-sdk-go-v2] %s", fmt.Sprintf(format, v...))
+	default:
+		hclog.Default().Debug("[aws-sdk-go-v2] %s", fmt.Sprintf(format, v...))
+	}
 }
 
 func (l awsSdkLogger) WithContext(ctx context.Context) logging.Logger {

--- a/internal/service/cloudcontrol/delete.go
+++ b/internal/service/cloudcontrol/delete.go
@@ -3,16 +3,16 @@ package cloudcontrol
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-awscc/internal/tfresource"
 )
 
 func DeleteResource(ctx context.Context, conn *cloudcontrol.Client, roleARN, typeName, id string, maxWaitTime time.Duration) error {
-	log.Printf("[DEBUG] DeleteResource. cfTypeName: %s, id: %s", typeName, id)
+	tflog.Debug(ctx, "DeleteResource", "cfTypeName", typeName, "id", id)
 
 	input := &cloudcontrol.DeleteResourceInput{
 		ClientToken: aws.String(tfresource.UniqueId()),

--- a/internal/service/cloudcontrol/find.go
+++ b/internal/service/cloudcontrol/find.go
@@ -3,17 +3,17 @@ package cloudcontrol
 import (
 	"context"
 	"errors"
-	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-awscc/internal/tfresource"
 )
 
 func FindResourceByTypeNameAndID(ctx context.Context, conn *cloudcontrol.Client, roleARN, typeName, id string) (*types.ResourceDescription, error) {
-	log.Printf("[DEBUG] FindResourceByTypeNameAndID. cfTypeName: %s, id: %s", typeName, id)
+	tflog.Debug(ctx, "FindResourceByTypeNameAndID", "cfTypeName", typeName, "id", id)
 
 	input := &cloudcontrol.GetResourceInput{
 		Identifier: aws.String(id),
@@ -43,7 +43,7 @@ func FindResourceByTypeNameAndID(ctx context.Context, conn *cloudcontrol.Client,
 		return nil, &tfresource.NotFoundError{Message: "Empty result"}
 	}
 
-	log.Printf("[DEBUG] ResourceDescription.ResourceModel. value: %s", aws.ToString(output.ResourceDescription.Properties))
+	tflog.Debug(ctx, "ResourceDescription.ResourceModel", "value", aws.ToString(output.ResourceDescription.Properties))
 
 	return output.ResourceDescription, nil
 }

--- a/internal/service/cloudcontrol/list.go
+++ b/internal/service/cloudcontrol/list.go
@@ -2,16 +2,16 @@ package cloudcontrol
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-awscc/internal/tfresource"
 )
 
 func ListResourcesByTypeName(ctx context.Context, conn *cloudcontrol.Client, roleARN, typeName string) ([]types.ResourceDescription, error) {
-	log.Printf("[DEBUG] ListResourcesByTypeName. cfTypeName: %s", typeName)
+	tflog.Debug(ctx, "ListResourcesByTypeName", "cfTypeName", typeName)
 
 	input := &cloudcontrol.ListResourcesInput{
 		TypeName: aws.String(typeName),


### PR DESCRIPTION
This reverts commit 66db1b0bac1e41ba7d7940e8f54d603f66bc1ade.

<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #306.
