### PR TITLE
Return `null` instead of an empty `tftypes.List` when the list is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ FEATURES:
 * **New Data Source:** `awscc_forecast_datasets`
 * **New Resource:** `awscc_forecast_dataset`
 
+BUG FIXES:
+
+* Prevent errors like `planned value ... for a non-computed attribute` for list arguments during `terraform plan` ([#368](https://github.com/hashicorp/terraform-provider-awscc/issues/368))
+
 ## [0.10.0](https://github.com/hashicorp/terraform-provider-awscc/releases/tag/v0.10.0) (January 13, 2022)
 
 FEATURES:

--- a/internal/generic/translate.go
+++ b/internal/generic/translate.go
@@ -200,6 +200,9 @@ func (t toTerraform) valueFromRaw(ctx context.Context, schema *tfsdk.Schema, pat
 	// Complex types.
 	//
 	case []interface{}:
+		if len(v) == 0 {
+			return tftypes.NewValue(typ, nil), nil
+		}
 		var vals []tftypes.Value
 		for idx, v := range v {
 			if typ.Is(tftypes.Set{}) {

--- a/internal/generic/translate_test.go
+++ b/internal/generic/translate_test.go
@@ -241,7 +241,7 @@ func TestTranslateToTerraform(t *testing.T) {
 				"identifier": tftypes.NewValue(tftypes.String, nil),
 				"name":       tftypes.NewValue(tftypes.String, "testing"),
 				"number":     tftypes.NewValue(tftypes.Number, 42),
-				"ports":      tftypes.NewValue(tftypes.List{ElementType: tftypes.Number}, []tftypes.Value{}),
+				"ports":      tftypes.NewValue(tftypes.List{ElementType: tftypes.Number}, nil),
 			}),
 		},
 		{


### PR DESCRIPTION
Empty lists returned by the provider were causing errors on any subsequent state refresh. The state stored a `null` value, whereas the generated plan would return an empty `tftypes.List`. This would cause Terraform to fail with an error like

```
│ Error: Provider produced invalid plan
│ 
│ Provider "registry.terraform.io/hashicorp/awscc" planned an invalid value for awscc_ec2_vpc.test.tags: planned value
│ cty.ListValEmpty(cty.Object(map[string]cty.Type{"key":cty.String, "value":cty.String})) for a non-computed attribute.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

This PR short-circuits the empty list case to return a `null` value of the list type instead of an empty list. This allows Terraform to continue and encounter behaviour such as seen in #301, where default values are not handled as expected because fields that should have default values or be computed are not marked as such in the Cloud Control schemas.

Terraform configuration

```terraform
terraform {
  required_providers {
    awscc = {
      source  = "hashicorp/awscc"
    }
  }
}

provider "awscc" {
  region = "us-west-2"
}

resource "awscc_ec2_vpc" "test" {
  cidr_block = "10.0.0.0/16"
}
```

Before the update, running `terraform apply` and then `terraform plan` results in the error above.

After the update, the `terraform plan` succeeds, but shows the following diff

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # awscc_ec2_vpc.test has changed
  ~ resource "awscc_ec2_vpc" "test" {
      + enable_dns_hostnames    = false
      + enable_dns_support      = true
        id                      = "vpc-056c110e94f3ed041"
      + instance_tenancy        = "default"
        # (5 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to
undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # awscc_ec2_vpc.test will be updated in-place
  ~ resource "awscc_ec2_vpc" "test" {
      - enable_dns_hostnames    = false -> null
      - enable_dns_support      = true -> null
        id                      = "vpc-056c110e94f3ed041"
      - instance_tenancy        = "default" -> null
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Note that a second `terraform apply` still results in the error as reported in #301.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #342
Closes #351
Closes #324