### PR TITLE
Use Framework `Int64` and `Float64` types instead of `Number` where possible

### DIFF
--- a/internal/aws/acmpca/certificate_authority_resource_gen.go
+++ b/internal/aws/acmpca/certificate_authority_resource_gen.go
@@ -635,7 +635,7 @@ func certificateAuthorityResourceType(ctx context.Context) (tfsdk.ResourceType, 
 								},
 								"expiration_in_days": {
 									// Property: ExpirationInDays
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"s3_bucket_name": {

--- a/internal/aws/acmpca/certificate_authority_singular_data_source_gen.go
+++ b/internal/aws/acmpca/certificate_authority_singular_data_source_gen.go
@@ -571,7 +571,7 @@ func certificateAuthorityDataSourceType(ctx context.Context) (tfsdk.DataSourceTy
 								},
 								"expiration_in_days": {
 									// Property: ExpirationInDays
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"s3_bucket_name": {

--- a/internal/aws/acmpca/certificate_resource_gen.go
+++ b/internal/aws/acmpca/certificate_resource_gen.go
@@ -848,7 +848,7 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"value": {
 						// Property: Value
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Required: true,
 					},
 				},
@@ -888,7 +888,7 @@ func certificateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"value": {
 						// Property: Value
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Required: true,
 					},
 				},

--- a/internal/aws/acmpca/certificate_singular_data_source_gen.go
+++ b/internal/aws/acmpca/certificate_singular_data_source_gen.go
@@ -772,7 +772,7 @@ func certificateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					},
 					"value": {
 						// Property: Value
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 				},
@@ -809,7 +809,7 @@ func certificateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					},
 					"value": {
 						// Property: Value
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/apigateway/authorizer_resource_gen.go
+++ b/internal/aws/apigateway/authorizer_resource_gen.go
@@ -61,7 +61,7 @@ func authorizerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The TTL in seconds of cached authorizer results.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"authorizer_uri": {

--- a/internal/aws/apigateway/authorizer_singular_data_source_gen.go
+++ b/internal/aws/apigateway/authorizer_singular_data_source_gen.go
@@ -58,7 +58,7 @@ func authorizerDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The TTL in seconds of cached authorizer results.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"authorizer_uri": {

--- a/internal/aws/apigateway/deployment_resource_gen.go
+++ b/internal/aws/apigateway/deployment_resource_gen.go
@@ -53,7 +53,7 @@ func deploymentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"percent_traffic": {
 						// Property: PercentTraffic
 						Description: "The percentage (0-100) of traffic diverted to a canary deployment.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 					},
 					"stage_variable_overrides": {
@@ -355,7 +355,7 @@ func deploymentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"cache_ttl_in_seconds": {
 						// Property: CacheTtlInSeconds
 						Description: "The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches responses. ",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"caching_enabled": {
@@ -372,7 +372,7 @@ func deploymentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"percent_traffic": {
 									// Property: PercentTraffic
 									Description: "The percent (0-100) of traffic diverted to a canary deployment.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Optional:    true,
 								},
 								"stage_variable_overrides": {
@@ -436,7 +436,7 @@ func deploymentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"cache_ttl_in_seconds": {
 									// Property: CacheTtlInSeconds
 									Description: "The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches responses. ",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"caching_enabled": {
@@ -478,13 +478,13 @@ func deploymentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"throttling_burst_limit": {
 									// Property: ThrottlingBurstLimit
 									Description: "The number of burst requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"throttling_rate_limit": {
 									// Property: ThrottlingRateLimit
 									Description: "The number of steady-state requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Optional:    true,
 								},
 							},
@@ -526,13 +526,13 @@ func deploymentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"throttling_burst_limit": {
 						// Property: ThrottlingBurstLimit
 						Description: "The number of burst requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"throttling_rate_limit": {
 						// Property: ThrottlingRateLimit
 						Description: "The number of steady-state requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 					},
 					"tracing_enabled": {

--- a/internal/aws/apigateway/deployment_singular_data_source_gen.go
+++ b/internal/aws/apigateway/deployment_singular_data_source_gen.go
@@ -53,7 +53,7 @@ func deploymentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"percent_traffic": {
 						// Property: PercentTraffic
 						Description: "The percentage (0-100) of traffic diverted to a canary deployment.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"stage_variable_overrides": {
@@ -343,7 +343,7 @@ func deploymentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"cache_ttl_in_seconds": {
 						// Property: CacheTtlInSeconds
 						Description: "The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches responses. ",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"caching_enabled": {
@@ -360,7 +360,7 @@ func deploymentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"percent_traffic": {
 									// Property: PercentTraffic
 									Description: "The percent (0-100) of traffic diverted to a canary deployment.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 								"stage_variable_overrides": {
@@ -424,7 +424,7 @@ func deploymentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"cache_ttl_in_seconds": {
 									// Property: CacheTtlInSeconds
 									Description: "The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches responses. ",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"caching_enabled": {
@@ -466,13 +466,13 @@ func deploymentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"throttling_burst_limit": {
 									// Property: ThrottlingBurstLimit
 									Description: "The number of burst requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"throttling_rate_limit": {
 									// Property: ThrottlingRateLimit
 									Description: "The number of steady-state requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -511,13 +511,13 @@ func deploymentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"throttling_burst_limit": {
 						// Property: ThrottlingBurstLimit
 						Description: "The number of burst requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"throttling_rate_limit": {
 						// Property: ThrottlingRateLimit
 						Description: "The number of steady-state requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"tracing_enabled": {

--- a/internal/aws/apigateway/method_resource_gen.go
+++ b/internal/aws/apigateway/method_resource_gen.go
@@ -389,7 +389,7 @@ func methodResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"timeout_in_millis": {
 						// Property: TimeoutInMillis
 						Description: "Custom timeout between 50 and 29,000 milliseconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(50, 29000),

--- a/internal/aws/apigateway/method_singular_data_source_gen.go
+++ b/internal/aws/apigateway/method_singular_data_source_gen.go
@@ -346,7 +346,7 @@ func methodDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"timeout_in_millis": {
 						// Property: TimeoutInMillis
 						Description: "Custom timeout between 50 and 29,000 milliseconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"type": {

--- a/internal/aws/apigateway/stage_resource_gen.go
+++ b/internal/aws/apigateway/stage_resource_gen.go
@@ -125,7 +125,7 @@ func stageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"percent_traffic": {
 						// Property: PercentTraffic
 						Description: "The percentage (0-100) of traffic diverted to a canary deployment.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 100.000000),
@@ -262,7 +262,7 @@ func stageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"cache_ttl_in_seconds": {
 						// Property: CacheTtlInSeconds
 						Description: "The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches responses.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"caching_enabled": {
@@ -304,7 +304,7 @@ func stageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"throttling_burst_limit": {
 						// Property: ThrottlingBurstLimit
 						Description: "The number of burst requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -313,7 +313,7 @@ func stageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"throttling_rate_limit": {
 						// Property: ThrottlingRateLimit
 						Description: "The number of steady-state requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatAtLeast(0.000000),

--- a/internal/aws/apigateway/stage_singular_data_source_gen.go
+++ b/internal/aws/apigateway/stage_singular_data_source_gen.go
@@ -124,7 +124,7 @@ func stageDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"percent_traffic": {
 						// Property: PercentTraffic
 						Description: "The percentage (0-100) of traffic diverted to a canary deployment.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"stage_variable_overrides": {
@@ -258,7 +258,7 @@ func stageDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"cache_ttl_in_seconds": {
 						// Property: CacheTtlInSeconds
 						Description: "The time-to-live (TTL) period, in seconds, that specifies how long API Gateway caches responses.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"caching_enabled": {
@@ -300,13 +300,13 @@ func stageDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"throttling_burst_limit": {
 						// Property: ThrottlingBurstLimit
 						Description: "The number of burst requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"throttling_rate_limit": {
 						// Property: ThrottlingRateLimit
 						Description: "The number of steady-state requests per second that API Gateway permits across all APIs, stages, and methods in your AWS account.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/apigateway/usage_plan_resource_gen.go
+++ b/internal/aws/apigateway/usage_plan_resource_gen.go
@@ -89,7 +89,7 @@ func usagePlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"burst_limit": {
 									// Property: BurstLimit
 									Description: "The maximum API request rate limit over a time ranging from one to a few seconds. The maximum API request rate limit depends on whether the underlying token bucket is at its full capacity.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(0),
@@ -98,7 +98,7 @@ func usagePlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"rate_limit": {
 									// Property: RateLimit
 									Description: "The API request steady-state rate limit (average requests per second over an extended period of time).",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatAtLeast(0.000000),
@@ -172,7 +172,7 @@ func usagePlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"limit": {
 						// Property: Limit
 						Description: "The maximum number of requests that users can make within the specified time period.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -181,7 +181,7 @@ func usagePlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"offset": {
 						// Property: Offset
 						Description: "For the initial time period, the number of requests to subtract from the specified limit. When you first implement a usage plan, the plan might start in the middle of the week or month. With this property, you can decrease the limit for this initial time period.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -283,7 +283,7 @@ func usagePlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"burst_limit": {
 						// Property: BurstLimit
 						Description: "The maximum API request rate limit over a time ranging from one to a few seconds. The maximum API request rate limit depends on whether the underlying token bucket is at its full capacity.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -292,7 +292,7 @@ func usagePlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"rate_limit": {
 						// Property: RateLimit
 						Description: "The API request steady-state rate limit (average requests per second over an extended period of time).",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatAtLeast(0.000000),

--- a/internal/aws/apigateway/usage_plan_singular_data_source_gen.go
+++ b/internal/aws/apigateway/usage_plan_singular_data_source_gen.go
@@ -88,13 +88,13 @@ func usagePlanDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 								"burst_limit": {
 									// Property: BurstLimit
 									Description: "The maximum API request rate limit over a time ranging from one to a few seconds. The maximum API request rate limit depends on whether the underlying token bucket is at its full capacity.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"rate_limit": {
 									// Property: RateLimit
 									Description: "The API request steady-state rate limit (average requests per second over an extended period of time).",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -159,13 +159,13 @@ func usagePlanDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					"limit": {
 						// Property: Limit
 						Description: "The maximum number of requests that users can make within the specified time period.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"offset": {
 						// Property: Offset
 						Description: "For the initial time period, the number of requests to subtract from the specified limit. When you first implement a usage plan, the plan might start in the middle of the week or month. With this property, you can decrease the limit for this initial time period.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"period": {
@@ -255,13 +255,13 @@ func usagePlanDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					"burst_limit": {
 						// Property: BurstLimit
 						Description: "The maximum API request rate limit over a time ranging from one to a few seconds. The maximum API request rate limit depends on whether the underlying token bucket is at its full capacity.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"rate_limit": {
 						// Property: RateLimit
 						Description: "The API request steady-state rate limit (average requests per second over an extended period of time).",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/appflow/connector_profile_resource_gen.go
+++ b/internal/aws/appflow/connector_profile_resource_gen.go
@@ -1655,7 +1655,7 @@ func connectorProfileResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 											},
 											"port_number": {
 												// Property: PortNumber
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 65535),

--- a/internal/aws/appflow/connector_profile_singular_data_source_gen.go
+++ b/internal/aws/appflow/connector_profile_singular_data_source_gen.go
@@ -1476,7 +1476,7 @@ func connectorProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 											},
 											"port_number": {
 												// Property: PortNumber
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"private_link_service_name": {

--- a/internal/aws/appflow/flow_resource_gen.go
+++ b/internal/aws/appflow/flow_resource_gen.go
@@ -2739,7 +2739,7 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"schedule_end_time": {
 									// Property: ScheduleEndTime
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 								"schedule_expression": {
@@ -2752,7 +2752,7 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"schedule_offset": {
 									// Property: ScheduleOffset
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(0.000000, 36000.000000),
@@ -2760,7 +2760,7 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"schedule_start_time": {
 									// Property: ScheduleStartTime
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 								"time_zone": {

--- a/internal/aws/appflow/flow_singular_data_source_gen.go
+++ b/internal/aws/appflow/flow_singular_data_source_gen.go
@@ -2127,7 +2127,7 @@ func flowDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"schedule_end_time": {
 									// Property: ScheduleEndTime
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"schedule_expression": {
@@ -2137,12 +2137,12 @@ func flowDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"schedule_offset": {
 									// Property: ScheduleOffset
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"schedule_start_time": {
 									// Property: ScheduleStartTime
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"time_zone": {

--- a/internal/aws/applicationinsights/application_resource_gen.go
+++ b/internal/aws/applicationinsights/application_resource_gen.go
@@ -1926,7 +1926,7 @@ func applicationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"rank": {
 									// Property: Rank
 									Description: "Rank of the log pattern.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 								},
 							},

--- a/internal/aws/applicationinsights/application_singular_data_source_gen.go
+++ b/internal/aws/applicationinsights/application_singular_data_source_gen.go
@@ -1702,7 +1702,7 @@ func applicationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 								"rank": {
 									// Property: Rank
 									Description: "Rank of the log pattern.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},

--- a/internal/aws/apprunner/service_resource_gen.go
+++ b/internal/aws/apprunner/service_resource_gen.go
@@ -129,7 +129,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"healthy_threshold": {
 						// Property: HealthyThreshold
 						Description: "Health check Healthy Threshold",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 20),
@@ -138,7 +138,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"interval": {
 						// Property: Interval
 						Description: "Health check Interval",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"path": {
@@ -162,7 +162,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"timeout": {
 						// Property: Timeout
 						Description: "Health check Timeout",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 20),
@@ -171,7 +171,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"unhealthy_threshold": {
 						// Property: UnhealthyThreshold
 						Description: "Health check Unhealthy Threshold",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 20),

--- a/internal/aws/apprunner/service_singular_data_source_gen.go
+++ b/internal/aws/apprunner/service_singular_data_source_gen.go
@@ -116,13 +116,13 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"healthy_threshold": {
 						// Property: HealthyThreshold
 						Description: "Health check Healthy Threshold",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"interval": {
 						// Property: Interval
 						Description: "Health check Interval",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"path": {
@@ -140,13 +140,13 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"timeout": {
 						// Property: Timeout
 						Description: "Health check Timeout",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"unhealthy_threshold": {
 						// Property: UnhealthyThreshold
 						Description: "Health check Unhealthy Threshold",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/appstream/app_block_resource_gen.go
+++ b/internal/aws/appstream/app_block_resource_gen.go
@@ -154,7 +154,7 @@ func appBlockResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"timeout_in_seconds": {
 						// Property: TimeoutInSeconds
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Required: true,
 					},
 				},

--- a/internal/aws/appstream/app_block_singular_data_source_gen.go
+++ b/internal/aws/appstream/app_block_singular_data_source_gen.go
@@ -135,7 +135,7 @@ func appBlockDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"timeout_in_seconds": {
 						// Property: TimeoutInSeconds
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/athena/work_group_resource_gen.go
+++ b/internal/aws/athena/work_group_resource_gen.go
@@ -235,7 +235,7 @@ func workGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"bytes_scanned_cutoff_per_query": {
 						// Property: BytesScannedCutoffPerQuery
 						Description: "The upper data usage limit (cutoff) for the amount of bytes a single query in a workgroup is allowed to scan.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(10000000),
@@ -423,7 +423,7 @@ func workGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"bytes_scanned_cutoff_per_query": {
 						// Property: BytesScannedCutoffPerQuery
 						Description: "The upper data usage limit (cutoff) for the amount of bytes a single query in a workgroup is allowed to scan.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(10000000),

--- a/internal/aws/athena/work_group_singular_data_source_gen.go
+++ b/internal/aws/athena/work_group_singular_data_source_gen.go
@@ -210,7 +210,7 @@ func workGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					"bytes_scanned_cutoff_per_query": {
 						// Property: BytesScannedCutoffPerQuery
 						Description: "The upper data usage limit (cutoff) for the amount of bytes a single query in a workgroup is allowed to scan.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"enforce_work_group_configuration": {
@@ -385,7 +385,7 @@ func workGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					"bytes_scanned_cutoff_per_query": {
 						// Property: BytesScannedCutoffPerQuery
 						Description: "The upper data usage limit (cutoff) for the amount of bytes a single query in a workgroup is allowed to scan.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"enforce_work_group_configuration": {

--- a/internal/aws/auditmanager/assessment_resource_gen.go
+++ b/internal/aws/auditmanager/assessment_resource_gen.go
@@ -175,7 +175,7 @@ func assessmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "The sequence of characters that identifies when the event occurred.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),
@@ -316,7 +316,7 @@ func assessmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"creation_time": {
 						// Property: CreationTime
 						Description: "The sequence of characters that identifies when the event occurred.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 					},
 					"id": {
@@ -330,7 +330,7 @@ func assessmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"last_updated": {
 						// Property: LastUpdated
 						Description: "The sequence of characters that identifies when the event occurred.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 					},
 					"role_arn": {

--- a/internal/aws/auditmanager/assessment_singular_data_source_gen.go
+++ b/internal/aws/auditmanager/assessment_singular_data_source_gen.go
@@ -149,7 +149,7 @@ func assessmentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "number"
 			// }
 			Description: "The sequence of characters that identifies when the event occurred.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"delegations": {
@@ -272,7 +272,7 @@ func assessmentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"creation_time": {
 						// Property: CreationTime
 						Description: "The sequence of characters that identifies when the event occurred.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"id": {
@@ -283,7 +283,7 @@ func assessmentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"last_updated": {
 						// Property: LastUpdated
 						Description: "The sequence of characters that identifies when the event occurred.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"role_arn": {

--- a/internal/aws/autoscaling/launch_configuration_resource_gen.go
+++ b/internal/aws/autoscaling/launch_configuration_resource_gen.go
@@ -131,7 +131,7 @@ func launchConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, e
 								"iops": {
 									// Property: Iops
 									Description: "The number of input/output (I/O) operations per second (IOPS) to provision for the volume. ",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"snapshot_id": {
@@ -143,13 +143,13 @@ func launchConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, e
 								"throughput": {
 									// Property: Throughput
 									Description: "The throughput (MiBps) to provision for a gp3 volume.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"volume_size": {
 									// Property: VolumeSize
 									Description: "The volume size, in GiBs.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"volume_type": {
@@ -400,7 +400,7 @@ func launchConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType, e
 					"http_put_response_hop_limit": {
 						// Property: HttpPutResponseHopLimit
 						Description: "The desired HTTP PUT response hop limit for instance metadata requests.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"http_tokens": {

--- a/internal/aws/autoscaling/launch_configuration_singular_data_source_gen.go
+++ b/internal/aws/autoscaling/launch_configuration_singular_data_source_gen.go
@@ -125,7 +125,7 @@ func launchConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSourceTyp
 								"iops": {
 									// Property: Iops
 									Description: "The number of input/output (I/O) operations per second (IOPS) to provision for the volume. ",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"snapshot_id": {
@@ -137,13 +137,13 @@ func launchConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSourceTyp
 								"throughput": {
 									// Property: Throughput
 									Description: "The throughput (MiBps) to provision for a gp3 volume.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"volume_size": {
 									// Property: VolumeSize
 									Description: "The volume size, in GiBs.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"volume_type": {
@@ -334,7 +334,7 @@ func launchConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSourceTyp
 					"http_put_response_hop_limit": {
 						// Property: HttpPutResponseHopLimit
 						Description: "The desired HTTP PUT response hop limit for instance metadata requests.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"http_tokens": {

--- a/internal/aws/autoscaling/lifecycle_hook_resource_gen.go
+++ b/internal/aws/autoscaling/lifecycle_hook_resource_gen.go
@@ -53,7 +53,7 @@ func lifecycleHookResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			//   "type": "integer"
 			// }
 			Description: "The maximum time, in seconds, that can elapse before the lifecycle hook times out. The range is from 30 to 7200 seconds. The default value is 3600 seconds (1 hour). If the lifecycle hook times out, Amazon EC2 Auto Scaling performs the action that you specified in the DefaultResult property.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"lifecycle_hook_name": {

--- a/internal/aws/autoscaling/lifecycle_hook_singular_data_source_gen.go
+++ b/internal/aws/autoscaling/lifecycle_hook_singular_data_source_gen.go
@@ -49,7 +49,7 @@ func lifecycleHookDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 			//   "type": "integer"
 			// }
 			Description: "The maximum time, in seconds, that can elapse before the lifecycle hook times out. The range is from 30 to 7200 seconds. The default value is 3600 seconds (1 hour). If the lifecycle hook times out, Amazon EC2 Auto Scaling performs the action that you specified in the DefaultResult property.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"lifecycle_hook_name": {

--- a/internal/aws/autoscaling/warm_pool_resource_gen.go
+++ b/internal/aws/autoscaling/warm_pool_resource_gen.go
@@ -60,7 +60,7 @@ func warmPoolResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 		},
 		"min_size": {
@@ -69,7 +69,7 @@ func warmPoolResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 		},
 		"pool_state": {

--- a/internal/aws/autoscaling/warm_pool_singular_data_source_gen.go
+++ b/internal/aws/autoscaling/warm_pool_singular_data_source_gen.go
@@ -57,7 +57,7 @@ func warmPoolDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"min_size": {
@@ -66,7 +66,7 @@ func warmPoolDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"pool_state": {

--- a/internal/aws/backup/backup_plan_resource_gen.go
+++ b/internal/aws/backup/backup_plan_resource_gen.go
@@ -168,7 +168,7 @@ func backupPlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"completion_window_minutes": {
 									// Property: CompletionWindowMinutes
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 								"copy_actions": {
@@ -186,12 +186,12 @@ func backupPlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"delete_after_days": {
 															// Property: DeleteAfterDays
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 														"move_to_cold_storage_after_days": {
 															// Property: MoveToColdStorageAfterDays
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 													},
@@ -214,12 +214,12 @@ func backupPlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"delete_after_days": {
 												// Property: DeleteAfterDays
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Optional: true,
 											},
 											"move_to_cold_storage_after_days": {
 												// Property: MoveToColdStorageAfterDays
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Optional: true,
 											},
 										},
@@ -244,7 +244,7 @@ func backupPlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"start_window_minutes": {
 									// Property: StartWindowMinutes
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 								"target_backup_vault": {

--- a/internal/aws/backup/backup_plan_singular_data_source_gen.go
+++ b/internal/aws/backup/backup_plan_singular_data_source_gen.go
@@ -168,7 +168,7 @@ func backupPlanDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 							map[string]tfsdk.Attribute{
 								"completion_window_minutes": {
 									// Property: CompletionWindowMinutes
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"copy_actions": {
@@ -186,12 +186,12 @@ func backupPlanDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 													map[string]tfsdk.Attribute{
 														"delete_after_days": {
 															// Property: DeleteAfterDays
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 														"move_to_cold_storage_after_days": {
 															// Property: MoveToColdStorageAfterDays
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 													},
@@ -214,12 +214,12 @@ func backupPlanDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 										map[string]tfsdk.Attribute{
 											"delete_after_days": {
 												// Property: DeleteAfterDays
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Computed: true,
 											},
 											"move_to_cold_storage_after_days": {
 												// Property: MoveToColdStorageAfterDays
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Computed: true,
 											},
 										},
@@ -244,7 +244,7 @@ func backupPlanDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								},
 								"start_window_minutes": {
 									// Property: StartWindowMinutes
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"target_backup_vault": {

--- a/internal/aws/backup/backup_vault_resource_gen.go
+++ b/internal/aws/backup/backup_vault_resource_gen.go
@@ -108,17 +108,17 @@ func backupVaultResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				map[string]tfsdk.Attribute{
 					"changeable_for_days": {
 						// Property: ChangeableForDays
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Optional: true,
 					},
 					"max_retention_days": {
 						// Property: MaxRetentionDays
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Optional: true,
 					},
 					"min_retention_days": {
 						// Property: MinRetentionDays
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Required: true,
 					},
 				},

--- a/internal/aws/backup/backup_vault_singular_data_source_gen.go
+++ b/internal/aws/backup/backup_vault_singular_data_source_gen.go
@@ -97,17 +97,17 @@ func backupVaultDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 				map[string]tfsdk.Attribute{
 					"changeable_for_days": {
 						// Property: ChangeableForDays
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"max_retention_days": {
 						// Property: MaxRetentionDays
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"min_retention_days": {
 						// Property: MinRetentionDays
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/backup/framework_resource_gen.go
+++ b/internal/aws/backup/framework_resource_gen.go
@@ -28,7 +28,7 @@ func frameworkResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "The date and time that a framework is created, in Unix format and Coordinated Universal Time (UTC). The value of `CreationTime` is accurate to milliseconds. For example, the value 1516925490.087 represents Friday, January 26, 2018 12:11:30.087 AM.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/backup/framework_singular_data_source_gen.go
+++ b/internal/aws/backup/framework_singular_data_source_gen.go
@@ -27,7 +27,7 @@ func frameworkDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 			//   "type": "number"
 			// }
 			Description: "The date and time that a framework is created, in Unix format and Coordinated Universal Time (UTC). The value of `CreationTime` is accurate to milliseconds. For example, the value 1516925490.087 represents Friday, January 26, 2018 12:11:30.087 AM.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"deployment_status": {

--- a/internal/aws/batch/scheduling_policy_resource_gen.go
+++ b/internal/aws/batch/scheduling_policy_resource_gen.go
@@ -78,7 +78,7 @@ func schedulingPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 				map[string]tfsdk.Attribute{
 					"compute_reservation": {
 						// Property: ComputeReservation
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 99.000000),
@@ -86,7 +86,7 @@ func schedulingPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 					},
 					"share_decay_seconds": {
 						// Property: ShareDecaySeconds
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 604800.000000),
@@ -104,7 +104,7 @@ func schedulingPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 								},
 								"weight_factor": {
 									// Property: WeightFactor
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(0.000000, 1000.000000),

--- a/internal/aws/batch/scheduling_policy_singular_data_source_gen.go
+++ b/internal/aws/batch/scheduling_policy_singular_data_source_gen.go
@@ -74,12 +74,12 @@ func schedulingPolicyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 				map[string]tfsdk.Attribute{
 					"compute_reservation": {
 						// Property: ComputeReservation
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"share_decay_seconds": {
 						// Property: ShareDecaySeconds
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"share_distribution": {
@@ -94,7 +94,7 @@ func schedulingPolicyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 								},
 								"weight_factor": {
 									// Property: WeightFactor
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 							},

--- a/internal/aws/budgets/budgets_action_resource_gen.go
+++ b/internal/aws/budgets/budgets_action_resource_gen.go
@@ -70,7 +70,7 @@ func budgetsActionResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					},
 					"value": {
 						// Property: Value
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Required: true,
 					},
 				},

--- a/internal/aws/budgets/budgets_action_singular_data_source_gen.go
+++ b/internal/aws/budgets/budgets_action_singular_data_source_gen.go
@@ -60,7 +60,7 @@ func budgetsActionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 					},
 					"value": {
 						// Property: Value
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/cassandra/table_resource_gen.go
+++ b/internal/aws/cassandra/table_resource_gen.go
@@ -86,7 +86,7 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"read_capacity_units": {
 									// Property: ReadCapacityUnits
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -94,7 +94,7 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"write_capacity_units": {
 									// Property: WriteCapacityUnits
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -210,7 +210,7 @@ func tableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Default TTL (Time To Live) in seconds, where zero is disabled. If the value is greater than zero, TTL is enabled for the entire table and an expiration timestamp is added to each column.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(0),

--- a/internal/aws/cassandra/table_singular_data_source_gen.go
+++ b/internal/aws/cassandra/table_singular_data_source_gen.go
@@ -74,12 +74,12 @@ func tableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 							map[string]tfsdk.Attribute{
 								"read_capacity_units": {
 									// Property: ReadCapacityUnits
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"write_capacity_units": {
 									// Property: WriteCapacityUnits
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -173,7 +173,7 @@ func tableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Default TTL (Time To Live) in seconds, where zero is disabled. If the value is greater than zero, TTL is enabled for the entire table and an expiration timestamp is added to each column.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"encryption_specification": {

--- a/internal/aws/ce/anomaly_monitor_resource_gen.go
+++ b/internal/aws/ce/anomaly_monitor_resource_gen.go
@@ -46,7 +46,7 @@ func anomalyMonitorResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The value for evaluated dimensions.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/ce/anomaly_monitor_singular_data_source_gen.go
+++ b/internal/aws/ce/anomaly_monitor_singular_data_source_gen.go
@@ -42,7 +42,7 @@ func anomalyMonitorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "The value for evaluated dimensions.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"last_evaluated_date": {

--- a/internal/aws/ce/anomaly_subscription_resource_gen.go
+++ b/internal/aws/ce/anomaly_subscription_resource_gen.go
@@ -194,7 +194,7 @@ func anomalySubscriptionResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			//   "type": "number"
 			// }
 			Description: "The dollar value that triggers a notification if the threshold is exceeded. ",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Required:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.FloatAtLeast(0.000000),

--- a/internal/aws/ce/anomaly_subscription_singular_data_source_gen.go
+++ b/internal/aws/ce/anomaly_subscription_singular_data_source_gen.go
@@ -159,7 +159,7 @@ func anomalySubscriptionDataSourceType(ctx context.Context) (tfsdk.DataSourceTyp
 			//   "type": "number"
 			// }
 			Description: "The dollar value that triggers a notification if the threshold is exceeded. ",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 	}

--- a/internal/aws/certificatemanager/account_resource_gen.go
+++ b/internal/aws/certificatemanager/account_resource_gen.go
@@ -50,7 +50,7 @@ func accountResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				map[string]tfsdk.Attribute{
 					"days_before_expiry": {
 						// Property: DaysBeforeExpiry
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 45),

--- a/internal/aws/certificatemanager/account_singular_data_source_gen.go
+++ b/internal/aws/certificatemanager/account_singular_data_source_gen.go
@@ -46,7 +46,7 @@ func accountDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 				map[string]tfsdk.Attribute{
 					"days_before_expiry": {
 						// Property: DaysBeforeExpiry
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/cloudformation/stack_set_resource_gen.go
+++ b/internal/aws/cloudformation/stack_set_resource_gen.go
@@ -230,7 +230,7 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				map[string]tfsdk.Attribute{
 					"failure_tolerance_count": {
 						// Property: FailureToleranceCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -238,7 +238,7 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"failure_tolerance_percentage": {
 						// Property: FailureTolerancePercentage
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 100),
@@ -246,7 +246,7 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"max_concurrent_count": {
 						// Property: MaxConcurrentCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(1),
@@ -254,7 +254,7 @@ func stackSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"max_concurrent_percentage": {
 						// Property: MaxConcurrentPercentage
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 100),

--- a/internal/aws/cloudformation/stack_set_singular_data_source_gen.go
+++ b/internal/aws/cloudformation/stack_set_singular_data_source_gen.go
@@ -206,22 +206,22 @@ func stackSetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 				map[string]tfsdk.Attribute{
 					"failure_tolerance_count": {
 						// Property: FailureToleranceCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"failure_tolerance_percentage": {
 						// Property: FailureTolerancePercentage
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"max_concurrent_count": {
 						// Property: MaxConcurrentCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"max_concurrent_percentage": {
 						// Property: MaxConcurrentPercentage
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"region_concurrency_type": {

--- a/internal/aws/cloudfront/cache_policy_resource_gen.go
+++ b/internal/aws/cloudfront/cache_policy_resource_gen.go
@@ -141,7 +141,7 @@ func cachePolicyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"default_ttl": {
 						// Property: DefaultTTL
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Required: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatAtLeast(0.000000),
@@ -149,7 +149,7 @@ func cachePolicyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"max_ttl": {
 						// Property: MaxTTL
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Required: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatAtLeast(0.000000),
@@ -157,7 +157,7 @@ func cachePolicyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"min_ttl": {
 						// Property: MinTTL
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Required: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatAtLeast(0.000000),

--- a/internal/aws/cloudfront/cache_policy_singular_data_source_gen.go
+++ b/internal/aws/cloudfront/cache_policy_singular_data_source_gen.go
@@ -140,17 +140,17 @@ func cachePolicyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					},
 					"default_ttl": {
 						// Property: DefaultTTL
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"max_ttl": {
 						// Property: MaxTTL
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"min_ttl": {
 						// Property: MinTTL
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"name": {

--- a/internal/aws/cloudfront/distribution_resource_gen.go
+++ b/internal/aws/cloudfront/distribution_resource_gen.go
@@ -4,7 +4,6 @@ package cloudfront
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -836,11 +835,11 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"default_ttl": {
 									// Property: DefaultTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(86400.000000)}),
+										DefaultValue(types.Float64{Value: 86400.000000}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
@@ -953,21 +952,21 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"max_ttl": {
 									// Property: MaxTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(31536000.000000)}),
+										DefaultValue(types.Float64{Value: 31536000.000000}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
 								"min_ttl": {
 									// Property: MinTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(0.000000)}),
+										DefaultValue(types.Float64{Value: 0.000000}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
@@ -1042,22 +1041,22 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"error_caching_min_ttl": {
 									// Property: ErrorCachingMinTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(300.000000)}),
+										DefaultValue(types.Float64{Value: 300.000000}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
 								"error_code": {
 									// Property: ErrorCode
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 								},
 								"response_code": {
 									// Property: ResponseCode
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"response_page_path": {
@@ -1081,21 +1080,21 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"http_port": {
 									// Property: HTTPPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(80)}),
+										DefaultValue(types.Int64{Value: 80}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
 								"https_port": {
 									// Property: HTTPSPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(443)}),
+										DefaultValue(types.Int64{Value: 443}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
@@ -1165,11 +1164,11 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"default_ttl": {
 									// Property: DefaultTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(86400.000000)}),
+										DefaultValue(types.Float64{Value: 86400.000000}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
@@ -1282,21 +1281,21 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"max_ttl": {
 									// Property: MaxTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(31536000.000000)}),
+										DefaultValue(types.Float64{Value: 31536000.000000}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
 								"min_ttl": {
 									// Property: MinTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Computed: true,
 									PlanModifiers: []tfsdk.AttributePlanModifier{
-										DefaultValue(types.Number{Value: big.NewFloat(0.000000)}),
+										DefaultValue(types.Float64{Value: 0.000000}),
 										tfsdk.UseStateForUnknown(),
 									},
 								},
@@ -1445,12 +1444,12 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"items": {
 																		// Property: Items
-																		Type:     types.ListType{ElemType: types.NumberType},
+																		Type:     types.ListType{ElemType: types.Int64Type},
 																		Required: true,
 																	},
 																	"quantity": {
 																		// Property: Quantity
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Required: true,
 																	},
 																},
@@ -1486,7 +1485,7 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"quantity": {
 															// Property: Quantity
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Required: true,
 														},
 													},
@@ -1500,7 +1499,7 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"quantity": {
 									// Property: Quantity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 								},
 							},
@@ -1513,12 +1512,12 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"connection_attempts": {
 									// Property: ConnectionAttempts
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"connection_timeout": {
 									// Property: ConnectionTimeout
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"custom_origin_config": {
@@ -1527,31 +1526,31 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"http_port": {
 												// Property: HTTPPort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Computed: true,
 												PlanModifiers: []tfsdk.AttributePlanModifier{
-													DefaultValue(types.Number{Value: big.NewFloat(80)}),
+													DefaultValue(types.Int64{Value: 80}),
 													tfsdk.UseStateForUnknown(),
 												},
 											},
 											"https_port": {
 												// Property: HTTPSPort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Computed: true,
 												PlanModifiers: []tfsdk.AttributePlanModifier{
-													DefaultValue(types.Number{Value: big.NewFloat(443)}),
+													DefaultValue(types.Int64{Value: 443}),
 													tfsdk.UseStateForUnknown(),
 												},
 											},
 											"origin_keepalive_timeout": {
 												// Property: OriginKeepaliveTimeout
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Computed: true,
 												PlanModifiers: []tfsdk.AttributePlanModifier{
-													DefaultValue(types.Number{Value: big.NewFloat(5)}),
+													DefaultValue(types.Int64{Value: 5}),
 													tfsdk.UseStateForUnknown(),
 												},
 											},
@@ -1562,11 +1561,11 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"origin_read_timeout": {
 												// Property: OriginReadTimeout
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Computed: true,
 												PlanModifiers: []tfsdk.AttributePlanModifier{
-													DefaultValue(types.Number{Value: big.NewFloat(30)}),
+													DefaultValue(types.Int64{Value: 30}),
 													tfsdk.UseStateForUnknown(),
 												},
 											},

--- a/internal/aws/cloudfront/distribution_singular_data_source_gen.go
+++ b/internal/aws/cloudfront/distribution_singular_data_source_gen.go
@@ -813,7 +813,7 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								},
 								"default_ttl": {
 									// Property: DefaultTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"field_level_encryption_id": {
@@ -907,12 +907,12 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								},
 								"max_ttl": {
 									// Property: MaxTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"min_ttl": {
 									// Property: MinTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"origin_request_policy_id": {
@@ -976,17 +976,17 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 							map[string]tfsdk.Attribute{
 								"error_caching_min_ttl": {
 									// Property: ErrorCachingMinTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"error_code": {
 									// Property: ErrorCode
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"response_code": {
 									// Property: ResponseCode
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"response_page_path": {
@@ -1010,12 +1010,12 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								},
 								"http_port": {
 									// Property: HTTPPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"https_port": {
 									// Property: HTTPSPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"origin_protocol_policy": {
@@ -1058,7 +1058,7 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								},
 								"default_ttl": {
 									// Property: DefaultTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"field_level_encryption_id": {
@@ -1152,12 +1152,12 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								},
 								"max_ttl": {
 									// Property: MaxTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"min_ttl": {
 									// Property: MinTTL
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"origin_request_policy_id": {
@@ -1265,12 +1265,12 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 																map[string]tfsdk.Attribute{
 																	"items": {
 																		// Property: Items
-																		Type:     types.ListType{ElemType: types.NumberType},
+																		Type:     types.ListType{ElemType: types.Int64Type},
 																		Computed: true,
 																	},
 																	"quantity": {
 																		// Property: Quantity
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -1306,7 +1306,7 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 														},
 														"quantity": {
 															// Property: Quantity
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -1320,7 +1320,7 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								},
 								"quantity": {
 									// Property: Quantity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1333,12 +1333,12 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 							map[string]tfsdk.Attribute{
 								"connection_attempts": {
 									// Property: ConnectionAttempts
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"connection_timeout": {
 									// Property: ConnectionTimeout
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"custom_origin_config": {
@@ -1347,17 +1347,17 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 										map[string]tfsdk.Attribute{
 											"http_port": {
 												// Property: HTTPPort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"https_port": {
 												// Property: HTTPSPort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"origin_keepalive_timeout": {
 												// Property: OriginKeepaliveTimeout
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"origin_protocol_policy": {
@@ -1367,7 +1367,7 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 											},
 											"origin_read_timeout": {
 												// Property: OriginReadTimeout
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"origin_ssl_protocols": {

--- a/internal/aws/cloudfront/realtime_log_config_resource_gen.go
+++ b/internal/aws/cloudfront/realtime_log_config_resource_gen.go
@@ -139,7 +139,7 @@ func realtimeLogConfigResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			//   "minimum": 1,
 			//   "type": "number"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Float64Type,
 			Required: true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.FloatBetween(1.000000, 100.000000),

--- a/internal/aws/cloudfront/realtime_log_config_singular_data_source_gen.go
+++ b/internal/aws/cloudfront/realtime_log_config_singular_data_source_gen.go
@@ -126,7 +126,7 @@ func realtimeLogConfigDataSourceType(ctx context.Context) (tfsdk.DataSourceType,
 			//   "minimum": 1,
 			//   "type": "number"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Float64Type,
 			Computed: true,
 		},
 	}

--- a/internal/aws/cloudfront/response_headers_policy_resource_gen.go
+++ b/internal/aws/cloudfront/response_headers_policy_resource_gen.go
@@ -375,7 +375,7 @@ func responseHeadersPolicyResourceType(ctx context.Context) (tfsdk.ResourceType,
 								},
 								"access_control_max_age_sec": {
 									// Property: AccessControlMaxAgeSec
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"origin_override": {
@@ -504,7 +504,7 @@ func responseHeadersPolicyResourceType(ctx context.Context) (tfsdk.ResourceType,
 										map[string]tfsdk.Attribute{
 											"access_control_max_age_sec": {
 												// Property: AccessControlMaxAgeSec
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 											},
 											"include_subdomains": {

--- a/internal/aws/cloudfront/response_headers_policy_singular_data_source_gen.go
+++ b/internal/aws/cloudfront/response_headers_policy_singular_data_source_gen.go
@@ -357,7 +357,7 @@ func responseHeadersPolicyDataSourceType(ctx context.Context) (tfsdk.DataSourceT
 								},
 								"access_control_max_age_sec": {
 									// Property: AccessControlMaxAgeSec
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"origin_override": {
@@ -483,7 +483,7 @@ func responseHeadersPolicyDataSourceType(ctx context.Context) (tfsdk.DataSourceT
 										map[string]tfsdk.Attribute{
 											"access_control_max_age_sec": {
 												// Property: AccessControlMaxAgeSec
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"include_subdomains": {

--- a/internal/aws/connect/hours_of_operation_resource_gen.go
+++ b/internal/aws/connect/hours_of_operation_resource_gen.go
@@ -129,7 +129,7 @@ func hoursOfOperationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 								"hours": {
 									// Property: Hours
 									Description: "The hours.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 23),
@@ -138,7 +138,7 @@ func hoursOfOperationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 								"minutes": {
 									// Property: Minutes
 									Description: "The minutes.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 59),
@@ -156,7 +156,7 @@ func hoursOfOperationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 								"hours": {
 									// Property: Hours
 									Description: "The hours.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 23),
@@ -165,7 +165,7 @@ func hoursOfOperationResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 								"minutes": {
 									// Property: Minutes
 									Description: "The minutes.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 59),

--- a/internal/aws/connect/hours_of_operation_singular_data_source_gen.go
+++ b/internal/aws/connect/hours_of_operation_singular_data_source_gen.go
@@ -117,13 +117,13 @@ func hoursOfOperationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 								"hours": {
 									// Property: Hours
 									Description: "The hours.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"minutes": {
 									// Property: Minutes
 									Description: "The minutes.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -138,13 +138,13 @@ func hoursOfOperationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 								"hours": {
 									// Property: Hours
 									Description: "The hours.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"minutes": {
 									// Property: Minutes
 									Description: "The minutes.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},

--- a/internal/aws/connect/user_resource_gen.go
+++ b/internal/aws/connect/user_resource_gen.go
@@ -155,7 +155,7 @@ func userResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"after_contact_work_time_limit": {
 						// Property: AfterContactWorkTimeLimit
 						Description: "The After Call Work (ACW) timeout setting, in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),

--- a/internal/aws/connect/user_singular_data_source_gen.go
+++ b/internal/aws/connect/user_singular_data_source_gen.go
@@ -153,7 +153,7 @@ func userDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"after_contact_work_time_limit": {
 						// Property: AfterContactWorkTimeLimit
 						Description: "The After Call Work (ACW) timeout setting, in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"auto_accept": {

--- a/internal/aws/customerprofiles/domain_resource_gen.go
+++ b/internal/aws/customerprofiles/domain_resource_gen.go
@@ -76,7 +76,7 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The default number of days until the data within the domain expires.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1, 1098),

--- a/internal/aws/customerprofiles/domain_singular_data_source_gen.go
+++ b/internal/aws/customerprofiles/domain_singular_data_source_gen.go
@@ -66,7 +66,7 @@ func domainDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The default number of days until the data within the domain expires.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"domain_name": {

--- a/internal/aws/customerprofiles/integration_resource_gen.go
+++ b/internal/aws/customerprofiles/integration_resource_gen.go
@@ -903,12 +903,12 @@ func integrationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"first_execution_from": {
 															// Property: FirstExecutionFrom
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 														"schedule_end_time": {
 															// Property: ScheduleEndTime
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 														"schedule_expression": {
@@ -921,7 +921,7 @@ func integrationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"schedule_offset": {
 															// Property: ScheduleOffset
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntBetween(0, 36000),
@@ -929,7 +929,7 @@ func integrationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"schedule_start_time": {
 															// Property: ScheduleStartTime
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 														"timezone": {

--- a/internal/aws/customerprofiles/integration_singular_data_source_gen.go
+++ b/internal/aws/customerprofiles/integration_singular_data_source_gen.go
@@ -695,12 +695,12 @@ func integrationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 														},
 														"first_execution_from": {
 															// Property: FirstExecutionFrom
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 														"schedule_end_time": {
 															// Property: ScheduleEndTime
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 														"schedule_expression": {
@@ -710,12 +710,12 @@ func integrationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 														},
 														"schedule_offset": {
 															// Property: ScheduleOffset
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"schedule_start_time": {
 															// Property: ScheduleStartTime
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 														"timezone": {

--- a/internal/aws/customerprofiles/object_type_resource_gen.go
+++ b/internal/aws/customerprofiles/object_type_resource_gen.go
@@ -107,7 +107,7 @@ func objectTypeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The default number of days until the data within the domain expires.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1, 1098),

--- a/internal/aws/customerprofiles/object_type_singular_data_source_gen.go
+++ b/internal/aws/customerprofiles/object_type_singular_data_source_gen.go
@@ -91,7 +91,7 @@ func objectTypeDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The default number of days until the data within the domain expires.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"fields": {

--- a/internal/aws/databrew/dataset_resource_gen.go
+++ b/internal/aws/databrew/dataset_resource_gen.go
@@ -155,7 +155,7 @@ func datasetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"sheet_indexes": {
 									// Property: SheetIndexes
-									Type:     types.ListType{ElemType: types.NumberType},
+									Type:     types.ListType{ElemType: types.Int64Type},
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.ArrayLenBetween(1, 1),
@@ -674,7 +674,7 @@ func datasetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"max_files": {
 									// Property: MaxFiles
 									Description: "Maximum number of files",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 								},
 								"order": {

--- a/internal/aws/databrew/dataset_singular_data_source_gen.go
+++ b/internal/aws/databrew/dataset_singular_data_source_gen.go
@@ -143,7 +143,7 @@ func datasetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"sheet_indexes": {
 									// Property: SheetIndexes
-									Type:     types.ListType{ElemType: types.NumberType},
+									Type:     types.ListType{ElemType: types.Int64Type},
 									Computed: true,
 								},
 								"sheet_names": {
@@ -638,7 +638,7 @@ func datasetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"max_files": {
 									// Property: MaxFiles
 									Description: "Maximum number of files",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"order": {

--- a/internal/aws/databrew/job_resource_gen.go
+++ b/internal/aws/databrew/job_resource_gen.go
@@ -458,7 +458,7 @@ func jobResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"size": {
 						// Property: Size
 						Description: "Sample configuration size for profile jobs.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 				},
@@ -494,7 +494,7 @@ func jobResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Max capacity",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"max_retries": {
@@ -505,7 +505,7 @@ func jobResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Max retries",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"name": {
@@ -1304,7 +1304,7 @@ func jobResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Timeout",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"type": {

--- a/internal/aws/databrew/job_singular_data_source_gen.go
+++ b/internal/aws/databrew/job_singular_data_source_gen.go
@@ -410,7 +410,7 @@ func jobDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"size": {
 						// Property: Size
 						Description: "Sample configuration size for profile jobs.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -440,7 +440,7 @@ func jobDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Max capacity",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"max_retries": {
@@ -451,7 +451,7 @@ func jobDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Max retries",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {
@@ -1143,7 +1143,7 @@ func jobDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Timeout",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"type": {

--- a/internal/aws/databrew/project_resource_gen.go
+++ b/internal/aws/databrew/project_resource_gen.go
@@ -115,7 +115,7 @@ func projectResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"size": {
 						// Property: Size
 						Description: "Sample size",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(1),

--- a/internal/aws/databrew/project_singular_data_source_gen.go
+++ b/internal/aws/databrew/project_singular_data_source_gen.go
@@ -102,7 +102,7 @@ func projectDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"size": {
 						// Property: Size
 						Description: "Sample size",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"type": {

--- a/internal/aws/databrew/ruleset_resource_gen.go
+++ b/internal/aws/databrew/ruleset_resource_gen.go
@@ -291,7 +291,7 @@ func rulesetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"value": {
 									// Property: Value
 									Description: "Threshold value for a rule",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 								},
 							},

--- a/internal/aws/databrew/ruleset_singular_data_source_gen.go
+++ b/internal/aws/databrew/ruleset_singular_data_source_gen.go
@@ -246,7 +246,7 @@ func rulesetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"value": {
 									// Property: Value
 									Description: "Threshold value for a rule",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},

--- a/internal/aws/datasync/location_hdfs_resource_gen.go
+++ b/internal/aws/datasync/location_hdfs_resource_gen.go
@@ -4,7 +4,6 @@ package datasync
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -79,7 +78,7 @@ func locationHDFSResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Size of chunks (blocks) in bytes that the data is divided into when stored in the HDFS cluster.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1048576, 1073741824),
@@ -222,7 +221,7 @@ func locationHDFSResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"port": {
 						// Property: Port
 						Description: "The port on which the Name Node is listening on for client requests.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 65536),
@@ -328,14 +327,14 @@ func locationHDFSResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Number of copies of each block that exists inside the HDFS cluster.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1, 512),
 			},
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				DefaultValue(types.Number{Value: big.NewFloat(3)}),
+				DefaultValue(types.Int64{Value: 3}),
 				tfsdk.UseStateForUnknown(),
 			},
 		},

--- a/internal/aws/datasync/location_hdfs_singular_data_source_gen.go
+++ b/internal/aws/datasync/location_hdfs_singular_data_source_gen.go
@@ -64,7 +64,7 @@ func locationHDFSDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 			//   "type": "integer"
 			// }
 			Description: "Size of chunks (blocks) in bytes that the data is divided into when stored in the HDFS cluster.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"kerberos_keytab": {
@@ -187,7 +187,7 @@ func locationHDFSDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"port": {
 						// Property: Port
 						Description: "The port on which the Name Node is listening on for client requests.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -258,7 +258,7 @@ func locationHDFSDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 			//   "type": "integer"
 			// }
 			Description: "Number of copies of each block that exists inside the HDFS cluster.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"simple_user": {

--- a/internal/aws/datasync/location_object_storage_resource_gen.go
+++ b/internal/aws/datasync/location_object_storage_resource_gen.go
@@ -164,7 +164,7 @@ func locationObjectStorageResourceType(ctx context.Context) (tfsdk.ResourceType,
 			//   "type": "integer"
 			// }
 			Description: "The port that your self-managed server accepts inbound network traffic on.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1, 65536),

--- a/internal/aws/datasync/location_object_storage_singular_data_source_gen.go
+++ b/internal/aws/datasync/location_object_storage_singular_data_source_gen.go
@@ -129,7 +129,7 @@ func locationObjectStorageDataSourceType(ctx context.Context) (tfsdk.DataSourceT
 			//   "type": "integer"
 			// }
 			Description: "The port that your self-managed server accepts inbound network traffic on.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"server_protocol": {

--- a/internal/aws/datasync/task_resource_gen.go
+++ b/internal/aws/datasync/task_resource_gen.go
@@ -396,7 +396,7 @@ func taskResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"bytes_per_second": {
 						// Property: BytesPerSecond
 						Description: "A value that limits the bandwidth used by AWS DataSync.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(-1),

--- a/internal/aws/datasync/task_singular_data_source_gen.go
+++ b/internal/aws/datasync/task_singular_data_source_gen.go
@@ -337,7 +337,7 @@ func taskDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"bytes_per_second": {
 						// Property: BytesPerSecond
 						Description: "A value that limits the bandwidth used by AWS DataSync.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"gid": {

--- a/internal/aws/dynamodb/global_table_resource_gen.go
+++ b/internal/aws/dynamodb/global_table_resource_gen.go
@@ -277,7 +277,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"max_capacity": {
 												// Property: MaxCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -285,7 +285,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"min_capacity": {
 												// Property: MinCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -293,7 +293,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"seed_capacity": {
 												// Property: SeedCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -310,7 +310,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"scale_in_cooldown": {
 															// Property: ScaleInCooldown
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntAtLeast(0),
@@ -318,7 +318,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"scale_out_cooldown": {
 															// Property: ScaleOutCooldown
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntAtLeast(0),
@@ -326,7 +326,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"target_value": {
 															// Property: TargetValue
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Required: true,
 														},
 													},
@@ -802,7 +802,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max_capacity": {
 															// Property: MaxCapacity
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Required: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntAtLeast(1),
@@ -810,7 +810,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"min_capacity": {
 															// Property: MinCapacity
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Required: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntAtLeast(1),
@@ -818,7 +818,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"seed_capacity": {
 															// Property: SeedCapacity
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntAtLeast(1),
@@ -835,7 +835,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																	},
 																	"scale_in_cooldown": {
 																		// Property: ScaleInCooldown
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																		Validators: []tfsdk.AttributeValidator{
 																			validate.IntAtLeast(0),
@@ -843,7 +843,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																	},
 																	"scale_out_cooldown": {
 																		// Property: ScaleOutCooldown
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																		Validators: []tfsdk.AttributeValidator{
 																			validate.IntAtLeast(0),
@@ -851,7 +851,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																	},
 																	"target_value": {
 																		// Property: TargetValue
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Required: true,
 																	},
 																},
@@ -864,7 +864,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"read_capacity_units": {
 												// Property: ReadCapacityUnits
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -902,7 +902,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"max_capacity": {
 												// Property: MaxCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -910,7 +910,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"min_capacity": {
 												// Property: MinCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -918,7 +918,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"seed_capacity": {
 												// Property: SeedCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -935,7 +935,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"scale_in_cooldown": {
 															// Property: ScaleInCooldown
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntAtLeast(0),
@@ -943,7 +943,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"scale_out_cooldown": {
 															// Property: ScaleOutCooldown
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntAtLeast(0),
@@ -951,7 +951,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"target_value": {
 															// Property: TargetValue
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Required: true,
 														},
 													},
@@ -964,7 +964,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"read_capacity_units": {
 									// Property: ReadCapacityUnits
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -1215,7 +1215,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"max_capacity": {
 									// Property: MaxCapacity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -1223,7 +1223,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"min_capacity": {
 									// Property: MinCapacity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -1231,7 +1231,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"seed_capacity": {
 									// Property: SeedCapacity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -1248,7 +1248,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"scale_in_cooldown": {
 												// Property: ScaleInCooldown
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(0),
@@ -1256,7 +1256,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"scale_out_cooldown": {
 												// Property: ScaleOutCooldown
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(0),
@@ -1264,7 +1264,7 @@ func globalTableResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"target_value": {
 												// Property: TargetValue
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Required: true,
 											},
 										},

--- a/internal/aws/dynamodb/global_table_singular_data_source_gen.go
+++ b/internal/aws/dynamodb/global_table_singular_data_source_gen.go
@@ -254,17 +254,17 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 										map[string]tfsdk.Attribute{
 											"max_capacity": {
 												// Property: MaxCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"min_capacity": {
 												// Property: MinCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"seed_capacity": {
 												// Property: SeedCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"target_tracking_scaling_policy_configuration": {
@@ -278,17 +278,17 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 														},
 														"scale_in_cooldown": {
 															// Property: ScaleInCooldown
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"scale_out_cooldown": {
 															// Property: ScaleOutCooldown
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"target_value": {
 															// Property: TargetValue
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 													},
@@ -733,17 +733,17 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 													map[string]tfsdk.Attribute{
 														"max_capacity": {
 															// Property: MaxCapacity
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min_capacity": {
 															// Property: MinCapacity
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"seed_capacity": {
 															// Property: SeedCapacity
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"target_tracking_scaling_policy_configuration": {
@@ -757,17 +757,17 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 																	},
 																	"scale_in_cooldown": {
 																		// Property: ScaleInCooldown
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"scale_out_cooldown": {
 																		// Property: ScaleOutCooldown
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"target_value": {
 																		// Property: TargetValue
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Computed: true,
 																	},
 																},
@@ -780,7 +780,7 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 											},
 											"read_capacity_units": {
 												// Property: ReadCapacityUnits
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -815,17 +815,17 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 										map[string]tfsdk.Attribute{
 											"max_capacity": {
 												// Property: MaxCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"min_capacity": {
 												// Property: MinCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"seed_capacity": {
 												// Property: SeedCapacity
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"target_tracking_scaling_policy_configuration": {
@@ -839,17 +839,17 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 														},
 														"scale_in_cooldown": {
 															// Property: ScaleInCooldown
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"scale_out_cooldown": {
 															// Property: ScaleOutCooldown
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"target_value": {
 															// Property: TargetValue
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 													},
@@ -862,7 +862,7 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 								},
 								"read_capacity_units": {
 									// Property: ReadCapacityUnits
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1096,17 +1096,17 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 							map[string]tfsdk.Attribute{
 								"max_capacity": {
 									// Property: MaxCapacity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"min_capacity": {
 									// Property: MinCapacity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"seed_capacity": {
 									// Property: SeedCapacity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"target_tracking_scaling_policy_configuration": {
@@ -1120,17 +1120,17 @@ func globalTableDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 											},
 											"scale_in_cooldown": {
 												// Property: ScaleInCooldown
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"scale_out_cooldown": {
 												// Property: ScaleOutCooldown
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"target_value": {
 												// Property: TargetValue
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Computed: true,
 											},
 										},

--- a/internal/aws/ec2/capacity_reservation_fleet_resource_gen.go
+++ b/internal/aws/ec2/capacity_reservation_fleet_resource_gen.go
@@ -149,7 +149,7 @@ func capacityReservationFleetResourceType(ctx context.Context) (tfsdk.ResourceTy
 					},
 					"priority": {
 						// Property: Priority
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 999),
@@ -157,7 +157,7 @@ func capacityReservationFleetResourceType(ctx context.Context) (tfsdk.ResourceTy
 					},
 					"weight": {
 						// Property: Weight
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Optional: true,
 					},
 				},
@@ -299,7 +299,7 @@ func capacityReservationFleetResourceType(ctx context.Context) (tfsdk.ResourceTy
 			//   "minimum": 1,
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1, 25000),

--- a/internal/aws/ec2/capacity_reservation_fleet_singular_data_source_gen.go
+++ b/internal/aws/ec2/capacity_reservation_fleet_singular_data_source_gen.go
@@ -125,12 +125,12 @@ func capacityReservationFleetDataSourceType(ctx context.Context) (tfsdk.DataSour
 					},
 					"priority": {
 						// Property: Priority
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"weight": {
 						// Property: Weight
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 				},
@@ -245,7 +245,7 @@ func capacityReservationFleetDataSourceType(ctx context.Context) (tfsdk.DataSour
 			//   "minimum": 1,
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 	}

--- a/internal/aws/ec2/dhcp_options_resource_gen.go
+++ b/internal/aws/ec2/dhcp_options_resource_gen.go
@@ -102,7 +102,7 @@ func dHCPOptionsResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The NetBIOS node type (1, 2, 4, or 8).",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{

--- a/internal/aws/ec2/dhcp_options_singular_data_source_gen.go
+++ b/internal/aws/ec2/dhcp_options_singular_data_source_gen.go
@@ -77,7 +77,7 @@ func dHCPOptionsDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "integer"
 			// }
 			Description: "The NetBIOS node type (1, 2, 4, or 8).",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"ntp_servers": {

--- a/internal/aws/ec2/ec2_fleet_resource_gen.go
+++ b/internal/aws/ec2/ec2_fleet_resource_gen.go
@@ -419,12 +419,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -468,12 +468,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -510,12 +510,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -594,12 +594,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 													},
@@ -612,12 +612,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -630,12 +630,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -644,7 +644,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"on_demand_max_price_percentage_over_lowest_price": {
 												// Property: OnDemandMaxPricePercentageOverLowestPrice
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"require_hibernate_support": {
@@ -654,7 +654,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"spot_max_price_percentage_over_lowest_price": {
 												// Property: SpotMaxPricePercentageOverLowestPrice
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"total_local_storage_gb": {
@@ -663,12 +663,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 													},
@@ -681,12 +681,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -738,7 +738,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"partition_number": {
 												// Property: PartitionNumber
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"spread_domain": {
@@ -757,7 +757,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"priority": {
 									// Property: Priority
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 								"subnet_id": {
@@ -767,7 +767,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"weighted_capacity": {
 									// Property: WeightedCapacity
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 							},
@@ -854,7 +854,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"min_target_capacity": {
 						// Property: MinTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"single_availability_zone": {
@@ -982,7 +982,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"instance_pools_to_use_count": {
 						// Property: InstancePoolsToUseCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"maintenance_strategies": {
@@ -1006,7 +1006,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"termination_delay": {
 												// Property: TerminationDelay
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1024,7 +1024,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"min_target_capacity": {
 						// Property: MinTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"single_availability_zone": {
@@ -1269,12 +1269,12 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"on_demand_target_capacity": {
 						// Property: OnDemandTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"spot_target_capacity": {
 						// Property: SpotTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"target_capacity_unit_type": {
@@ -1291,7 +1291,7 @@ func eC2FleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"total_target_capacity": {
 						// Property: TotalTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Required: true,
 					},
 				},

--- a/internal/aws/ec2/ec2_fleet_singular_data_source_gen.go
+++ b/internal/aws/ec2/ec2_fleet_singular_data_source_gen.go
@@ -406,12 +406,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -434,12 +434,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -462,12 +462,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -510,12 +510,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 													},
@@ -528,12 +528,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -546,12 +546,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -560,7 +560,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											},
 											"on_demand_max_price_percentage_over_lowest_price": {
 												// Property: OnDemandMaxPricePercentageOverLowestPrice
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"require_hibernate_support": {
@@ -570,7 +570,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											},
 											"spot_max_price_percentage_over_lowest_price": {
 												// Property: SpotMaxPricePercentageOverLowestPrice
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"total_local_storage_gb": {
@@ -579,12 +579,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 													},
@@ -597,12 +597,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -654,7 +654,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											},
 											"partition_number": {
 												// Property: PartitionNumber
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"spread_domain": {
@@ -673,7 +673,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"priority": {
 									// Property: Priority
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"subnet_id": {
@@ -683,7 +683,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"weighted_capacity": {
 									// Property: WeightedCapacity
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 							},
@@ -759,7 +759,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"min_target_capacity": {
 						// Property: MinTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"single_availability_zone": {
@@ -862,7 +862,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"instance_pools_to_use_count": {
 						// Property: InstancePoolsToUseCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"maintenance_strategies": {
@@ -880,7 +880,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											},
 											"termination_delay": {
 												// Property: TerminationDelay
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -898,7 +898,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"min_target_capacity": {
 						// Property: MinTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"single_availability_zone": {
@@ -1076,12 +1076,12 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"on_demand_target_capacity": {
 						// Property: OnDemandTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"spot_target_capacity": {
 						// Property: SpotTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"target_capacity_unit_type": {
@@ -1091,7 +1091,7 @@ func eC2FleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"total_target_capacity": {
 						// Property: TotalTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/ec2/flow_log_resource_gen.go
+++ b/internal/aws/ec2/flow_log_resource_gen.go
@@ -191,7 +191,7 @@ func flowLogResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1 minute) or 600 seconds (10 minutes).",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{

--- a/internal/aws/ec2/flow_log_singular_data_source_gen.go
+++ b/internal/aws/ec2/flow_log_singular_data_source_gen.go
@@ -145,7 +145,7 @@ func flowLogDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1 minute) or 600 seconds (10 minutes).",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"resource_id": {

--- a/internal/aws/ec2/ipam_allocation_resource_gen.go
+++ b/internal/aws/ec2/ipam_allocation_resource_gen.go
@@ -85,7 +85,7 @@ func iPAMAllocationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The desired netmask length of the allocation. If set, IPAM will choose a block of free space with this size and return the CIDR representing it.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{

--- a/internal/aws/ec2/ipam_allocation_singular_data_source_gen.go
+++ b/internal/aws/ec2/ipam_allocation_singular_data_source_gen.go
@@ -69,7 +69,7 @@ func iPAMAllocationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "The desired netmask length of the allocation. If set, IPAM will choose a block of free space with this size and return the CIDR representing it.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 	}

--- a/internal/aws/ec2/ipam_pool_resource_gen.go
+++ b/internal/aws/ec2/ipam_pool_resource_gen.go
@@ -42,7 +42,7 @@ func iPAMPoolResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The default netmask length for allocations made from this pool. This value is used when the netmask length of an allocation isn't specified.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"allocation_max_netmask_length": {
@@ -53,7 +53,7 @@ func iPAMPoolResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The maximum allowed netmask length for allocations made from this pool.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"allocation_min_netmask_length": {
@@ -64,7 +64,7 @@ func iPAMPoolResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The minimum allowed netmask length for allocations made from this pool.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"allocation_resource_tags": {
@@ -258,7 +258,7 @@ func iPAMPoolResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The depth of this pool in the source pool hierarchy.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/ec2/ipam_pool_singular_data_source_gen.go
+++ b/internal/aws/ec2/ipam_pool_singular_data_source_gen.go
@@ -38,7 +38,7 @@ func iPAMPoolDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The default netmask length for allocations made from this pool. This value is used when the netmask length of an allocation isn't specified.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"allocation_max_netmask_length": {
@@ -49,7 +49,7 @@ func iPAMPoolDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The maximum allowed netmask length for allocations made from this pool.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"allocation_min_netmask_length": {
@@ -60,7 +60,7 @@ func iPAMPoolDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The minimum allowed netmask length for allocations made from this pool.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"allocation_resource_tags": {
@@ -224,7 +224,7 @@ func iPAMPoolDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The depth of this pool in the source pool hierarchy.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"provisioned_cidrs": {

--- a/internal/aws/ec2/ipam_resource_gen.go
+++ b/internal/aws/ec2/ipam_resource_gen.go
@@ -131,7 +131,7 @@ func iPAMResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of scopes that currently exist in this IPAM.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/ec2/ipam_scope_resource_gen.go
+++ b/internal/aws/ec2/ipam_scope_resource_gen.go
@@ -126,7 +126,7 @@ func iPAMScopeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of pools that currently exist in this scope.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/ec2/ipam_scope_singular_data_source_gen.go
+++ b/internal/aws/ec2/ipam_scope_singular_data_source_gen.go
@@ -106,7 +106,7 @@ func iPAMScopeDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 			//   "type": "integer"
 			// }
 			Description: "The number of pools that currently exist in this scope.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"tags": {

--- a/internal/aws/ec2/ipam_singular_data_source_gen.go
+++ b/internal/aws/ec2/ipam_singular_data_source_gen.go
@@ -118,7 +118,7 @@ func iPAMDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of scopes that currently exist in this IPAM.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"tags": {

--- a/internal/aws/ec2/network_insights_access_scope_analysis_resource_gen.go
+++ b/internal/aws/ec2/network_insights_access_scope_analysis_resource_gen.go
@@ -25,7 +25,7 @@ func networkInsightsAccessScopeAnalysisResourceType(ctx context.Context) (tfsdk.
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/ec2/network_insights_access_scope_analysis_singular_data_source_gen.go
+++ b/internal/aws/ec2/network_insights_access_scope_analysis_singular_data_source_gen.go
@@ -25,7 +25,7 @@ func networkInsightsAccessScopeAnalysisDataSourceType(ctx context.Context) (tfsd
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"end_date": {

--- a/internal/aws/ec2/network_insights_analysis_resource_gen.go
+++ b/internal/aws/ec2/network_insights_analysis_resource_gen.go
@@ -625,12 +625,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -649,7 +649,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 								},
 								"rule_number": {
 									// Property: RuleNumber
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -700,12 +700,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 							map[string]tfsdk.Attribute{
 								"instance_port": {
 									// Property: InstancePort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"load_balancer_port": {
 									// Property: LoadBalancerPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -855,7 +855,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 					},
 					"load_balancer_listener_port": {
 						// Property: LoadBalancerListenerPort
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"load_balancer_target": {
@@ -892,7 +892,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 								},
 								"port": {
 									// Property: Port
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -938,7 +938,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 					},
 					"load_balancer_target_port": {
 						// Property: LoadBalancerTargetPort
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"missing_component": {
@@ -989,7 +989,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 					},
 					"port": {
 						// Property: Port
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"port_ranges": {
@@ -998,12 +998,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 							map[string]tfsdk.Attribute{
 								"from": {
 									// Property: From
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"to": {
 									// Property: To
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -1148,12 +1148,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1673,12 +1673,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1697,7 +1697,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 								},
 								"rule_number": {
 									// Property: RuleNumber
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -1755,12 +1755,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1784,12 +1784,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1816,12 +1816,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1845,12 +1845,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1940,12 +1940,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1973,7 +1973,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 					},
 					"sequence_number": {
 						// Property: SequenceNumber
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"source_vpc": {
@@ -2387,12 +2387,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2411,7 +2411,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 								},
 								"rule_number": {
 									// Property: RuleNumber
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -2469,12 +2469,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2498,12 +2498,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2530,12 +2530,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2559,12 +2559,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2654,12 +2654,12 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2687,7 +2687,7 @@ func networkInsightsAnalysisResourceType(ctx context.Context) (tfsdk.ResourceTyp
 					},
 					"sequence_number": {
 						// Property: SequenceNumber
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"source_vpc": {

--- a/internal/aws/ec2/network_insights_analysis_singular_data_source_gen.go
+++ b/internal/aws/ec2/network_insights_analysis_singular_data_source_gen.go
@@ -622,12 +622,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -646,7 +646,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 								},
 								"rule_number": {
 									// Property: RuleNumber
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -697,12 +697,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 							map[string]tfsdk.Attribute{
 								"instance_port": {
 									// Property: InstancePort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"load_balancer_port": {
 									// Property: LoadBalancerPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -852,7 +852,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 					},
 					"load_balancer_listener_port": {
 						// Property: LoadBalancerListenerPort
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"load_balancer_target": {
@@ -889,7 +889,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 								},
 								"port": {
 									// Property: Port
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -935,7 +935,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 					},
 					"load_balancer_target_port": {
 						// Property: LoadBalancerTargetPort
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"missing_component": {
@@ -986,7 +986,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 					},
 					"port": {
 						// Property: Port
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"port_ranges": {
@@ -995,12 +995,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 							map[string]tfsdk.Attribute{
 								"from": {
 									// Property: From
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"to": {
 									// Property: To
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1145,12 +1145,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1662,12 +1662,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1686,7 +1686,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 								},
 								"rule_number": {
 									// Property: RuleNumber
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1744,12 +1744,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1773,12 +1773,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1805,12 +1805,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1834,12 +1834,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1929,12 +1929,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1962,7 +1962,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 					},
 					"sequence_number": {
 						// Property: SequenceNumber
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"source_vpc": {
@@ -2361,12 +2361,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -2385,7 +2385,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 								},
 								"rule_number": {
 									// Property: RuleNumber
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -2443,12 +2443,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -2472,12 +2472,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -2504,12 +2504,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -2533,12 +2533,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -2628,12 +2628,12 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 										map[string]tfsdk.Attribute{
 											"from": {
 												// Property: From
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"to": {
 												// Property: To
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -2661,7 +2661,7 @@ func networkInsightsAnalysisDataSourceType(ctx context.Context) (tfsdk.DataSourc
 					},
 					"sequence_number": {
 						// Property: SequenceNumber
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"source_vpc": {

--- a/internal/aws/ec2/network_insights_path_resource_gen.go
+++ b/internal/aws/ec2/network_insights_path_resource_gen.go
@@ -64,7 +64,7 @@ func networkInsightsPathResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{

--- a/internal/aws/ec2/network_insights_path_singular_data_source_gen.go
+++ b/internal/aws/ec2/network_insights_path_singular_data_source_gen.go
@@ -52,7 +52,7 @@ func networkInsightsPathDataSourceType(ctx context.Context) (tfsdk.DataSourceTyp
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"network_insights_path_arn": {

--- a/internal/aws/ec2/network_interface_resource_gen.go
+++ b/internal/aws/ec2/network_interface_resource_gen.go
@@ -87,7 +87,7 @@ func networkInterfaceResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			//   "type": "integer"
 			// }
 			Description: "The number of IPv6 addresses to assign to a network interface. Amazon EC2 automatically selects the IPv6 addresses from the subnet range. To specify specific IPv6 addresses, use the Ipv6Addresses property and don't specify this property.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"ipv_6_addresses": {
@@ -208,7 +208,7 @@ func networkInterfaceResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			//   "type": "integer"
 			// }
 			Description: "The number of secondary private IPv4 addresses to assign to a network interface. When you specify a number of secondary IPv4 addresses, Amazon EC2 selects these IP addresses within the subnet's IPv4 CIDR range. You can't specify this option and specify more than one private IP address using privateIpAddresses",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"secondary_private_ip_addresses": {

--- a/internal/aws/ec2/network_interface_singular_data_source_gen.go
+++ b/internal/aws/ec2/network_interface_singular_data_source_gen.go
@@ -76,7 +76,7 @@ func networkInterfaceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 			//   "type": "integer"
 			// }
 			Description: "The number of IPv6 addresses to assign to a network interface. Amazon EC2 automatically selects the IPv6 addresses from the subnet range. To specify specific IPv6 addresses, use the Ipv6Addresses property and don't specify this property.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"ipv_6_addresses": {
@@ -186,7 +186,7 @@ func networkInterfaceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 			//   "type": "integer"
 			// }
 			Description: "The number of secondary private IPv4 addresses to assign to a network interface. When you specify a number of secondary IPv4 addresses, Amazon EC2 selects these IP addresses within the subnet's IPv4 CIDR range. You can't specify this option and specify more than one private IP address using privateIpAddresses",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"secondary_private_ip_addresses": {

--- a/internal/aws/ec2/prefix_list_resource_gen.go
+++ b/internal/aws/ec2/prefix_list_resource_gen.go
@@ -114,7 +114,7 @@ func prefixListResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Max Entries of Prefix List.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(1),
@@ -221,7 +221,7 @@ func prefixListResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Version of Prefix List.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/ec2/prefix_list_singular_data_source_gen.go
+++ b/internal/aws/ec2/prefix_list_singular_data_source_gen.go
@@ -98,7 +98,7 @@ func prefixListDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Max Entries of Prefix List.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"owner_id": {
@@ -187,7 +187,7 @@ func prefixListDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Version of Prefix List.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 	}

--- a/internal/aws/ec2/spot_fleet_resource_gen.go
+++ b/internal/aws/ec2/spot_fleet_resource_gen.go
@@ -1080,7 +1080,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"instance_pools_to_use_count": {
 						// Property: InstancePoolsToUseCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
@@ -1117,7 +1117,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"iops": {
 															// Property: Iops
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"snapshot_id": {
@@ -1127,7 +1127,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"volume_size": {
 															// Property: VolumeSize
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"volume_type": {
@@ -1206,12 +1206,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -1255,12 +1255,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -1297,12 +1297,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -1381,12 +1381,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 													},
@@ -1399,12 +1399,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -1417,12 +1417,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -1431,7 +1431,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"on_demand_max_price_percentage_over_lowest_price": {
 												// Property: OnDemandMaxPricePercentageOverLowestPrice
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"require_hibernate_support": {
@@ -1441,7 +1441,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"spot_max_price_percentage_over_lowest_price": {
 												// Property: SpotMaxPricePercentageOverLowestPrice
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"total_local_storage_gb": {
@@ -1450,12 +1450,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Optional: true,
 														},
 													},
@@ -1468,12 +1468,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 													},
@@ -1538,7 +1538,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"device_index": {
 												// Property: DeviceIndex
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"groups": {
@@ -1551,7 +1551,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"ipv_6_address_count": {
 												// Property: Ipv6AddressCount
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"ipv_6_addresses": {
@@ -1600,7 +1600,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"secondary_private_ip_address_count": {
 												// Property: SecondaryPrivateIpAddressCount
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"subnet_id": {
@@ -1772,7 +1772,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"weighted_capacity": {
 									// Property: WeightedCapacity
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 							},
@@ -1837,12 +1837,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																},
@@ -1886,12 +1886,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																},
@@ -1928,12 +1928,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																},
@@ -2012,12 +2012,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Optional: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Optional: true,
 																	},
 																},
@@ -2030,12 +2030,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																},
@@ -2048,12 +2048,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																},
@@ -2062,7 +2062,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"on_demand_max_price_percentage_over_lowest_price": {
 															// Property: OnDemandMaxPricePercentageOverLowestPrice
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"require_hibernate_support": {
@@ -2072,7 +2072,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"spot_max_price_percentage_over_lowest_price": {
 															// Property: SpotMaxPricePercentageOverLowestPrice
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"total_local_storage_gb": {
@@ -2081,12 +2081,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Optional: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Optional: true,
 																	},
 																},
@@ -2099,12 +2099,12 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																},
@@ -2132,7 +2132,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"weighted_capacity": {
 												// Property: WeightedCapacity
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Optional: true,
 											},
 										},
@@ -2241,7 +2241,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"on_demand_target_capacity": {
 						// Property: OnDemandTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
@@ -2280,7 +2280,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"termination_delay": {
 												// Property: TerminationDelay
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2318,7 +2318,7 @@ func spotFleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"target_capacity": {
 						// Property: TargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Required: true,
 					},
 					"target_capacity_unit_type": {

--- a/internal/aws/ec2/spot_fleet_singular_data_source_gen.go
+++ b/internal/aws/ec2/spot_fleet_singular_data_source_gen.go
@@ -1040,7 +1040,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					},
 					"instance_pools_to_use_count": {
 						// Property: InstancePoolsToUseCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"launch_specifications": {
@@ -1072,7 +1072,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 														},
 														"iops": {
 															// Property: Iops
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"snapshot_id": {
@@ -1082,7 +1082,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 														},
 														"volume_size": {
 															// Property: VolumeSize
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"volume_type": {
@@ -1142,12 +1142,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -1170,12 +1170,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -1198,12 +1198,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -1246,12 +1246,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 													},
@@ -1264,12 +1264,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -1282,12 +1282,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -1296,7 +1296,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											},
 											"on_demand_max_price_percentage_over_lowest_price": {
 												// Property: OnDemandMaxPricePercentageOverLowestPrice
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"require_hibernate_support": {
@@ -1306,7 +1306,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											},
 											"spot_max_price_percentage_over_lowest_price": {
 												// Property: SpotMaxPricePercentageOverLowestPrice
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"total_local_storage_gb": {
@@ -1315,12 +1315,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 													},
@@ -1333,12 +1333,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"max": {
 															// Property: Max
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"min": {
 															// Property: Min
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -1398,7 +1398,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											},
 											"device_index": {
 												// Property: DeviceIndex
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"groups": {
@@ -1408,7 +1408,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											},
 											"ipv_6_address_count": {
 												// Property: Ipv6AddressCount
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"ipv_6_addresses": {
@@ -1451,7 +1451,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											},
 											"secondary_private_ip_address_count": {
 												// Property: SecondaryPrivateIpAddressCount
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"subnet_id": {
@@ -1556,7 +1556,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 								},
 								"weighted_capacity": {
 									// Property: WeightedCapacity
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 							},
@@ -1610,12 +1610,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -1638,12 +1638,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -1666,12 +1666,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -1714,12 +1714,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Computed: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Computed: true,
 																	},
 																},
@@ -1732,12 +1732,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -1750,12 +1750,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -1764,7 +1764,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 														},
 														"on_demand_max_price_percentage_over_lowest_price": {
 															// Property: OnDemandMaxPricePercentageOverLowestPrice
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"require_hibernate_support": {
@@ -1774,7 +1774,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 														},
 														"spot_max_price_percentage_over_lowest_price": {
 															// Property: SpotMaxPricePercentageOverLowestPrice
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"total_local_storage_gb": {
@@ -1783,12 +1783,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Computed: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Computed: true,
 																	},
 																},
@@ -1801,12 +1801,12 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																map[string]tfsdk.Attribute{
 																	"max": {
 																		// Property: Max
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"min": {
 																		// Property: Min
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -1834,7 +1834,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											},
 											"weighted_capacity": {
 												// Property: WeightedCapacity
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Computed: true,
 											},
 										},
@@ -1911,7 +1911,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					},
 					"on_demand_target_capacity": {
 						// Property: OnDemandTargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"replace_unhealthy_instances": {
@@ -1934,7 +1934,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											},
 											"termination_delay": {
 												// Property: TerminationDelay
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1957,7 +1957,7 @@ func spotFleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					},
 					"target_capacity": {
 						// Property: TargetCapacity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"target_capacity_unit_type": {

--- a/internal/aws/ec2/transit_gateway_resource_gen.go
+++ b/internal/aws/ec2/transit_gateway_resource_gen.go
@@ -25,7 +25,7 @@ func transitGatewayResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{

--- a/internal/aws/ec2/transit_gateway_singular_data_source_gen.go
+++ b/internal/aws/ec2/transit_gateway_singular_data_source_gen.go
@@ -25,7 +25,7 @@ func transitGatewayDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"association_default_route_table_id": {

--- a/internal/aws/ecs/capacity_provider_resource_gen.go
+++ b/internal/aws/ecs/capacity_provider_resource_gen.go
@@ -85,17 +85,17 @@ func capacityProviderResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 							map[string]tfsdk.Attribute{
 								"instance_warmup_period": {
 									// Property: InstanceWarmupPeriod
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"maximum_scaling_step_size": {
 									// Property: MaximumScalingStepSize
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"minimum_scaling_step_size": {
 									// Property: MinimumScalingStepSize
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"status": {
@@ -111,7 +111,7 @@ func capacityProviderResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 								},
 								"target_capacity": {
 									// Property: TargetCapacity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},

--- a/internal/aws/ecs/capacity_provider_singular_data_source_gen.go
+++ b/internal/aws/ecs/capacity_provider_singular_data_source_gen.go
@@ -81,17 +81,17 @@ func capacityProviderDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 							map[string]tfsdk.Attribute{
 								"instance_warmup_period": {
 									// Property: InstanceWarmupPeriod
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"maximum_scaling_step_size": {
 									// Property: MaximumScalingStepSize
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"minimum_scaling_step_size": {
 									// Property: MinimumScalingStepSize
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"status": {
@@ -101,7 +101,7 @@ func capacityProviderDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 								},
 								"target_capacity": {
 									// Property: TargetCapacity
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},

--- a/internal/aws/ecs/cluster_capacity_provider_associations_resource_gen.go
+++ b/internal/aws/ecs/cluster_capacity_provider_associations_resource_gen.go
@@ -101,7 +101,7 @@ func clusterCapacityProviderAssociationsResourceType(ctx context.Context) (tfsdk
 				map[string]tfsdk.Attribute{
 					"base": {
 						// Property: Base
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 100000),
@@ -115,7 +115,7 @@ func clusterCapacityProviderAssociationsResourceType(ctx context.Context) (tfsdk
 					},
 					"weight": {
 						// Property: Weight
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 1000),

--- a/internal/aws/ecs/cluster_capacity_provider_associations_singular_data_source_gen.go
+++ b/internal/aws/ecs/cluster_capacity_provider_associations_singular_data_source_gen.go
@@ -91,7 +91,7 @@ func clusterCapacityProviderAssociationsDataSourceType(ctx context.Context) (tfs
 				map[string]tfsdk.Attribute{
 					"base": {
 						// Property: Base
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"capacity_provider": {
@@ -102,7 +102,7 @@ func clusterCapacityProviderAssociationsDataSourceType(ctx context.Context) (tfs
 					},
 					"weight": {
 						// Property: Weight
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/ecs/cluster_resource_gen.go
+++ b/internal/aws/ecs/cluster_resource_gen.go
@@ -228,7 +228,7 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				map[string]tfsdk.Attribute{
 					"base": {
 						// Property: Base
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"capacity_provider": {
@@ -238,7 +238,7 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"weight": {
 						// Property: Weight
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 				},

--- a/internal/aws/ecs/cluster_singular_data_source_gen.go
+++ b/internal/aws/ecs/cluster_singular_data_source_gen.go
@@ -220,7 +220,7 @@ func clusterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 				map[string]tfsdk.Attribute{
 					"base": {
 						// Property: Base
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"capacity_provider": {
@@ -230,7 +230,7 @@ func clusterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"weight": {
 						// Property: Weight
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/ecs/service_resource_gen.go
+++ b/internal/aws/ecs/service_resource_gen.go
@@ -45,7 +45,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				map[string]tfsdk.Attribute{
 					"base": {
 						// Property: Base
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"capacity_provider": {
@@ -55,7 +55,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"weight": {
 						// Property: Weight
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 				},
@@ -130,12 +130,12 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"maximum_percent": {
 						// Property: MaximumPercent
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"minimum_healthy_percent": {
 						// Property: MinimumHealthyPercent
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 				},
@@ -188,7 +188,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 		},
 		"enable_ecs_managed_tags": {
@@ -220,7 +220,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 		},
 		"launch_type": {
@@ -282,7 +282,7 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"container_port": {
 						// Property: ContainerPort
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"load_balancer_name": {
@@ -630,12 +630,12 @@ func serviceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"container_port": {
 						// Property: ContainerPort
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"port": {
 						// Property: Port
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"registry_arn": {

--- a/internal/aws/ecs/service_singular_data_source_gen.go
+++ b/internal/aws/ecs/service_singular_data_source_gen.go
@@ -44,7 +44,7 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 				map[string]tfsdk.Attribute{
 					"base": {
 						// Property: Base
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"capacity_provider": {
@@ -54,7 +54,7 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"weight": {
 						// Property: Weight
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},
@@ -124,12 +124,12 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"maximum_percent": {
 						// Property: MaximumPercent
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"minimum_healthy_percent": {
 						// Property: MinimumHealthyPercent
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},
@@ -170,7 +170,7 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"enable_ecs_managed_tags": {
@@ -197,7 +197,7 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"launch_type": {
@@ -247,7 +247,7 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"container_port": {
 						// Property: ContainerPort
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"load_balancer_name": {
@@ -518,12 +518,12 @@ func serviceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"container_port": {
 						// Property: ContainerPort
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"port": {
 						// Property: Port
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"registry_arn": {

--- a/internal/aws/ecs/task_definition_resource_gen.go
+++ b/internal/aws/ecs/task_definition_resource_gen.go
@@ -513,7 +513,7 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"cpu": {
 						// Property: Cpu
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"depends_on": {
@@ -666,25 +666,25 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"interval": {
 									// Property: Interval
 									Description: "The time period in seconds between each health check execution. You may specify between 5 and 300 seconds. The default value is 30 seconds.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"retries": {
 									// Property: Retries
 									Description: "The number of times to retry a failed health check before the container is considered unhealthy. You may specify between 1 and 10 retries. The default value is three retries.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"start_period": {
 									// Property: StartPeriod
 									Description: "The optional grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. You may specify between 0 and 300 seconds. The startPeriod is disabled by default.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"timeout": {
 									// Property: Timeout
 									Description: "The time period in seconds to wait for a health check to succeed before it is considered a failure. You may specify between 2 and 60 seconds. The default value is 5 seconds.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 							},
@@ -771,17 +771,17 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								},
 								"max_swap": {
 									// Property: MaxSwap
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"shared_memory_size": {
 									// Property: SharedMemorySize
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"swappiness": {
 									// Property: Swappiness
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"tmpfs": {
@@ -800,7 +800,7 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 											},
 											"size": {
 												// Property: Size
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 											},
 										},
@@ -853,12 +853,12 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"memory": {
 						// Property: Memory
 						Description: "The amount (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"memory_reservation": {
 						// Property: MemoryReservation
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"mount_points": {
@@ -901,12 +901,12 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"container_port": {
 									// Property: ContainerPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"host_port": {
 									// Property: HostPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"protocol": {
@@ -990,12 +990,12 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"start_timeout": {
 						// Property: StartTimeout
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"stop_timeout": {
 						// Property: StopTimeout
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"system_controls": {
@@ -1023,7 +1023,7 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"hard_limit": {
 									// Property: HardLimit
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 								},
 								"name": {
@@ -1033,7 +1033,7 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								},
 								"soft_limit": {
 									// Property: SoftLimit
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 								},
 							},
@@ -1116,7 +1116,7 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 				map[string]tfsdk.Attribute{
 					"size_in_gi_b": {
 						// Property: SizeInGiB
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 				},
@@ -1687,7 +1687,7 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								},
 								"transit_encryption_port": {
 									// Property: TransitEncryptionPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},

--- a/internal/aws/ecs/task_definition_singular_data_source_gen.go
+++ b/internal/aws/ecs/task_definition_singular_data_source_gen.go
@@ -512,7 +512,7 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					},
 					"cpu": {
 						// Property: Cpu
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"depends_on": {
@@ -662,25 +662,25 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"interval": {
 									// Property: Interval
 									Description: "The time period in seconds between each health check execution. You may specify between 5 and 300 seconds. The default value is 30 seconds.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"retries": {
 									// Property: Retries
 									Description: "The number of times to retry a failed health check before the container is considered unhealthy. You may specify between 1 and 10 retries. The default value is three retries.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"start_period": {
 									// Property: StartPeriod
 									Description: "The optional grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. You may specify between 0 and 300 seconds. The startPeriod is disabled by default.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"timeout": {
 									// Property: Timeout
 									Description: "The time period in seconds to wait for a health check to succeed before it is considered a failure. You may specify between 2 and 60 seconds. The default value is 5 seconds.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -761,17 +761,17 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								},
 								"max_swap": {
 									// Property: MaxSwap
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"shared_memory_size": {
 									// Property: SharedMemorySize
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"swappiness": {
 									// Property: Swappiness
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"tmpfs": {
@@ -790,7 +790,7 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 											},
 											"size": {
 												// Property: Size
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -843,12 +843,12 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					"memory": {
 						// Property: Memory
 						Description: "The amount (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"memory_reservation": {
 						// Property: MemoryReservation
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"mount_points": {
@@ -888,12 +888,12 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"container_port": {
 									// Property: ContainerPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"host_port": {
 									// Property: HostPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"protocol": {
@@ -974,12 +974,12 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					},
 					"start_timeout": {
 						// Property: StartTimeout
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"stop_timeout": {
 						// Property: StopTimeout
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"system_controls": {
@@ -1007,7 +1007,7 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"hard_limit": {
 									// Property: HardLimit
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"name": {
@@ -1017,7 +1017,7 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								},
 								"soft_limit": {
 									// Property: SoftLimit
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1084,7 +1084,7 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 				map[string]tfsdk.Attribute{
 					"size_in_gi_b": {
 						// Property: SizeInGiB
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},
@@ -1563,7 +1563,7 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								},
 								"transit_encryption_port": {
 									// Property: TransitEncryptionPort
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},

--- a/internal/aws/ecs/task_set_resource_gen.go
+++ b/internal/aws/ecs/task_set_resource_gen.go
@@ -130,7 +130,7 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"container_port": {
 						// Property: ContainerPort
 						Description: "The port on the container to associate with the load balancer. This port must correspond to a containerPort in the task definition the tasks in the service are using. For tasks that use the EC2 launch type, the container instance they are launched on must allow ingress traffic on the hostPort of the port mapping.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"load_balancer_name": {
@@ -306,7 +306,7 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"value": {
 						// Property: Value
 						Description: "The value, specified as a percent total of a service's desiredCount, to scale the task set. Accepted values are numbers between 0 and 100.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 100.000000),
@@ -371,13 +371,13 @@ func taskSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"container_port": {
 						// Property: ContainerPort
 						Description: "The port value, already specified in the task definition, to be used for your service discovery service. If the task definition your service task specifies uses the bridge or host network mode, you must specify a containerName and containerPort combination from the task definition. If the task definition your service task specifies uses the awsvpc network mode and a type SRV DNS record is used, you must specify either a containerName and containerPort combination or a port value, but not both.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"port": {
 						// Property: Port
 						Description: "The port value used if your service discovery service specified an SRV record. This field may be used if both the awsvpc network mode and SRV records are used.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"registry_arn": {

--- a/internal/aws/ecs/task_set_singular_data_source_gen.go
+++ b/internal/aws/ecs/task_set_singular_data_source_gen.go
@@ -107,7 +107,7 @@ func taskSetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"container_port": {
 						// Property: ContainerPort
 						Description: "The port on the container to associate with the load balancer. This port must correspond to a containerPort in the task definition the tasks in the service are using. For tasks that use the EC2 launch type, the container instance they are launched on must allow ingress traffic on the hostPort of the port mapping.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"load_balancer_name": {
@@ -251,7 +251,7 @@ func taskSetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"value": {
 						// Property: Value
 						Description: "The value, specified as a percent total of a service's desiredCount, to scale the task set. Accepted values are numbers between 0 and 100.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 				},
@@ -310,13 +310,13 @@ func taskSetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"container_port": {
 						// Property: ContainerPort
 						Description: "The port value, already specified in the task definition, to be used for your service discovery service. If the task definition your service task specifies uses the bridge or host network mode, you must specify a containerName and containerPort combination from the task definition. If the task definition your service task specifies uses the awsvpc network mode and a type SRV DNS record is used, you must specify either a containerName and containerPort combination or a port value, but not both.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"port": {
 						// Property: Port
 						Description: "The port value used if your service discovery service specified an SRV record. This field may be used if both the awsvpc network mode and SRV records are used.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"registry_arn": {

--- a/internal/aws/efs/file_system_resource_gen.go
+++ b/internal/aws/efs/file_system_resource_gen.go
@@ -235,7 +235,7 @@ func fileSystemResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// {
 			//   "type": "number"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Float64Type,
 			Optional: true,
 		},
 		"throughput_mode": {

--- a/internal/aws/efs/file_system_singular_data_source_gen.go
+++ b/internal/aws/efs/file_system_singular_data_source_gen.go
@@ -201,7 +201,7 @@ func fileSystemDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			// {
 			//   "type": "number"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Float64Type,
 			Computed: true,
 		},
 		"throughput_mode": {

--- a/internal/aws/elasticache/global_replication_group_resource_gen.go
+++ b/internal/aws/elasticache/global_replication_group_resource_gen.go
@@ -75,7 +75,7 @@ func globalReplicationGroupResourceType(ctx context.Context) (tfsdk.ResourceType
 			//   "type": "integer"
 			// }
 			Description: "Indicates the number of node groups in the Global Datastore.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			// GlobalNodeGroupCount is a write-only property.
 		},

--- a/internal/aws/elasticache/global_replication_group_singular_data_source_gen.go
+++ b/internal/aws/elasticache/global_replication_group_singular_data_source_gen.go
@@ -71,7 +71,7 @@ func globalReplicationGroupDataSourceType(ctx context.Context) (tfsdk.DataSource
 			//   "type": "integer"
 			// }
 			Description: "Indicates the number of node groups in the Global Datastore.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"global_replication_group_description": {

--- a/internal/aws/events/api_destination_resource_gen.go
+++ b/internal/aws/events/api_destination_resource_gen.go
@@ -105,7 +105,7 @@ func apiDestinationResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "minimum": 1,
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(1),

--- a/internal/aws/events/api_destination_singular_data_source_gen.go
+++ b/internal/aws/events/api_destination_singular_data_source_gen.go
@@ -87,7 +87,7 @@ func apiDestinationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "minimum": 1,
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"name": {

--- a/internal/aws/events/archive_resource_gen.go
+++ b/internal/aws/events/archive_resource_gen.go
@@ -70,7 +70,7 @@ func archiveResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 		},
 		"source_arn": {

--- a/internal/aws/events/archive_singular_data_source_gen.go
+++ b/internal/aws/events/archive_singular_data_source_gen.go
@@ -63,7 +63,7 @@ func archiveDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"source_arn": {

--- a/internal/aws/evidently/experiment_resource_gen.go
+++ b/internal/aws/evidently/experiment_resource_gen.go
@@ -232,7 +232,7 @@ func experimentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"split_weight": {
 									// Property: SplitWeight
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 100000),
@@ -296,7 +296,7 @@ func experimentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "minimum": 0,
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(0, 100000),

--- a/internal/aws/evidently/experiment_singular_data_source_gen.go
+++ b/internal/aws/evidently/experiment_singular_data_source_gen.go
@@ -200,7 +200,7 @@ func experimentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 							map[string]tfsdk.Attribute{
 								"split_weight": {
 									// Property: SplitWeight
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"treatment": {
@@ -249,7 +249,7 @@ func experimentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "minimum": 0,
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"tags": {

--- a/internal/aws/evidently/feature_resource_gen.go
+++ b/internal/aws/evidently/feature_resource_gen.go
@@ -297,12 +297,12 @@ func featureResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"double_value": {
 						// Property: DoubleValue
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Optional: true,
 					},
 					"long_value": {
 						// Property: LongValue
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Optional: true,
 					},
 					"string_value": {

--- a/internal/aws/evidently/feature_singular_data_source_gen.go
+++ b/internal/aws/evidently/feature_singular_data_source_gen.go
@@ -257,12 +257,12 @@ func featureDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"double_value": {
 						// Property: DoubleValue
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"long_value": {
 						// Property: LongValue
-						Type:     types.NumberType,
+						Type:     types.Float64Type,
 						Computed: true,
 					},
 					"string_value": {

--- a/internal/aws/evidently/launch_resource_gen.go
+++ b/internal/aws/evidently/launch_resource_gen.go
@@ -327,7 +327,7 @@ func launchResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"split_weight": {
 									// Property: SplitWeight
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 								},
 							},

--- a/internal/aws/evidently/launch_singular_data_source_gen.go
+++ b/internal/aws/evidently/launch_singular_data_source_gen.go
@@ -282,7 +282,7 @@ func launchDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"split_weight": {
 									// Property: SplitWeight
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},

--- a/internal/aws/gamelift/fleet_resource_gen.go
+++ b/internal/aws/gamelift/fleet_resource_gen.go
@@ -105,7 +105,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "[DEPRECATED] The number of EC2 instances that you want this fleet to host. When creating a new fleet, GameLift automatically sets this value to \"1\" and initiates a single instance. Once the fleet is active, update this value to trigger GameLift to add or remove instances from the fleet.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(0),
@@ -164,7 +164,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"from_port": {
 						// Property: FromPort
 						Description: "A starting value for a range of allowed port numbers.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 60000),
@@ -191,7 +191,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"to_port": {
 						// Property: ToPort
 						Description: "An ending value for a range of allowed port numbers. Port numbers are end-inclusive. This value must be higher than FromPort.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 60000),
@@ -357,7 +357,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"desired_ec2_instances": {
 									// Property: DesiredEC2Instances
 									Description: "The number of EC2 instances you want to maintain in the specified fleet location. This value must fall between the minimum and maximum size limits.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(0),
@@ -366,7 +366,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"max_size": {
 									// Property: MaxSize
 									Description: "The maximum value that is allowed for the fleet's instance count for a location. When creating a new fleet, GameLift automatically sets this value to \"1\". Once the fleet is active, you can change this value.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(0),
@@ -375,7 +375,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"min_size": {
 									// Property: MinSize
 									Description: "The minimum value allowed for the fleet's instance count for a location. When creating a new fleet, GameLift automatically sets this value to \"0\". After the fleet is active, you can change this value.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(0),
@@ -426,7 +426,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "[DEPRECATED] The maximum value that is allowed for the fleet's instance count. When creating a new fleet, GameLift automatically sets this value to \"1\". Once the fleet is active, you can change this value.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(0),
@@ -463,7 +463,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "[DEPRECATED] The minimum value allowed for the fleet's instance count. When creating a new fleet, GameLift automatically sets this value to \"0\". After the fleet is active, you can change this value.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(0),
@@ -576,7 +576,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"new_game_sessions_per_creator": {
 						// Property: NewGameSessionsPerCreator
 						Description: "The maximum number of game sessions that an individual can create during the policy period.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -585,7 +585,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"policy_period_in_minutes": {
 						// Property: PolicyPeriodInMinutes
 						Description: "The time span used in evaluating the resource creation limit policy.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -658,7 +658,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"game_session_activation_timeout_seconds": {
 						// Property: GameSessionActivationTimeoutSeconds
 						Description: "The maximum amount of time (in seconds) that a game session can remain in status ACTIVATING. If the game session is not active before the timeout, activation is terminated and the game session status is changed to TERMINATED.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 600),
@@ -667,7 +667,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"max_concurrent_game_session_activations": {
 						// Property: MaxConcurrentGameSessionActivations
 						Description: "The maximum number of game sessions with status ACTIVATING to allow on an instance simultaneously. This setting limits the amount of instance resources that can be used for new game activations at any one time.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 2147483647),
@@ -681,7 +681,7 @@ func fleetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"concurrent_executions": {
 									// Property: ConcurrentExecutions
 									Description: "The number of server processes that use this configuration to run concurrently on an instance.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),

--- a/internal/aws/gamelift/fleet_singular_data_source_gen.go
+++ b/internal/aws/gamelift/fleet_singular_data_source_gen.go
@@ -85,7 +85,7 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "[DEPRECATED] The number of EC2 instances that you want this fleet to host. When creating a new fleet, GameLift automatically sets this value to \"1\" and initiates a single instance. Once the fleet is active, update this value to trigger GameLift to add or remove instances from the fleet.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"ec2_inbound_permissions": {
@@ -141,7 +141,7 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"from_port": {
 						// Property: FromPort
 						Description: "A starting value for a range of allowed port numbers.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"ip_range": {
@@ -159,7 +159,7 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"to_port": {
 						// Property: ToPort
 						Description: "An ending value for a range of allowed port numbers. Port numbers are end-inclusive. This value must be higher than FromPort.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -286,19 +286,19 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"desired_ec2_instances": {
 									// Property: DesiredEC2Instances
 									Description: "The number of EC2 instances you want to maintain in the specified fleet location. This value must fall between the minimum and maximum size limits.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"max_size": {
 									// Property: MaxSize
 									Description: "The maximum value that is allowed for the fleet's instance count for a location. When creating a new fleet, GameLift automatically sets this value to \"1\". Once the fleet is active, you can change this value.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"min_size": {
 									// Property: MinSize
 									Description: "The minimum value allowed for the fleet's instance count for a location. When creating a new fleet, GameLift automatically sets this value to \"0\". After the fleet is active, you can change this value.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -334,7 +334,7 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "[DEPRECATED] The maximum value that is allowed for the fleet's instance count. When creating a new fleet, GameLift automatically sets this value to \"1\". Once the fleet is active, you can change this value.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"metric_groups": {
@@ -362,7 +362,7 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "[DEPRECATED] The minimum value allowed for the fleet's instance count. When creating a new fleet, GameLift automatically sets this value to \"0\". After the fleet is active, you can change this value.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {
@@ -447,13 +447,13 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"new_game_sessions_per_creator": {
 						// Property: NewGameSessionsPerCreator
 						Description: "The maximum number of game sessions that an individual can create during the policy period.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"policy_period_in_minutes": {
 						// Property: PolicyPeriodInMinutes
 						Description: "The time span used in evaluating the resource creation limit policy.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -523,13 +523,13 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"game_session_activation_timeout_seconds": {
 						// Property: GameSessionActivationTimeoutSeconds
 						Description: "The maximum amount of time (in seconds) that a game session can remain in status ACTIVATING. If the game session is not active before the timeout, activation is terminated and the game session status is changed to TERMINATED.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"max_concurrent_game_session_activations": {
 						// Property: MaxConcurrentGameSessionActivations
 						Description: "The maximum number of game sessions with status ACTIVATING to allow on an instance simultaneously. This setting limits the amount of instance resources that can be used for new game activations at any one time.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"server_processes": {
@@ -540,7 +540,7 @@ func fleetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"concurrent_executions": {
 									// Property: ConcurrentExecutions
 									Description: "The number of server processes that use this configuration to run concurrently on an instance.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"launch_path": {

--- a/internal/aws/gamelift/game_server_group_resource_gen.go
+++ b/internal/aws/gamelift/game_server_group_resource_gen.go
@@ -74,7 +74,7 @@ func gameServerGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error
 					"estimated_instance_warmup": {
 						// Property: EstimatedInstanceWarmup
 						Description: "Length of time, in seconds, it takes for a new instance to start new game server processes and register with GameLift FleetIQ.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 					},
 					"target_tracking_configuration": {
@@ -85,7 +85,7 @@ func gameServerGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error
 								"target_value": {
 									// Property: TargetValue
 									Description: "Desired value to use with a game server group target-based scaling policy.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 								},
 							},
@@ -309,7 +309,7 @@ func gameServerGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			//   "type": "number"
 			// }
 			Description: "The maximum number of instances allowed in the EC2 Auto Scaling group.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.FloatAtLeast(1.000000),
@@ -324,7 +324,7 @@ func gameServerGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			//   "type": "number"
 			// }
 			Description: "The minimum number of instances allowed in the EC2 Auto Scaling group.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.FloatAtLeast(0.000000),

--- a/internal/aws/gamelift/game_server_group_singular_data_source_gen.go
+++ b/internal/aws/gamelift/game_server_group_singular_data_source_gen.go
@@ -70,7 +70,7 @@ func gameServerGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 					"estimated_instance_warmup": {
 						// Property: EstimatedInstanceWarmup
 						Description: "Length of time, in seconds, it takes for a new instance to start new game server processes and register with GameLift FleetIQ.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"target_tracking_configuration": {
@@ -81,7 +81,7 @@ func gameServerGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 								"target_value": {
 									// Property: TargetValue
 									Description: "Desired value to use with a game server group target-based scaling policy.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -272,7 +272,7 @@ func gameServerGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 			//   "type": "number"
 			// }
 			Description: "The maximum number of instances allowed in the EC2 Auto Scaling group.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"min_size": {
@@ -284,7 +284,7 @@ func gameServerGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 			//   "type": "number"
 			// }
 			Description: "The minimum number of instances allowed in the EC2 Auto Scaling group.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"role_arn": {

--- a/internal/aws/globalaccelerator/endpoint_group_resource_gen.go
+++ b/internal/aws/globalaccelerator/endpoint_group_resource_gen.go
@@ -4,7 +4,6 @@ package globalaccelerator
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -77,14 +76,14 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"weight": {
 						// Property: Weight
 						Description: "The weight for the endpoint.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Computed:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 255),
 						},
 						PlanModifiers: []tfsdk.AttributePlanModifier{
-							DefaultValue(types.Number{Value: big.NewFloat(100)}),
+							DefaultValue(types.Int64{Value: 100}),
 							tfsdk.UseStateForUnknown(),
 						},
 					},
@@ -130,11 +129,11 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			//   "type": "integer"
 			// }
 			Description: "The time in seconds between each health check for an endpoint. Must be a value of 10 or 30",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				DefaultValue(types.Number{Value: big.NewFloat(30)}),
+				DefaultValue(types.Int64{Value: 30}),
 				tfsdk.UseStateForUnknown(),
 			},
 		},
@@ -166,14 +165,14 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			//   "type": "integer"
 			// }
 			Description: "The port that AWS Global Accelerator uses to check the health of endpoints in this endpoint group.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(-1, 65535),
 			},
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				DefaultValue(types.Number{Value: big.NewFloat(-1)}),
+				DefaultValue(types.Int64{Value: -1}),
 				tfsdk.UseStateForUnknown(),
 			},
 		},
@@ -254,7 +253,7 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"endpoint_port": {
 						// Property: EndpointPort
 						Description: "A network port number",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 65535),
@@ -263,7 +262,7 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"listener_port": {
 						// Property: ListenerPort
 						Description: "A network port number",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 65535),
@@ -283,11 +282,11 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			//   "type": "integer"
 			// }
 			Description: "The number of consecutive health checks required to set the state of the endpoint to unhealthy.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				DefaultValue(types.Number{Value: big.NewFloat(3)}),
+				DefaultValue(types.Int64{Value: 3}),
 				tfsdk.UseStateForUnknown(),
 			},
 		},
@@ -302,14 +301,14 @@ func endpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 			//   "type": "number"
 			// }
 			Description: "The percentage of traffic to sent to an AWS Region",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Optional:    true,
 			Computed:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.FloatBetween(0.000000, 100.000000),
 			},
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				DefaultValue(types.Number{Value: big.NewFloat(100.000000)}),
+				DefaultValue(types.Float64{Value: 100.000000}),
 				tfsdk.UseStateForUnknown(),
 			},
 		},

--- a/internal/aws/globalaccelerator/endpoint_group_singular_data_source_gen.go
+++ b/internal/aws/globalaccelerator/endpoint_group_singular_data_source_gen.go
@@ -70,7 +70,7 @@ func endpointGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 					"weight": {
 						// Property: Weight
 						Description: "The weight for the endpoint.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -109,7 +109,7 @@ func endpointGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 			//   "type": "integer"
 			// }
 			Description: "The time in seconds between each health check for an endpoint. Must be a value of 10 or 30",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"health_check_path": {
@@ -135,7 +135,7 @@ func endpointGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 			//   "type": "integer"
 			// }
 			Description: "The port that AWS Global Accelerator uses to check the health of endpoints in this endpoint group.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"health_check_protocol": {
@@ -200,13 +200,13 @@ func endpointGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 					"endpoint_port": {
 						// Property: EndpointPort
 						Description: "A network port number",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"listener_port": {
 						// Property: ListenerPort
 						Description: "A network port number",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -223,7 +223,7 @@ func endpointGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 			//   "type": "integer"
 			// }
 			Description: "The number of consecutive health checks required to set the state of the endpoint to unhealthy.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"traffic_dial_percentage": {
@@ -237,7 +237,7 @@ func endpointGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 			//   "type": "number"
 			// }
 			Description: "The percentage of traffic to sent to an AWS Region",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 	}

--- a/internal/aws/globalaccelerator/listener_resource_gen.go
+++ b/internal/aws/globalaccelerator/listener_resource_gen.go
@@ -109,7 +109,7 @@ func listenerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"from_port": {
 						// Property: FromPort
 						Description: "A network port number",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 65535),
@@ -118,7 +118,7 @@ func listenerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"to_port": {
 						// Property: ToPort
 						Description: "A network port number",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 65535),

--- a/internal/aws/globalaccelerator/listener_singular_data_source_gen.go
+++ b/internal/aws/globalaccelerator/listener_singular_data_source_gen.go
@@ -91,13 +91,13 @@ func listenerDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"from_port": {
 						// Property: FromPort
 						Description: "A network port number",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"to_port": {
 						// Property: ToPort
 						Description: "A network port number",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/glue/schema_resource_gen.go
+++ b/internal/aws/glue/schema_resource_gen.go
@@ -67,7 +67,7 @@ func schemaResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"version_number": {
 						// Property: VersionNumber
 						Description: "Indicates the version number in the schema to update.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 100000),

--- a/internal/aws/glue/schema_singular_data_source_gen.go
+++ b/internal/aws/glue/schema_singular_data_source_gen.go
@@ -63,7 +63,7 @@ func schemaDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"version_number": {
 						// Property: VersionNumber
 						Description: "Indicates the version number in the schema to update.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/greengrassv2/component_version_resource_gen.go
+++ b/internal/aws/greengrassv2/component_version_resource_gen.go
@@ -400,7 +400,7 @@ func componentVersionResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 														},
 														"memory_size_in_kb": {
 															// Property: MemorySizeInKB
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Optional: true,
 														},
 														"mount_ro_sysfs": {
@@ -467,17 +467,17 @@ func componentVersionResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 								},
 								"max_idle_time_in_seconds": {
 									// Property: MaxIdleTimeInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"max_instances_count": {
 									// Property: MaxInstancesCount
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"max_queue_size": {
 									// Property: MaxQueueSize
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"pinned": {
@@ -487,12 +487,12 @@ func componentVersionResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 								},
 								"status_timeout_in_seconds": {
 									// Property: StatusTimeoutInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"timeout_in_seconds": {
 									// Property: TimeoutInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},

--- a/internal/aws/greengrassv2/component_version_singular_data_source_gen.go
+++ b/internal/aws/greengrassv2/component_version_singular_data_source_gen.go
@@ -354,7 +354,7 @@ func componentVersionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 														},
 														"memory_size_in_kb": {
 															// Property: MemorySizeInKB
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"mount_ro_sysfs": {
@@ -406,17 +406,17 @@ func componentVersionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 								},
 								"max_idle_time_in_seconds": {
 									// Property: MaxIdleTimeInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"max_instances_count": {
 									// Property: MaxInstancesCount
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"max_queue_size": {
 									// Property: MaxQueueSize
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"pinned": {
@@ -426,12 +426,12 @@ func componentVersionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 								},
 								"status_timeout_in_seconds": {
 									// Property: StatusTimeoutInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"timeout_in_seconds": {
 									// Property: TimeoutInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},

--- a/internal/aws/groundstation/dataflow_endpoint_group_resource_gen.go
+++ b/internal/aws/groundstation/dataflow_endpoint_group_resource_gen.go
@@ -108,7 +108,7 @@ func dataflowEndpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType,
 											},
 											"port": {
 												// Property: Port
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -117,7 +117,7 @@ func dataflowEndpointGroupResourceType(ctx context.Context) (tfsdk.ResourceType,
 								},
 								"mtu": {
 									// Property: Mtu
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"name": {

--- a/internal/aws/groundstation/dataflow_endpoint_group_singular_data_source_gen.go
+++ b/internal/aws/groundstation/dataflow_endpoint_group_singular_data_source_gen.go
@@ -104,7 +104,7 @@ func dataflowEndpointGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceT
 											},
 											"port": {
 												// Property: Port
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -113,7 +113,7 @@ func dataflowEndpointGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceT
 								},
 								"mtu": {
 									// Property: Mtu
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"name": {

--- a/internal/aws/groundstation/mission_profile_resource_gen.go
+++ b/internal/aws/groundstation/mission_profile_resource_gen.go
@@ -40,7 +40,7 @@ func missionProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Post-pass time needed after the contact.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"contact_pre_pass_duration_seconds": {
@@ -51,7 +51,7 @@ func missionProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Pre-pass time needed before the contact.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"dataflow_edges": {
@@ -115,7 +115,7 @@ func missionProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Visibilities with shorter duration than the specified minimum viable contact duration will be ignored when searching for available contacts.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 		},
 		"name": {

--- a/internal/aws/groundstation/mission_profile_singular_data_source_gen.go
+++ b/internal/aws/groundstation/mission_profile_singular_data_source_gen.go
@@ -36,7 +36,7 @@ func missionProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "Post-pass time needed after the contact.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"contact_pre_pass_duration_seconds": {
@@ -47,7 +47,7 @@ func missionProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "Pre-pass time needed before the contact.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"dataflow_edges": {
@@ -105,7 +105,7 @@ func missionProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "Visibilities with shorter duration than the specified minimum viable contact duration will be ignored when searching for available contacts.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {

--- a/internal/aws/healthlake/fhir_datastore_resource_gen.go
+++ b/internal/aws/healthlake/fhir_datastore_resource_gen.go
@@ -48,7 +48,7 @@ func fHIRDatastoreResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"nanos": {
 						// Property: Nanos
 						Description: "Nanoseconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 					},
 					"seconds": {

--- a/internal/aws/healthlake/fhir_datastore_singular_data_source_gen.go
+++ b/internal/aws/healthlake/fhir_datastore_singular_data_source_gen.go
@@ -47,7 +47,7 @@ func fHIRDatastoreDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 					"nanos": {
 						// Property: Nanos
 						Description: "Nanoseconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"seconds": {

--- a/internal/aws/iam/role_resource_gen.go
+++ b/internal/aws/iam/role_resource_gen.go
@@ -86,7 +86,7 @@ func roleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours. ",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(3600, 43200),

--- a/internal/aws/iam/role_singular_data_source_gen.go
+++ b/internal/aws/iam/role_singular_data_source_gen.go
@@ -79,7 +79,7 @@ func roleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours. ",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"path": {

--- a/internal/aws/imagebuilder/container_recipe_resource_gen.go
+++ b/internal/aws/imagebuilder/container_recipe_resource_gen.go
@@ -280,7 +280,7 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 											"iops": {
 												// Property: Iops
 												Description: "Use to configure device IOPS.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"kms_key_id": {
@@ -298,13 +298,13 @@ func containerRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error
 											"throughput": {
 												// Property: Throughput
 												Description: "For GP3 volumes only ? The throughput in MiB/s that the volume supports.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"volume_size": {
 												// Property: VolumeSize
 												Description: "Use to override the device's volume size.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"volume_type": {

--- a/internal/aws/imagebuilder/container_recipe_singular_data_source_gen.go
+++ b/internal/aws/imagebuilder/container_recipe_singular_data_source_gen.go
@@ -239,7 +239,7 @@ func containerRecipeDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 											"iops": {
 												// Property: Iops
 												Description: "Use to configure device IOPS.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"kms_key_id": {
@@ -257,13 +257,13 @@ func containerRecipeDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 											"throughput": {
 												// Property: Throughput
 												Description: "For GP3 volumes only ? The throughput in MiB/s that the volume supports.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"volume_size": {
 												// Property: VolumeSize
 												Description: "Use to override the device's volume size.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"volume_type": {

--- a/internal/aws/imagebuilder/image_pipeline_resource_gen.go
+++ b/internal/aws/imagebuilder/image_pipeline_resource_gen.go
@@ -121,7 +121,7 @@ func imagePipelineResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"timeout_minutes": {
 						// Property: TimeoutMinutes
 						Description: "The maximum time in minutes that tests are permitted to run.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(60, 1440),

--- a/internal/aws/imagebuilder/image_pipeline_singular_data_source_gen.go
+++ b/internal/aws/imagebuilder/image_pipeline_singular_data_source_gen.go
@@ -117,7 +117,7 @@ func imagePipelineDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 					"timeout_minutes": {
 						// Property: TimeoutMinutes
 						Description: "The maximum time in minutes that tests are permitted to run.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/imagebuilder/image_recipe_resource_gen.go
+++ b/internal/aws/imagebuilder/image_recipe_resource_gen.go
@@ -190,7 +190,7 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"iops": {
 									// Property: Iops
 									Description: "Use to configure device IOPS.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"kms_key_id": {
@@ -208,13 +208,13 @@ func imageRecipeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"throughput": {
 									// Property: Throughput
 									Description: "For GP3 volumes only ? The throughput in MiB/s that the volume supports.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"volume_size": {
 									// Property: VolumeSize
 									Description: "Use to override the device's volume size.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"volume_type": {

--- a/internal/aws/imagebuilder/image_recipe_singular_data_source_gen.go
+++ b/internal/aws/imagebuilder/image_recipe_singular_data_source_gen.go
@@ -186,7 +186,7 @@ func imageRecipeDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 								"iops": {
 									// Property: Iops
 									Description: "Use to configure device IOPS.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"kms_key_id": {
@@ -204,13 +204,13 @@ func imageRecipeDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 								"throughput": {
 									// Property: Throughput
 									Description: "For GP3 volumes only ? The throughput in MiB/s that the volume supports.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"volume_size": {
 									// Property: VolumeSize
 									Description: "Use to override the device's volume size.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"volume_type": {

--- a/internal/aws/imagebuilder/image_resource_gen.go
+++ b/internal/aws/imagebuilder/image_resource_gen.go
@@ -138,7 +138,7 @@ func imageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"timeout_minutes": {
 						// Property: TimeoutMinutes
 						Description: "TimeoutMinutes",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(60, 1440),

--- a/internal/aws/imagebuilder/image_singular_data_source_gen.go
+++ b/internal/aws/imagebuilder/image_singular_data_source_gen.go
@@ -116,7 +116,7 @@ func imageDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"timeout_minutes": {
 						// Property: TimeoutMinutes
 						Description: "TimeoutMinutes",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/imagebuilder/infrastructure_configuration_resource_gen.go
+++ b/internal/aws/imagebuilder/infrastructure_configuration_resource_gen.go
@@ -73,7 +73,7 @@ func infrastructureConfigurationResourceType(ctx context.Context) (tfsdk.Resourc
 					"http_put_response_hop_limit": {
 						// Property: HttpPutResponseHopLimit
 						Description: "Limit the number of hops that an instance metadata request can traverse to reach its destination.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"http_tokens": {

--- a/internal/aws/imagebuilder/infrastructure_configuration_singular_data_source_gen.go
+++ b/internal/aws/imagebuilder/infrastructure_configuration_singular_data_source_gen.go
@@ -69,7 +69,7 @@ func infrastructureConfigurationDataSourceType(ctx context.Context) (tfsdk.DataS
 					"http_put_response_hop_limit": {
 						// Property: HttpPutResponseHopLimit
 						Description: "Limit the number of hops that an instance metadata request can traverse to reach its destination.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"http_tokens": {

--- a/internal/aws/inspectorv2/filter_resource_gen.go
+++ b/internal/aws/inspectorv2/filter_resource_gen.go
@@ -1329,12 +1329,12 @@ func filterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"start_inclusive": {
 									// Property: StartInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -1564,12 +1564,12 @@ func filterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"start_inclusive": {
 									// Property: StartInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -1589,12 +1589,12 @@ func filterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"lower_inclusive": {
 									// Property: LowerInclusive
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 								"upper_inclusive": {
 									// Property: UpperInclusive
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 							},
@@ -1614,12 +1614,12 @@ func filterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"start_inclusive": {
 									// Property: StartInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -1674,7 +1674,7 @@ func filterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"begin_inclusive": {
 									// Property: BeginInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 65535),
@@ -1682,7 +1682,7 @@ func filterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 65535),
@@ -1921,12 +1921,12 @@ func filterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"start_inclusive": {
 									// Property: StartInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -2083,12 +2083,12 @@ func filterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"lower_inclusive": {
 												// Property: LowerInclusive
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Optional: true,
 											},
 											"upper_inclusive": {
 												// Property: UpperInclusive
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Optional: true,
 											},
 										},

--- a/internal/aws/inspectorv2/filter_singular_data_source_gen.go
+++ b/internal/aws/inspectorv2/filter_singular_data_source_gen.go
@@ -1188,12 +1188,12 @@ func filterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 							map[string]tfsdk.Attribute{
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"start_inclusive": {
 									// Property: StartInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1321,12 +1321,12 @@ func filterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 							map[string]tfsdk.Attribute{
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"start_inclusive": {
 									// Property: StartInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1340,12 +1340,12 @@ func filterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 							map[string]tfsdk.Attribute{
 								"lower_inclusive": {
 									// Property: LowerInclusive
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"upper_inclusive": {
 									// Property: UpperInclusive
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 							},
@@ -1359,12 +1359,12 @@ func filterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 							map[string]tfsdk.Attribute{
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"start_inclusive": {
 									// Property: StartInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1397,12 +1397,12 @@ func filterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 							map[string]tfsdk.Attribute{
 								"begin_inclusive": {
 									// Property: BeginInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1535,12 +1535,12 @@ func filterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 							map[string]tfsdk.Attribute{
 								"end_inclusive": {
 									// Property: EndInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"start_inclusive": {
 									// Property: StartInclusive
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1633,12 +1633,12 @@ func filterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 										map[string]tfsdk.Attribute{
 											"lower_inclusive": {
 												// Property: LowerInclusive
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Computed: true,
 											},
 											"upper_inclusive": {
 												// Property: UpperInclusive
-												Type:     types.NumberType,
+												Type:     types.Float64Type,
 												Computed: true,
 											},
 										},

--- a/internal/aws/iot/fleet_metric_resource_gen.go
+++ b/internal/aws/iot/fleet_metric_resource_gen.go
@@ -87,7 +87,7 @@ func fleetMetricResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "The creation date of a fleet metric",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),
@@ -123,7 +123,7 @@ func fleetMetricResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "The last modified date of a fleet metric",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),
@@ -165,7 +165,7 @@ func fleetMetricResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The period of metric emission in seconds",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"query_string": {
@@ -271,7 +271,7 @@ func fleetMetricResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "The version of a fleet metric",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/iot/fleet_metric_singular_data_source_gen.go
+++ b/internal/aws/iot/fleet_metric_singular_data_source_gen.go
@@ -83,7 +83,7 @@ func fleetMetricDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "number"
 			// }
 			Description: "The creation date of a fleet metric",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"description": {
@@ -116,7 +116,7 @@ func fleetMetricDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "number"
 			// }
 			Description: "The last modified date of a fleet metric",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"metric_arn": {
@@ -149,7 +149,7 @@ func fleetMetricDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "integer"
 			// }
 			Description: "The period of metric emission in seconds",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"query_string": {
@@ -246,7 +246,7 @@ func fleetMetricDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "number"
 			// }
 			Description: "The version of a fleet metric",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 	}

--- a/internal/aws/iot/job_template_resource_gen.go
+++ b/internal/aws/iot/job_template_resource_gen.go
@@ -113,7 +113,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"min_number_of_executed_things": {
 									// Property: MinNumberOfExecutedThings
 									Description: "The minimum number of things which must receive job execution notifications before the job can be aborted.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -122,7 +122,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"threshold_percentage": {
 									// Property: ThresholdPercentage
 									Description: "The minimum percentage of job execution failures that must occur to initiate the job abort.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatAtMost(100.000000),
@@ -292,7 +292,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"number_of_retries": {
 									// Property: NumberOfRetries
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 10),
@@ -377,7 +377,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"base_rate_per_minute": {
 									// Property: BaseRatePerMinute
 									Description: "The minimum number of things that will be notified of a pending job, per minute at the start of job rollout. This parameter allows you to define the initial rate of rollout.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -386,7 +386,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"increment_factor": {
 									// Property: IncrementFactor
 									Description: "The exponential factor to increase the rate of rollout for a job.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 5.000000),
@@ -399,7 +399,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"number_of_notified_things": {
 												// Property: NumberOfNotifiedThings
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -407,7 +407,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"number_of_succeeded_things": {
 												// Property: NumberOfSucceededThings
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(1),
@@ -424,7 +424,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"maximum_per_minute": {
 						// Property: MaximumPerMinute
 						Description: "The maximum number of things that will be notified of a pending job, per minute. This parameter allows you to create a staged rollout.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(1),
@@ -488,7 +488,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"expires_in_sec": {
 						// Property: ExpiresInSec
 						Description: "How number (in seconds) pre-signed URLs are valid.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(60, 3600),
@@ -605,7 +605,7 @@ func jobTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"in_progress_timeout_in_minutes": {
 						// Property: InProgressTimeoutInMinutes
 						Description: "Specifies the amount of time, in minutes, this device has to finish execution of this job.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 10080),

--- a/internal/aws/iot/job_template_singular_data_source_gen.go
+++ b/internal/aws/iot/job_template_singular_data_source_gen.go
@@ -99,13 +99,13 @@ func jobTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 								"min_number_of_executed_things": {
 									// Property: MinNumberOfExecutedThings
 									Description: "The minimum number of things which must receive job execution notifications before the job can be aborted.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"threshold_percentage": {
 									// Property: ThresholdPercentage
 									Description: "The minimum percentage of job execution failures that must occur to initiate the job abort.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -223,7 +223,7 @@ func jobTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 								},
 								"number_of_retries": {
 									// Property: NumberOfRetries
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -299,13 +299,13 @@ func jobTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 								"base_rate_per_minute": {
 									// Property: BaseRatePerMinute
 									Description: "The minimum number of things that will be notified of a pending job, per minute at the start of job rollout. This parameter allows you to define the initial rate of rollout.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"increment_factor": {
 									// Property: IncrementFactor
 									Description: "The exponential factor to increase the rate of rollout for a job.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 								"rate_increase_criteria": {
@@ -315,12 +315,12 @@ func jobTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 										map[string]tfsdk.Attribute{
 											"number_of_notified_things": {
 												// Property: NumberOfNotifiedThings
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"number_of_succeeded_things": {
 												// Property: NumberOfSucceededThings
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -334,7 +334,7 @@ func jobTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					"maximum_per_minute": {
 						// Property: MaximumPerMinute
 						Description: "The maximum number of things that will be notified of a pending job, per minute. This parameter allows you to create a staged rollout.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -384,7 +384,7 @@ func jobTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					"expires_in_sec": {
 						// Property: ExpiresInSec
 						Description: "How number (in seconds) pre-signed URLs are valid.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"role_arn": {
@@ -475,7 +475,7 @@ func jobTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					"in_progress_timeout_in_minutes": {
 						// Property: InProgressTimeoutInMinutes
 						Description: "Specifies the amount of time, in minutes, this device has to finish execution of this job.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/iot/security_profile_resource_gen.go
+++ b/internal/aws/iot/security_profile_resource_gen.go
@@ -405,7 +405,7 @@ func securityProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error
 								"consecutive_datapoints_to_alarm": {
 									// Property: ConsecutiveDatapointsToAlarm
 									Description: "If a device is in violation of the behavior for the specified number of consecutive datapoints, an alarm occurs. If not specified, the default is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 10),
@@ -414,7 +414,7 @@ func securityProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error
 								"consecutive_datapoints_to_clear": {
 									// Property: ConsecutiveDatapointsToClear
 									Description: "If an alarm has occurred and the offending device is no longer in violation of the behavior for the specified number of consecutive datapoints, the alarm is cleared. If not specified, the default is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 10),
@@ -423,7 +423,7 @@ func securityProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error
 								"duration_seconds": {
 									// Property: DurationSeconds
 									Description: "Use this to specify the time duration over which the behavior is evaluated.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"ml_detection_config": {
@@ -499,19 +499,19 @@ func securityProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error
 											"number": {
 												// Property: Number
 												Description: "The numeral value of a metric.",
-												Type:        types.NumberType,
+												Type:        types.Float64Type,
 												Optional:    true,
 											},
 											"numbers": {
 												// Property: Numbers
 												Description: "The numeral values of a metric.",
-												Type:        types.SetType{ElemType: types.NumberType},
+												Type:        types.SetType{ElemType: types.Float64Type},
 												Optional:    true,
 											},
 											"ports": {
 												// Property: Ports
 												Description: "If the ComparisonOperator calls for a set of ports, use this to specify that set to be compared with the metric.",
-												Type:        types.SetType{ElemType: types.NumberType},
+												Type:        types.SetType{ElemType: types.Int64Type},
 												Optional:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.ArrayForEach(validate.IntBetween(0, 65535)),

--- a/internal/aws/iot/security_profile_singular_data_source_gen.go
+++ b/internal/aws/iot/security_profile_singular_data_source_gen.go
@@ -372,19 +372,19 @@ func securityProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 								"consecutive_datapoints_to_alarm": {
 									// Property: ConsecutiveDatapointsToAlarm
 									Description: "If a device is in violation of the behavior for the specified number of consecutive datapoints, an alarm occurs. If not specified, the default is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"consecutive_datapoints_to_clear": {
 									// Property: ConsecutiveDatapointsToClear
 									Description: "If an alarm has occurred and the offending device is no longer in violation of the behavior for the specified number of consecutive datapoints, the alarm is cleared. If not specified, the default is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"duration_seconds": {
 									// Property: DurationSeconds
 									Description: "Use this to specify the time duration over which the behavior is evaluated.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"ml_detection_config": {
@@ -437,19 +437,19 @@ func securityProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 											"number": {
 												// Property: Number
 												Description: "The numeral value of a metric.",
-												Type:        types.NumberType,
+												Type:        types.Float64Type,
 												Computed:    true,
 											},
 											"numbers": {
 												// Property: Numbers
 												Description: "The numeral values of a metric.",
-												Type:        types.SetType{ElemType: types.NumberType},
+												Type:        types.SetType{ElemType: types.Float64Type},
 												Computed:    true,
 											},
 											"ports": {
 												// Property: Ports
 												Description: "If the ComparisonOperator calls for a set of ports, use this to specify that set to be compared with the metric.",
-												Type:        types.SetType{ElemType: types.NumberType},
+												Type:        types.SetType{ElemType: types.Int64Type},
 												Computed:    true,
 											},
 											"strings": {

--- a/internal/aws/iot/topic_rule_resource_gen.go
+++ b/internal/aws/iot/topic_rule_resource_gen.go
@@ -1952,7 +1952,7 @@ func topicRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"qos": {
 												// Property: Qos
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"role_arn": {
@@ -2728,7 +2728,7 @@ func topicRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"qos": {
 												// Property: Qos
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"role_arn": {

--- a/internal/aws/iot/topic_rule_singular_data_source_gen.go
+++ b/internal/aws/iot/topic_rule_singular_data_source_gen.go
@@ -1934,7 +1934,7 @@ func topicRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 										map[string]tfsdk.Attribute{
 											"qos": {
 												// Property: Qos
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"role_arn": {
@@ -2686,7 +2686,7 @@ func topicRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 										map[string]tfsdk.Attribute{
 											"qos": {
 												// Property: Qos
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"role_arn": {

--- a/internal/aws/iotevents/detector_model_resource_gen.go
+++ b/internal/aws/iotevents/detector_model_resource_gen.go
@@ -2675,7 +2675,7 @@ func detectorModelResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 																				"seconds": {
 																					// Property: Seconds
 																					Description: "The number of seconds until the timer expires. The minimum value is `60` seconds to ensure accuracy. The maximum value is `31622400` seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Optional:    true,
 																					Validators: []tfsdk.AttributeValidator{
 																						validate.IntBetween(60, 31622400),
@@ -3310,7 +3310,7 @@ func detectorModelResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 																				"seconds": {
 																					// Property: Seconds
 																					Description: "The number of seconds until the timer expires. The minimum value is `60` seconds to ensure accuracy. The maximum value is `31622400` seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Optional:    true,
 																					Validators: []tfsdk.AttributeValidator{
 																						validate.IntBetween(60, 31622400),
@@ -3945,7 +3945,7 @@ func detectorModelResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 																				"seconds": {
 																					// Property: Seconds
 																					Description: "The number of seconds until the timer expires. The minimum value is `60` seconds to ensure accuracy. The maximum value is `31622400` seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Optional:    true,
 																					Validators: []tfsdk.AttributeValidator{
 																						validate.IntBetween(60, 31622400),
@@ -4571,7 +4571,7 @@ func detectorModelResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 																				"seconds": {
 																					// Property: Seconds
 																					Description: "The number of seconds until the timer expires. The minimum value is `60` seconds to ensure accuracy. The maximum value is `31622400` seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Optional:    true,
 																					Validators: []tfsdk.AttributeValidator{
 																						validate.IntBetween(60, 31622400),

--- a/internal/aws/iotevents/detector_model_singular_data_source_gen.go
+++ b/internal/aws/iotevents/detector_model_singular_data_source_gen.go
@@ -2635,7 +2635,7 @@ func detectorModelDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 																				"seconds": {
 																					// Property: Seconds
 																					Description: "The number of seconds until the timer expires. The minimum value is `60` seconds to ensure accuracy. The maximum value is `31622400` seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Computed:    true,
 																				},
 																				"timer_name": {
@@ -3201,7 +3201,7 @@ func detectorModelDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 																				"seconds": {
 																					// Property: Seconds
 																					Description: "The number of seconds until the timer expires. The minimum value is `60` seconds to ensure accuracy. The maximum value is `31622400` seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Computed:    true,
 																				},
 																				"timer_name": {
@@ -3767,7 +3767,7 @@ func detectorModelDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 																				"seconds": {
 																					// Property: Seconds
 																					Description: "The number of seconds until the timer expires. The minimum value is `60` seconds to ensure accuracy. The maximum value is `31622400` seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Computed:    true,
 																				},
 																				"timer_name": {
@@ -4324,7 +4324,7 @@ func detectorModelDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 																				"seconds": {
 																					// Property: Seconds
 																					Description: "The number of seconds until the timer expires. The minimum value is `60` seconds to ensure accuracy. The maximum value is `31622400` seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Computed:    true,
 																				},
 																				"timer_name": {

--- a/internal/aws/iotfleethub/application_resource_gen.go
+++ b/internal/aws/iotfleethub/application_resource_gen.go
@@ -45,7 +45,7 @@ func applicationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "When the Application was created",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),
@@ -93,7 +93,7 @@ func applicationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "When the Application was last updated",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/iotfleethub/application_singular_data_source_gen.go
+++ b/internal/aws/iotfleethub/application_singular_data_source_gen.go
@@ -41,7 +41,7 @@ func applicationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "integer"
 			// }
 			Description: "When the Application was created",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"application_description": {
@@ -80,7 +80,7 @@ func applicationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "integer"
 			// }
 			Description: "When the Application was last updated",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"application_name": {

--- a/internal/aws/iotwireless/device_profile_resource_gen.go
+++ b/internal/aws/iotwireless/device_profile_resource_gen.go
@@ -123,7 +123,7 @@ func deviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 				map[string]tfsdk.Attribute{
 					"class_b_timeout": {
 						// Property: ClassBTimeout
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 1000),
@@ -131,7 +131,7 @@ func deviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					},
 					"class_c_timeout": {
 						// Property: ClassCTimeout
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 1000),
@@ -147,7 +147,7 @@ func deviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					},
 					"max_duty_cycle": {
 						// Property: MaxDutyCycle
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 100),
@@ -155,7 +155,7 @@ func deviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					},
 					"max_eirp": {
 						// Property: MaxEirp
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 15),
@@ -163,7 +163,7 @@ func deviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					},
 					"ping_slot_dr": {
 						// Property: PingSlotDr
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 15),
@@ -171,7 +171,7 @@ func deviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					},
 					"ping_slot_freq": {
 						// Property: PingSlotFreq
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1000000, 16700000),
@@ -179,7 +179,7 @@ func deviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					},
 					"ping_slot_period": {
 						// Property: PingSlotPeriod
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(128, 4096),

--- a/internal/aws/iotwireless/device_profile_singular_data_source_gen.go
+++ b/internal/aws/iotwireless/device_profile_singular_data_source_gen.go
@@ -116,12 +116,12 @@ func deviceProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 				map[string]tfsdk.Attribute{
 					"class_b_timeout": {
 						// Property: ClassBTimeout
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"class_c_timeout": {
 						// Property: ClassCTimeout
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"mac_version": {
@@ -131,27 +131,27 @@ func deviceProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 					},
 					"max_duty_cycle": {
 						// Property: MaxDutyCycle
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"max_eirp": {
 						// Property: MaxEirp
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"ping_slot_dr": {
 						// Property: PingSlotDr
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"ping_slot_freq": {
 						// Property: PingSlotFreq
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"ping_slot_period": {
 						// Property: PingSlotPeriod
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"reg_params_revision": {

--- a/internal/aws/iotwireless/multicast_group_resource_gen.go
+++ b/internal/aws/iotwireless/multicast_group_resource_gen.go
@@ -143,7 +143,7 @@ func multicastGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"number_of_devices_in_group": {
 						// Property: NumberOfDevicesInGroup
 						Description: "Multicast group number of devices in group. Returned after successful read.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -152,7 +152,7 @@ func multicastGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"number_of_devices_requested": {
 						// Property: NumberOfDevicesRequested
 						Description: "Multicast group number of devices requested. Returned after successful read.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),

--- a/internal/aws/iotwireless/multicast_group_singular_data_source_gen.go
+++ b/internal/aws/iotwireless/multicast_group_singular_data_source_gen.go
@@ -124,13 +124,13 @@ func multicastGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					"number_of_devices_in_group": {
 						// Property: NumberOfDevicesInGroup
 						Description: "Multicast group number of devices in group. Returned after successful read.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"number_of_devices_requested": {
 						// Property: NumberOfDevicesRequested
 						Description: "Multicast group number of devices requested. Returned after successful read.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"rf_region": {

--- a/internal/aws/iotwireless/service_profile_resource_gen.go
+++ b/internal/aws/iotwireless/service_profile_resource_gen.go
@@ -134,7 +134,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"dev_status_req_freq": {
 						// Property: DevStatusReqFreq
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -142,7 +142,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"dl_bucket_size": {
 						// Property: DlBucketSize
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -150,7 +150,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"dl_rate": {
 						// Property: DlRate
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -166,7 +166,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"dr_max": {
 						// Property: DrMax
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -174,7 +174,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"dr_min": {
 						// Property: DrMin
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -190,7 +190,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"min_gw_diversity": {
 						// Property: MinGwDiversity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -238,7 +238,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"target_per": {
 						// Property: TargetPer
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -246,7 +246,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"ul_bucket_size": {
 						// Property: UlBucketSize
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -254,7 +254,7 @@ func serviceProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"ul_rate": {
 						// Property: UlRate
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),

--- a/internal/aws/iotwireless/service_profile_singular_data_source_gen.go
+++ b/internal/aws/iotwireless/service_profile_singular_data_source_gen.go
@@ -124,17 +124,17 @@ func serviceProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					},
 					"dev_status_req_freq": {
 						// Property: DevStatusReqFreq
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"dl_bucket_size": {
 						// Property: DlBucketSize
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"dl_rate": {
 						// Property: DlRate
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"dl_rate_policy": {
@@ -144,12 +144,12 @@ func serviceProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					},
 					"dr_max": {
 						// Property: DrMax
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"dr_min": {
 						// Property: DrMin
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"hr_allowed": {
@@ -159,7 +159,7 @@ func serviceProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					},
 					"min_gw_diversity": {
 						// Property: MinGwDiversity
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"nwk_geo_loc": {
@@ -189,17 +189,17 @@ func serviceProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					},
 					"target_per": {
 						// Property: TargetPer
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"ul_bucket_size": {
 						// Property: UlBucketSize
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"ul_rate": {
 						// Property: UlRate
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"ul_rate_policy": {

--- a/internal/aws/iotwireless/task_definition_resource_gen.go
+++ b/internal/aws/iotwireless/task_definition_resource_gen.go
@@ -389,7 +389,7 @@ func taskDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								},
 								"sig_key_crc": {
 									// Property: SigKeyCrc
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"update_signature": {

--- a/internal/aws/iotwireless/task_definition_singular_data_source_gen.go
+++ b/internal/aws/iotwireless/task_definition_singular_data_source_gen.go
@@ -338,7 +338,7 @@ func taskDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								},
 								"sig_key_crc": {
 									// Property: SigKeyCrc
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"update_signature": {

--- a/internal/aws/ivs/recording_configuration_resource_gen.go
+++ b/internal/aws/ivs/recording_configuration_resource_gen.go
@@ -245,7 +245,7 @@ func recordingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 					"target_interval_seconds": {
 						// Property: TargetIntervalSeconds
 						Description: "Thumbnail recording Target Interval Seconds defines the interval at which thumbnails are recorded. This field is required if RecordingMode is INTERVAL.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Computed:    true,
 						Validators: []tfsdk.AttributeValidator{

--- a/internal/aws/ivs/recording_configuration_singular_data_source_gen.go
+++ b/internal/aws/ivs/recording_configuration_singular_data_source_gen.go
@@ -200,7 +200,7 @@ func recordingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 					"target_interval_seconds": {
 						// Property: TargetIntervalSeconds
 						Description: "Thumbnail recording Target Interval Seconds defines the interval at which thumbnails are recorded. This field is required if RecordingMode is INTERVAL.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/kafkaconnect/connector_resource_gen.go
+++ b/internal/aws/kafkaconnect/connector_resource_gen.go
@@ -141,13 +141,13 @@ func connectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"max_worker_count": {
 									// Property: MaxWorkerCount
 									Description: "The maximum number of workers for a connector.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 								},
 								"mcu_count": {
 									// Property: McuCount
 									Description: "Specifies how many MSK Connect Units (MCU) as the minimum scaling unit.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntInSlice([]int{
@@ -161,7 +161,7 @@ func connectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"min_worker_count": {
 									// Property: MinWorkerCount
 									Description: "The minimum number of workers for a connector.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 								},
 								"scale_in_policy": {
@@ -172,7 +172,7 @@ func connectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"cpu_utilization_percentage": {
 												// Property: CpuUtilizationPercentage
 												Description: "Specifies the CPU utilization percentage threshold at which connector scale in should trigger.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 100),
@@ -190,7 +190,7 @@ func connectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"cpu_utilization_percentage": {
 												// Property: CpuUtilizationPercentage
 												Description: "Specifies the CPU utilization percentage threshold at which connector scale out should trigger.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 100),
@@ -212,7 +212,7 @@ func connectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"mcu_count": {
 									// Property: McuCount
 									Description: "Specifies how many MSK Connect Units (MCU) are allocated to the connector.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntInSlice([]int{
@@ -226,7 +226,7 @@ func connectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"worker_count": {
 									// Property: WorkerCount
 									Description: "Number of workers for a connector.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 								},
 							},
@@ -758,7 +758,7 @@ func connectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"revision": {
 									// Property: Revision
 									Description: "The revision of the custom plugin to use.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -825,7 +825,7 @@ func connectorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"revision": {
 						// Property: Revision
 						Description: "The revision of the worker configuration to use.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(1),

--- a/internal/aws/kafkaconnect/connector_singular_data_source_gen.go
+++ b/internal/aws/kafkaconnect/connector_singular_data_source_gen.go
@@ -140,19 +140,19 @@ func connectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 								"max_worker_count": {
 									// Property: MaxWorkerCount
 									Description: "The maximum number of workers for a connector.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"mcu_count": {
 									// Property: McuCount
 									Description: "Specifies how many MSK Connect Units (MCU) as the minimum scaling unit.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"min_worker_count": {
 									// Property: MinWorkerCount
 									Description: "The minimum number of workers for a connector.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"scale_in_policy": {
@@ -163,7 +163,7 @@ func connectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											"cpu_utilization_percentage": {
 												// Property: CpuUtilizationPercentage
 												Description: "Specifies the CPU utilization percentage threshold at which connector scale in should trigger.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},
@@ -178,7 +178,7 @@ func connectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											"cpu_utilization_percentage": {
 												// Property: CpuUtilizationPercentage
 												Description: "Specifies the CPU utilization percentage threshold at which connector scale out should trigger.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},
@@ -197,13 +197,13 @@ func connectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 								"mcu_count": {
 									// Property: McuCount
 									Description: "Specifies how many MSK Connect Units (MCU) are allocated to the connector.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"worker_count": {
 									// Property: WorkerCount
 									Description: "Number of workers for a connector.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -671,7 +671,7 @@ func connectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 								"revision": {
 									// Property: Revision
 									Description: "The revision of the custom plugin to use.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -726,7 +726,7 @@ func connectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					"revision": {
 						// Property: Revision
 						Description: "The revision of the worker configuration to use.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"worker_configuration_arn": {

--- a/internal/aws/kendra/data_source_resource_gen.go
+++ b/internal/aws/kendra/data_source_resource_gen.go
@@ -2199,7 +2199,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"database_port": {
 												// Property: DatabasePort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 65535),
@@ -3425,7 +3425,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"port": {
 															// Property: Port
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Required: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntBetween(1, 65535),
@@ -3445,7 +3445,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"crawl_depth": {
 									// Property: CrawlDepth
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 10),
@@ -3453,7 +3453,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"max_content_size_per_page_in_mega_bytes": {
 									// Property: MaxContentSizePerPageInMegaBytes
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(0.000000, 50.000000),
@@ -3461,7 +3461,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"max_links_per_page": {
 									// Property: MaxLinksPerPage
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 1000),
@@ -3469,7 +3469,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"max_urls_per_minute_crawl_rate": {
 									// Property: MaxUrlsPerMinuteCrawlRate
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 300),
@@ -3497,7 +3497,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"port": {
 												// Property: Port
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 65535),

--- a/internal/aws/kendra/data_source_singular_data_source_gen.go
+++ b/internal/aws/kendra/data_source_singular_data_source_gen.go
@@ -2037,7 +2037,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 											},
 											"database_port": {
 												// Property: DatabasePort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"secret_arn": {
@@ -2852,7 +2852,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														},
 														"port": {
 															// Property: Port
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 													},
@@ -2866,22 +2866,22 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								},
 								"crawl_depth": {
 									// Property: CrawlDepth
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"max_content_size_per_page_in_mega_bytes": {
 									// Property: MaxContentSizePerPageInMegaBytes
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"max_links_per_page": {
 									// Property: MaxLinksPerPage
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"max_urls_per_minute_crawl_rate": {
 									// Property: MaxUrlsPerMinuteCrawlRate
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"proxy_configuration": {
@@ -2900,7 +2900,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 											},
 											"port": {
 												// Property: Port
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},

--- a/internal/aws/kendra/index_resource_gen.go
+++ b/internal/aws/kendra/index_resource_gen.go
@@ -60,7 +60,7 @@ func indexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 				map[string]tfsdk.Attribute{
 					"query_capacity_units": {
 						// Property: QueryCapacityUnits
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Required: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -68,7 +68,7 @@ func indexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"storage_capacity_units": {
 						// Property: StorageCapacityUnits
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Required: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -219,7 +219,7 @@ func indexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"importance": {
 									// Property: Importance
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 10),
@@ -250,7 +250,7 @@ func indexResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"value": {
 												// Property: Value
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 10),

--- a/internal/aws/kendra/index_singular_data_source_gen.go
+++ b/internal/aws/kendra/index_singular_data_source_gen.go
@@ -56,12 +56,12 @@ func indexDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 				map[string]tfsdk.Attribute{
 					"query_capacity_units": {
 						// Property: QueryCapacityUnits
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"storage_capacity_units": {
 						// Property: StorageCapacityUnits
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},
@@ -200,7 +200,7 @@ func indexDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"importance": {
 									// Property: Importance
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"rank_order": {
@@ -219,7 +219,7 @@ func indexDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											},
 											"value": {
 												// Property: Value
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},

--- a/internal/aws/kinesis/stream_resource_gen.go
+++ b/internal/aws/kinesis/stream_resource_gen.go
@@ -66,7 +66,7 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of hours for the data records that are stored in shards to remain accessible.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(24),
@@ -81,7 +81,7 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of shards that the stream uses. Required when StreamMode = PROVISIONED is passed.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(1),

--- a/internal/aws/kinesis/stream_singular_data_source_gen.go
+++ b/internal/aws/kinesis/stream_singular_data_source_gen.go
@@ -53,7 +53,7 @@ func streamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of hours for the data records that are stored in shards to remain accessible.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"shard_count": {
@@ -65,7 +65,7 @@ func streamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of shards that the stream uses. Required when StreamMode = PROVISIONED is passed.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"stream_encryption": {

--- a/internal/aws/kinesisfirehose/delivery_stream_resource_gen.go
+++ b/internal/aws/kinesisfirehose/delivery_stream_resource_gen.go
@@ -306,12 +306,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -445,7 +445,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -489,12 +489,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1042,12 +1042,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -1181,7 +1181,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -1225,12 +1225,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1824,12 +1824,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -1952,7 +1952,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 																map[string]tfsdk.Attribute{
 																	"block_size_bytes": {
 																		// Property: BlockSizeBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"bloom_filter_columns": {
@@ -1965,7 +1965,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 																	},
 																	"bloom_filter_false_positive_probability": {
 																		// Property: BloomFilterFalsePositiveProbability
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Optional: true,
 																	},
 																	"compression": {
@@ -1975,7 +1975,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 																	},
 																	"dictionary_key_threshold": {
 																		// Property: DictionaryKeyThreshold
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Optional: true,
 																	},
 																	"enable_padding": {
@@ -1990,17 +1990,17 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 																	},
 																	"padding_tolerance": {
 																		// Property: PaddingTolerance
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Optional: true,
 																	},
 																	"row_index_stride": {
 																		// Property: RowIndexStride
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"stripe_size_bytes": {
 																		// Property: StripeSizeBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																},
@@ -2013,7 +2013,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 																map[string]tfsdk.Attribute{
 																	"block_size_bytes": {
 																		// Property: BlockSizeBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"compression": {
@@ -2028,12 +2028,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 																	},
 																	"max_padding_bytes": {
 																		// Property: MaxPaddingBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"page_size_bytes": {
 																		// Property: PageSizeBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Optional: true,
 																	},
 																	"writer_version": {
@@ -2113,7 +2113,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 										map[string]tfsdk.Attribute{
 											"duration_in_seconds": {
 												// Property: DurationInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2257,12 +2257,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2653,12 +2653,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -2834,7 +2834,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -2872,12 +2872,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -3505,7 +3505,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -3538,12 +3538,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -3675,12 +3675,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -3907,12 +3907,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -4250,7 +4250,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"hec_acknowledgment_timeout_in_seconds": {
 						// Property: HECAcknowledgmentTimeoutInSeconds
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(180, 600),
@@ -4349,7 +4349,7 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},
@@ -4379,12 +4379,12 @@ func deliveryStreamResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},

--- a/internal/aws/kinesisfirehose/delivery_stream_singular_data_source_gen.go
+++ b/internal/aws/kinesisfirehose/delivery_stream_singular_data_source_gen.go
@@ -305,12 +305,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -412,7 +412,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -444,12 +444,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -922,12 +922,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1029,7 +1029,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1061,12 +1061,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1613,12 +1613,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -1729,7 +1729,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 																map[string]tfsdk.Attribute{
 																	"block_size_bytes": {
 																		// Property: BlockSizeBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"bloom_filter_columns": {
@@ -1739,7 +1739,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 																	},
 																	"bloom_filter_false_positive_probability": {
 																		// Property: BloomFilterFalsePositiveProbability
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Computed: true,
 																	},
 																	"compression": {
@@ -1749,7 +1749,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 																	},
 																	"dictionary_key_threshold": {
 																		// Property: DictionaryKeyThreshold
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Computed: true,
 																	},
 																	"enable_padding": {
@@ -1764,17 +1764,17 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 																	},
 																	"padding_tolerance": {
 																		// Property: PaddingTolerance
-																		Type:     types.NumberType,
+																		Type:     types.Float64Type,
 																		Computed: true,
 																	},
 																	"row_index_stride": {
 																		// Property: RowIndexStride
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"stripe_size_bytes": {
 																		// Property: StripeSizeBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -1787,7 +1787,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 																map[string]tfsdk.Attribute{
 																	"block_size_bytes": {
 																		// Property: BlockSizeBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"compression": {
@@ -1802,12 +1802,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 																	},
 																	"max_padding_bytes": {
 																		// Property: MaxPaddingBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"page_size_bytes": {
 																		// Property: PageSizeBytes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																	"writer_version": {
@@ -1884,7 +1884,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 										map[string]tfsdk.Attribute{
 											"duration_in_seconds": {
 												// Property: DurationInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1997,12 +1997,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -2364,12 +2364,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -2506,7 +2506,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -2538,12 +2538,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -3108,7 +3108,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -3135,12 +3135,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -3240,12 +3240,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -3443,12 +3443,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"interval_in_seconds": {
 									// Property: IntervalInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"size_in_m_bs": {
 									// Property: SizeInMBs
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -3763,7 +3763,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					},
 					"hec_acknowledgment_timeout_in_seconds": {
 						// Property: HECAcknowledgmentTimeoutInSeconds
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"hec_endpoint": {
@@ -3833,7 +3833,7 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"duration_in_seconds": {
 									// Property: DurationInSeconds
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -3860,12 +3860,12 @@ func deliveryStreamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 										map[string]tfsdk.Attribute{
 											"interval_in_seconds": {
 												// Property: IntervalInSeconds
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"size_in_m_bs": {
 												// Property: SizeInMBs
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},

--- a/internal/aws/kinesisvideo/signaling_channel_resource_gen.go
+++ b/internal/aws/kinesisvideo/signaling_channel_resource_gen.go
@@ -44,7 +44,7 @@ func signalingChannelResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 			//   "type": "integer"
 			// }
 			Description: "The period of time a signaling channel retains undelivered messages before they are discarded.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(5, 120),

--- a/internal/aws/kinesisvideo/signaling_channel_singular_data_source_gen.go
+++ b/internal/aws/kinesisvideo/signaling_channel_singular_data_source_gen.go
@@ -40,7 +40,7 @@ func signalingChannelDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 			//   "type": "integer"
 			// }
 			Description: "The period of time a signaling channel retains undelivered messages before they are discarded.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {

--- a/internal/aws/kinesisvideo/stream_resource_gen.go
+++ b/internal/aws/kinesisvideo/stream_resource_gen.go
@@ -44,7 +44,7 @@ func streamResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of hours till which Kinesis Video will retain the data in the stream",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(0, 87600),

--- a/internal/aws/kinesisvideo/stream_singular_data_source_gen.go
+++ b/internal/aws/kinesisvideo/stream_singular_data_source_gen.go
@@ -40,7 +40,7 @@ func streamDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of hours till which Kinesis Video will retain the data in the stream",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"device_name": {

--- a/internal/aws/kms/key_resource_gen.go
+++ b/internal/aws/kms/key_resource_gen.go
@@ -186,7 +186,7 @@ func keyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Specifies the number of days in the waiting period before AWS KMS deletes a CMK that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(7, 30),

--- a/internal/aws/kms/key_singular_data_source_gen.go
+++ b/internal/aws/kms/key_singular_data_source_gen.go
@@ -143,7 +143,7 @@ func keyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Specifies the number of days in the waiting period before AWS KMS deletes a CMK that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"tags": {

--- a/internal/aws/kms/replica_key_resource_gen.go
+++ b/internal/aws/kms/replica_key_resource_gen.go
@@ -92,7 +92,7 @@ func replicaKeyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Specifies the number of days in the waiting period before AWS KMS deletes a CMK that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(7, 30),

--- a/internal/aws/kms/replica_key_singular_data_source_gen.go
+++ b/internal/aws/kms/replica_key_singular_data_source_gen.go
@@ -82,7 +82,7 @@ func replicaKeyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Specifies the number of days in the waiting period before AWS KMS deletes a CMK that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"primary_key_arn": {

--- a/internal/aws/lambda/event_source_mapping_resource_gen.go
+++ b/internal/aws/lambda/event_source_mapping_resource_gen.go
@@ -30,7 +30,7 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "integer"
 			// }
 			Description: "The maximum number of items to retrieve in a single batch.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1, 10000),
@@ -260,7 +260,7 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "integer"
 			// }
 			Description: "(Streams) The maximum amount of time to gather records before invoking the function, in seconds.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(0, 300),
@@ -276,7 +276,7 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "integer"
 			// }
 			Description: "(Streams) The maximum age of a record that Lambda sends to a function for processing.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(-1, 604800),
@@ -292,7 +292,7 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "integer"
 			// }
 			Description: "(Streams) The maximum number of times to retry when the function returns an error.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(-1, 10000),
@@ -308,7 +308,7 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "integer"
 			// }
 			Description: "(Streams) The number of batches to process from each shard concurrently.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1, 10),
@@ -509,7 +509,7 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "number"
 			// }
 			Description: "With StartingPosition set to AT_TIMESTAMP, the time from which to start reading, in Unix time seconds.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Optional:    true,
 		},
 		"topics": {
@@ -547,7 +547,7 @@ func eventSourceMappingResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "integer"
 			// }
 			Description: "(Streams) Tumbling window (non-overlapping time window) duration to perform aggregations.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(0, 900),

--- a/internal/aws/lambda/event_source_mapping_singular_data_source_gen.go
+++ b/internal/aws/lambda/event_source_mapping_singular_data_source_gen.go
@@ -29,7 +29,7 @@ func eventSourceMappingDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "integer"
 			// }
 			Description: "The maximum number of items to retrieve in a single batch.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"bisect_batch_on_function_error": {
@@ -226,7 +226,7 @@ func eventSourceMappingDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "integer"
 			// }
 			Description: "(Streams) The maximum amount of time to gather records before invoking the function, in seconds.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"maximum_record_age_in_seconds": {
@@ -239,7 +239,7 @@ func eventSourceMappingDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "integer"
 			// }
 			Description: "(Streams) The maximum age of a record that Lambda sends to a function for processing.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"maximum_retry_attempts": {
@@ -252,7 +252,7 @@ func eventSourceMappingDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "integer"
 			// }
 			Description: "(Streams) The maximum number of times to retry when the function returns an error.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"parallelization_factor": {
@@ -265,7 +265,7 @@ func eventSourceMappingDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "integer"
 			// }
 			Description: "(Streams) The number of batches to process from each shard concurrently.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"queues": {
@@ -421,7 +421,7 @@ func eventSourceMappingDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "number"
 			// }
 			Description: "With StartingPosition set to AT_TIMESTAMP, the time from which to start reading, in Unix time seconds.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"topics": {
@@ -454,7 +454,7 @@ func eventSourceMappingDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "integer"
 			// }
 			Description: "(Streams) Tumbling window (non-overlapping time window) duration to perform aggregations.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 	}

--- a/internal/aws/lambda/function_resource_gen.go
+++ b/internal/aws/lambda/function_resource_gen.go
@@ -429,7 +429,7 @@ func functionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The amount of memory that your function has access to. Increasing the function's memory also increases its CPU allocation. The default value is 128 MB. The value must be a multiple of 64 MB.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"package_type": {
@@ -462,7 +462,7 @@ func functionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of simultaneous executions to reserve for the function.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(0),
@@ -556,7 +556,7 @@ func functionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The amount of time that Lambda allows a function to run before stopping it. The default is 3 seconds. The maximum allowed value is 900 seconds.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(1),

--- a/internal/aws/lambda/function_singular_data_source_gen.go
+++ b/internal/aws/lambda/function_singular_data_source_gen.go
@@ -376,7 +376,7 @@ func functionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The amount of memory that your function has access to. Increasing the function's memory also increases its CPU allocation. The default value is 128 MB. The value must be a multiple of 64 MB.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"package_type": {
@@ -403,7 +403,7 @@ func functionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of simultaneous executions to reserve for the function.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"role": {
@@ -488,7 +488,7 @@ func functionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The amount of time that Lambda allows a function to run before stopping it. The default is 3 seconds. The maximum allowed value is 900 seconds.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"tracing_config": {

--- a/internal/aws/lex/bot_resource_gen.go
+++ b/internal/aws/lex/bot_resource_gen.go
@@ -3975,7 +3975,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																	"delay_in_seconds": {
 																		// Property: DelayInSeconds
 																		Description: "The delay between when the Lambda fulfillment function starts running and the start message is played. If the Lambda function returns before the delay is over, the start message isn't played.",
-																		Type:        types.NumberType,
+																		Type:        types.Int64Type,
 																		Required:    true,
 																		Validators: []tfsdk.AttributeValidator{
 																			validate.IntBetween(1, 900),
@@ -4277,7 +4277,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"timeout_in_seconds": {
 															// Property: TimeoutInSeconds
 															Description: "The length of time that the fulfillment Lambda function should run before it times out.",
-															Type:        types.NumberType,
+															Type:        types.Int64Type,
 															Optional:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntBetween(1, 900),
@@ -4297,7 +4297,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																	"frequency_in_seconds": {
 																		// Property: FrequencyInSeconds
 																		Description: "The frequency that a message is sent to the user. When the period ends, Amazon Lex chooses a message from the message groups and plays it to the user. If the fulfillment Lambda returns before the first period ends, an update message is not played to the user.",
-																		Type:        types.NumberType,
+																		Type:        types.Int64Type,
 																		Required:    true,
 																		Validators: []tfsdk.AttributeValidator{
 																			validate.IntBetween(1, 900),
@@ -6196,7 +6196,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"max_retries": {
 															// Property: MaxRetries
 															Description: "The maximum number of times the bot tries to elicit a resonse from the user using this prompt.",
-															Type:        types.NumberType,
+															Type:        types.Int64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntBetween(0, 5),
@@ -6558,7 +6558,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"time_to_live_in_seconds": {
 												// Property: TimeToLiveInSeconds
 												Description: "The amount of time, in seconds, that the output context should remain active.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(5, 86400),
@@ -6567,7 +6567,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"turns_to_live": {
 												// Property: TurnsToLive
 												Description: "The number of conversation turns that the output context should remain active.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 20),
@@ -6617,7 +6617,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"priority": {
 												// Property: Priority
 												Description: "The priority that a slot should be elicited.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(0, 100),
@@ -6757,7 +6757,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																	"max_retries": {
 																		// Property: MaxRetries
 																		Description: "The maximum number of times the bot tries to elicit a resonse from the user using this prompt.",
-																		Type:        types.NumberType,
+																		Type:        types.Int64Type,
 																		Required:    true,
 																		Validators: []tfsdk.AttributeValidator{
 																			validate.IntBetween(0, 5),
@@ -7416,7 +7416,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																				"frequency_in_seconds": {
 																					// Property: FrequencyInSeconds
 																					Description: "How often a message should be sent to the user in seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Required:    true,
 																					Validators: []tfsdk.AttributeValidator{
 																						validate.IntBetween(1, 300),
@@ -7714,7 +7714,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																				"timeout_in_seconds": {
 																					// Property: TimeoutInSeconds
 																					Description: "If Amazon Lex waits longer than this length of time in seconds for a response, it will stop sending messages.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Required:    true,
 																					Validators: []tfsdk.AttributeValidator{
 																						validate.IntBetween(1, 900),
@@ -8061,7 +8061,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"nlu_confidence_threshold": {
 						// Property: NluConfidenceThreshold
 						Description: "The specified confidence threshold for inserting the AMAZON.FallbackIntent and AMAZON.KendraSearchIntent intents.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 1.000000),
@@ -8411,7 +8411,7 @@ func botResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "IdleSessionTTLInSeconds of the resource",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(60, 86400),

--- a/internal/aws/lex/bot_singular_data_source_gen.go
+++ b/internal/aws/lex/bot_singular_data_source_gen.go
@@ -3954,7 +3954,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 																	"delay_in_seconds": {
 																		// Property: DelayInSeconds
 																		Description: "The delay between when the Lambda fulfillment function starts running and the start message is played. If the Lambda function returns before the delay is over, the start message isn't played.",
-																		Type:        types.NumberType,
+																		Type:        types.Int64Type,
 																		Computed:    true,
 																	},
 																	"message_groups": {
@@ -4181,7 +4181,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 														"timeout_in_seconds": {
 															// Property: TimeoutInSeconds
 															Description: "The length of time that the fulfillment Lambda function should run before it times out.",
-															Type:        types.NumberType,
+															Type:        types.Int64Type,
 															Computed:    true,
 														},
 														"update_response": {
@@ -4198,7 +4198,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 																	"frequency_in_seconds": {
 																		// Property: FrequencyInSeconds
 																		Description: "The frequency that a message is sent to the user. When the period ends, Amazon Lex chooses a message from the message groups and plays it to the user. If the fulfillment Lambda returns before the first period ends, an update message is not played to the user.",
-																		Type:        types.NumberType,
+																		Type:        types.Int64Type,
 																		Computed:    true,
 																	},
 																	"message_groups": {
@@ -5653,7 +5653,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 														"max_retries": {
 															// Property: MaxRetries
 															Description: "The maximum number of times the bot tries to elicit a resonse from the user using this prompt.",
-															Type:        types.NumberType,
+															Type:        types.Int64Type,
 															Computed:    true,
 														},
 														"message_groups_list": {
@@ -5928,13 +5928,13 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"time_to_live_in_seconds": {
 												// Property: TimeToLiveInSeconds
 												Description: "The amount of time, in seconds, that the output context should remain active.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"turns_to_live": {
 												// Property: TurnsToLive
 												Description: "The number of conversation turns that the output context should remain active.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},
@@ -5972,7 +5972,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"priority": {
 												// Property: Priority
 												Description: "The priority that a slot should be elicited.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"slot_name": {
@@ -6082,7 +6082,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 																	"max_retries": {
 																		// Property: MaxRetries
 																		Description: "The maximum number of times the bot tries to elicit a resonse from the user using this prompt.",
-																		Type:        types.NumberType,
+																		Type:        types.Int64Type,
 																		Computed:    true,
 																	},
 																	"message_groups_list": {
@@ -6585,7 +6585,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 																				"frequency_in_seconds": {
 																					// Property: FrequencyInSeconds
 																					Description: "How often a message should be sent to the user in seconds.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Computed:    true,
 																				},
 																				"message_groups_list": {
@@ -6808,7 +6808,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 																				"timeout_in_seconds": {
 																					// Property: TimeoutInSeconds
 																					Description: "If Amazon Lex waits longer than this length of time in seconds for a response, it will stop sending messages.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Computed:    true,
 																				},
 																			},
@@ -7074,7 +7074,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"nlu_confidence_threshold": {
 						// Property: NluConfidenceThreshold
 						Description: "The specified confidence threshold for inserting the AMAZON.FallbackIntent and AMAZON.KendraSearchIntent intents.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"slot_types": {
@@ -7359,7 +7359,7 @@ func botDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "IdleSessionTTLInSeconds of the resource",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {

--- a/internal/aws/licensemanager/license_resource_gen.go
+++ b/internal/aws/licensemanager/license_resource_gen.go
@@ -84,7 +84,7 @@ func licenseResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"max_time_to_live_in_minutes": {
 									// Property: MaxTimeToLiveInMinutes
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 								},
 							},
@@ -97,7 +97,7 @@ func licenseResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 							map[string]tfsdk.Attribute{
 								"max_time_to_live_in_minutes": {
 									// Property: MaxTimeToLiveInMinutes
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 								},
 							},
@@ -157,7 +157,7 @@ func licenseResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"max_count": {
 						// Property: MaxCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 					"name": {

--- a/internal/aws/licensemanager/license_singular_data_source_gen.go
+++ b/internal/aws/licensemanager/license_singular_data_source_gen.go
@@ -83,7 +83,7 @@ func licenseDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"max_time_to_live_in_minutes": {
 									// Property: MaxTimeToLiveInMinutes
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -96,7 +96,7 @@ func licenseDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 							map[string]tfsdk.Attribute{
 								"max_time_to_live_in_minutes": {
 									// Property: MaxTimeToLiveInMinutes
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},
@@ -156,7 +156,7 @@ func licenseDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					},
 					"max_count": {
 						// Property: MaxCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"name": {

--- a/internal/aws/lightsail/alarm_resource_gen.go
+++ b/internal/aws/lightsail/alarm_resource_gen.go
@@ -81,7 +81,7 @@ func alarmResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of data points that must be not within the specified threshold to trigger the alarm. If you are setting an \"M out of N\" alarm, this value (datapointsToAlarm) is the M.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"evaluation_periods": {
@@ -92,7 +92,7 @@ func alarmResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of most recent periods over which data is compared to the specified threshold. If you are setting an \"M out of N\" alarm, this value (evaluationPeriods) is the N.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 		},
 		"metric_name": {
@@ -172,7 +172,7 @@ func alarmResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "The value against which the specified statistic is compared.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Required:    true,
 		},
 		"treat_missing_data": {

--- a/internal/aws/lightsail/alarm_singular_data_source_gen.go
+++ b/internal/aws/lightsail/alarm_singular_data_source_gen.go
@@ -75,7 +75,7 @@ func alarmDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of data points that must be not within the specified threshold to trigger the alarm. If you are setting an \"M out of N\" alarm, this value (datapointsToAlarm) is the M.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"evaluation_periods": {
@@ -86,7 +86,7 @@ func alarmDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of most recent periods over which data is compared to the specified threshold. If you are setting an \"M out of N\" alarm, this value (evaluationPeriods) is the N.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"metric_name": {
@@ -157,7 +157,7 @@ func alarmDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "The value against which the specified statistic is compared.",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"treat_missing_data": {

--- a/internal/aws/lightsail/container_resource_gen.go
+++ b/internal/aws/lightsail/container_resource_gen.go
@@ -239,7 +239,7 @@ func containerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"container_port": {
 									// Property: ContainerPort
 									Description: "The port of the container to which traffic is forwarded to.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"health_check_config": {
@@ -250,13 +250,13 @@ func containerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"healthy_threshold": {
 												// Property: HealthyThreshold
 												Description: "The number of consecutive health checks successes required before moving the container to the Healthy state. The default value is 2.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"interval_seconds": {
 												// Property: IntervalSeconds
 												Description: "The approximate interval, in seconds, between health checks of an individual container. You can specify between 5 and 300 seconds. The default value is 5.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"path": {
@@ -274,13 +274,13 @@ func containerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"timeout_seconds": {
 												// Property: TimeoutSeconds
 												Description: "The amount of time, in seconds, during which no response means a failed health check. You can specify between 2 and 60 seconds. The default value is 2.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"unhealthy_threshold": {
 												// Property: UnhealthyThreshold
 												Description: "The number of consecutive health check failures required before moving the container to the Unhealthy state. The default value is 2.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 										},
@@ -374,7 +374,7 @@ func containerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The scale specification for the container service.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(1, 20),

--- a/internal/aws/lightsail/container_singular_data_source_gen.go
+++ b/internal/aws/lightsail/container_singular_data_source_gen.go
@@ -235,7 +235,7 @@ func containerDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 								"container_port": {
 									// Property: ContainerPort
 									Description: "The port of the container to which traffic is forwarded to.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"health_check_config": {
@@ -246,13 +246,13 @@ func containerDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											"healthy_threshold": {
 												// Property: HealthyThreshold
 												Description: "The number of consecutive health checks successes required before moving the container to the Healthy state. The default value is 2.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"interval_seconds": {
 												// Property: IntervalSeconds
 												Description: "The approximate interval, in seconds, between health checks of an individual container. You can specify between 5 and 300 seconds. The default value is 5.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"path": {
@@ -270,13 +270,13 @@ func containerDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 											"timeout_seconds": {
 												// Property: TimeoutSeconds
 												Description: "The amount of time, in seconds, during which no response means a failed health check. You can specify between 2 and 60 seconds. The default value is 2.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"unhealthy_threshold": {
 												// Property: UnhealthyThreshold
 												Description: "The number of consecutive health check failures required before moving the container to the Unhealthy state. The default value is 2.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},
@@ -370,7 +370,7 @@ func containerDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 			//   "type": "integer"
 			// }
 			Description: "The scale specification for the container service.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"service_name": {

--- a/internal/aws/lightsail/disk_resource_gen.go
+++ b/internal/aws/lightsail/disk_resource_gen.go
@@ -210,7 +210,7 @@ func diskResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Iops of the Lightsail disk",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),
@@ -306,7 +306,7 @@ func diskResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Size of the Lightsail disk",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.RequiresReplace(),

--- a/internal/aws/lightsail/disk_singular_data_source_gen.go
+++ b/internal/aws/lightsail/disk_singular_data_source_gen.go
@@ -169,7 +169,7 @@ func diskDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Iops of the Lightsail disk",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"is_attached": {
@@ -250,7 +250,7 @@ func diskDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Size of the Lightsail disk",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"state": {

--- a/internal/aws/lightsail/distribution_resource_gen.go
+++ b/internal/aws/lightsail/distribution_resource_gen.go
@@ -156,7 +156,7 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"default_ttl": {
 						// Property: DefaultTTL
 						Description: "The default amount of time that objects stay in the distribution's cache before the distribution forwards another request to the origin to determine whether the content has been updated.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"forwarded_cookies": {
@@ -225,13 +225,13 @@ func distributionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"maximum_ttl": {
 						// Property: MaximumTTL
 						Description: "The maximum amount of time that objects stay in the distribution's cache before the distribution forwards another request to the origin to determine whether the object has been updated.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"minimum_ttl": {
 						// Property: MinimumTTL
 						Description: "The minimum amount of time that objects stay in the distribution's cache before the distribution forwards another request to the origin to determine whether the object has been updated.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 				},

--- a/internal/aws/lightsail/distribution_singular_data_source_gen.go
+++ b/internal/aws/lightsail/distribution_singular_data_source_gen.go
@@ -152,7 +152,7 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"default_ttl": {
 						// Property: DefaultTTL
 						Description: "The default amount of time that objects stay in the distribution's cache before the distribution forwards another request to the origin to determine whether the content has been updated.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"forwarded_cookies": {
@@ -221,13 +221,13 @@ func distributionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"maximum_ttl": {
 						// Property: MaximumTTL
 						Description: "The maximum amount of time that objects stay in the distribution's cache before the distribution forwards another request to the origin to determine whether the object has been updated.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"minimum_ttl": {
 						// Property: MinimumTTL
 						Description: "The minimum amount of time that objects stay in the distribution's cache before the distribution forwards another request to the origin to determine whether the object has been updated.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/lightsail/instance_resource_gen.go
+++ b/internal/aws/lightsail/instance_resource_gen.go
@@ -252,7 +252,7 @@ func instanceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"cpu_count": {
 						// Property: CpuCount
 						Description: "CPU count of the Instance.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -287,7 +287,7 @@ func instanceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"iops": {
 									// Property: IOPS
 									Description: "IOPS of disk.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"is_system_disk": {
@@ -316,7 +316,7 @@ func instanceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"ram_size_in_gb": {
 						// Property: RamSizeInGb
 						Description: "RAM Size of the Instance.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -586,7 +586,7 @@ func instanceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"from_port": {
 									// Property: FromPort
 									Description: "From Port of the Instance.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"ipv_6_cidrs": {
@@ -607,7 +607,7 @@ func instanceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"to_port": {
 									// Property: ToPort
 									Description: "To Port of the Instance.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 							},
@@ -699,7 +699,7 @@ func instanceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"code": {
 						// Property: Code
 						Description: "Status code of the Instance.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),

--- a/internal/aws/lightsail/instance_singular_data_source_gen.go
+++ b/internal/aws/lightsail/instance_singular_data_source_gen.go
@@ -214,7 +214,7 @@ func instanceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"cpu_count": {
 						// Property: CpuCount
 						Description: "CPU count of the Instance.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"disks": {
@@ -243,7 +243,7 @@ func instanceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"iops": {
 									// Property: IOPS
 									Description: "IOPS of disk.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"is_system_disk": {
@@ -272,7 +272,7 @@ func instanceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"ram_size_in_gb": {
 						// Property: RamSizeInGb
 						Description: "RAM Size of the Instance.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -512,7 +512,7 @@ func instanceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"from_port": {
 									// Property: FromPort
 									Description: "From Port of the Instance.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"ipv_6_cidrs": {
@@ -530,7 +530,7 @@ func instanceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"to_port": {
 									// Property: ToPort
 									Description: "To Port of the Instance.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -610,7 +610,7 @@ func instanceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"code": {
 						// Property: Code
 						Description: "Status code of the Instance.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"name": {

--- a/internal/aws/lightsail/load_balancer_resource_gen.go
+++ b/internal/aws/lightsail/load_balancer_resource_gen.go
@@ -55,7 +55,7 @@ func loadBalancerResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The instance port where you're creating your load balancer.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.RequiresReplace(),

--- a/internal/aws/lightsail/load_balancer_singular_data_source_gen.go
+++ b/internal/aws/lightsail/load_balancer_singular_data_source_gen.go
@@ -54,7 +54,7 @@ func loadBalancerDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 			//   "type": "integer"
 			// }
 			Description: "The instance port where you're creating your load balancer.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"ip_address_type": {

--- a/internal/aws/logs/log_group_resource_gen.go
+++ b/internal/aws/logs/log_group_resource_gen.go
@@ -99,7 +99,7 @@ func logGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntInSlice([]int{

--- a/internal/aws/logs/log_group_singular_data_source_gen.go
+++ b/internal/aws/logs/log_group_singular_data_source_gen.go
@@ -84,7 +84,7 @@ func logGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"tags": {

--- a/internal/aws/lookoutequipment/inference_scheduler_resource_gen.go
+++ b/internal/aws/lookoutequipment/inference_scheduler_resource_gen.go
@@ -30,7 +30,7 @@ func inferenceSchedulerResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "integer"
 			// }
 			Description: "A period of time (in minutes) by which inference on the data is delayed after the data starts.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(0, 60),

--- a/internal/aws/lookoutequipment/inference_scheduler_singular_data_source_gen.go
+++ b/internal/aws/lookoutequipment/inference_scheduler_singular_data_source_gen.go
@@ -29,7 +29,7 @@ func inferenceSchedulerDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "integer"
 			// }
 			Description: "A period of time (in minutes) by which inference on the data is delayed after the data starts.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"data_input_configuration": {

--- a/internal/aws/lookoutmetrics/alert_resource_gen.go
+++ b/internal/aws/lookoutmetrics/alert_resource_gen.go
@@ -193,7 +193,7 @@ func alertResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "A number between 0 and 100 (inclusive) that tunes the sensitivity of the alert.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(0, 100),

--- a/internal/aws/lookoutmetrics/alert_singular_data_source_gen.go
+++ b/internal/aws/lookoutmetrics/alert_singular_data_source_gen.go
@@ -161,7 +161,7 @@ func alertDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "A number between 0 and 100 (inclusive) that tunes the sensitivity of the alert.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"anomaly_detector_arn": {

--- a/internal/aws/lookoutmetrics/anomaly_detector_resource_gen.go
+++ b/internal/aws/lookoutmetrics/anomaly_detector_resource_gen.go
@@ -727,7 +727,7 @@ func anomalyDetectorResourceType(ctx context.Context) (tfsdk.ResourceType, error
 											},
 											"database_port": {
 												// Property: DatabasePort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 65535),
@@ -815,7 +815,7 @@ func anomalyDetectorResourceType(ctx context.Context) (tfsdk.ResourceType, error
 											},
 											"database_port": {
 												// Property: DatabasePort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 65535),
@@ -1005,7 +1005,7 @@ func anomalyDetectorResourceType(ctx context.Context) (tfsdk.ResourceType, error
 					"offset": {
 						// Property: Offset
 						Description: "Offset, in seconds, between the frequency interval and the time at which the metrics are available.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 432000),

--- a/internal/aws/lookoutmetrics/anomaly_detector_singular_data_source_gen.go
+++ b/internal/aws/lookoutmetrics/anomaly_detector_singular_data_source_gen.go
@@ -644,7 +644,7 @@ func anomalyDetectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 											},
 											"database_port": {
 												// Property: DatabasePort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"role_arn": {
@@ -705,7 +705,7 @@ func anomalyDetectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 											},
 											"database_port": {
 												// Property: DatabasePort
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"role_arn": {
@@ -839,7 +839,7 @@ func anomalyDetectorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 					"offset": {
 						// Property: Offset
 						Description: "Offset, in seconds, between the frequency interval and the time at which the metrics are available.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"timestamp_column": {

--- a/internal/aws/macie/custom_data_identifier_resource_gen.go
+++ b/internal/aws/macie/custom_data_identifier_resource_gen.go
@@ -109,7 +109,7 @@ func customDataIdentifierResourceType(ctx context.Context) (tfsdk.ResourceType, 
 			//   "type": "integer"
 			// }
 			Description: "Maximum match distance.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{

--- a/internal/aws/macie/custom_data_identifier_singular_data_source_gen.go
+++ b/internal/aws/macie/custom_data_identifier_singular_data_source_gen.go
@@ -88,7 +88,7 @@ func customDataIdentifierDataSourceType(ctx context.Context) (tfsdk.DataSourceTy
 			//   "type": "integer"
 			// }
 			Description: "Maximum match distance.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {

--- a/internal/aws/macie/findings_filter_resource_gen.go
+++ b/internal/aws/macie/findings_filter_resource_gen.go
@@ -130,22 +130,22 @@ func findingsFilterResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								},
 								"gt": {
 									// Property: gt
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"gte": {
 									// Property: gte
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"lt": {
 									// Property: lt
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"lte": {
 									// Property: lte
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"neq": {
@@ -235,7 +235,7 @@ func findingsFilterResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Findings filter position.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 	}

--- a/internal/aws/macie/findings_filter_singular_data_source_gen.go
+++ b/internal/aws/macie/findings_filter_singular_data_source_gen.go
@@ -120,22 +120,22 @@ func findingsFilterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								},
 								"gt": {
 									// Property: gt
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"gte": {
 									// Property: gte
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"lt": {
 									// Property: lt
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"lte": {
 									// Property: lte
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"neq": {
@@ -219,7 +219,7 @@ func findingsFilterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "Findings filter position.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 	}

--- a/internal/aws/mediaconnect/flow_entitlement_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_entitlement_resource_gen.go
@@ -4,7 +4,6 @@ package mediaconnect
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -30,11 +29,11 @@ func flowEntitlementResourceType(ctx context.Context) (tfsdk.ResourceType, error
 			//   "type": "integer"
 			// }
 			Description: "Percentage from 0-100 of the data transfer cost to be billed to the subscriber.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				DefaultValue(types.Number{Value: big.NewFloat(0)}),
+				DefaultValue(types.Int64{Value: 0}),
 				tfsdk.UseStateForUnknown(),
 				tfsdk.RequiresReplace(),
 			},

--- a/internal/aws/mediaconnect/flow_entitlement_singular_data_source_gen.go
+++ b/internal/aws/mediaconnect/flow_entitlement_singular_data_source_gen.go
@@ -28,7 +28,7 @@ func flowEntitlementDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 			//   "type": "integer"
 			// }
 			Description: "Percentage from 0-100 of the data transfer cost to be billed to the subscriber.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"description": {

--- a/internal/aws/mediaconnect/flow_output_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_output_resource_gen.go
@@ -164,7 +164,7 @@ func flowOutputResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"min_latency": {
@@ -175,7 +175,7 @@ func flowOutputResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The minimum latency in milliseconds.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"name": {
@@ -216,7 +216,7 @@ func flowOutputResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The port to use when content is distributed to this output.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"protocol": {
@@ -267,7 +267,7 @@ func flowOutputResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The smoothing latency in milliseconds for RIST, RTP, and RTP-FEC streams.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"stream_id": {

--- a/internal/aws/mediaconnect/flow_output_singular_data_source_gen.go
+++ b/internal/aws/mediaconnect/flow_output_singular_data_source_gen.go
@@ -145,7 +145,7 @@ func flowOutputDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"min_latency": {
@@ -156,7 +156,7 @@ func flowOutputDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The minimum latency in milliseconds.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {
@@ -189,7 +189,7 @@ func flowOutputDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The port to use when content is distributed to this output.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"protocol": {
@@ -230,7 +230,7 @@ func flowOutputDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The smoothing latency in milliseconds for RIST, RTP, and RTP-FEC streams.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"stream_id": {

--- a/internal/aws/mediaconnect/flow_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_resource_gen.go
@@ -4,7 +4,6 @@ package mediaconnect
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -320,34 +319,34 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"ingest_port": {
 						// Property: IngestPort
 						Description: "The port that the flow will be listening on for incoming content.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"max_bitrate": {
 						// Property: MaxBitrate
 						Description: "The smoothing max bitrate for RIST, RTP, and RTP-FEC streams.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"max_latency": {
 						// Property: MaxLatency
 						Description: "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
-							DefaultValue(types.Number{Value: big.NewFloat(2000)}),
+							DefaultValue(types.Int64{Value: 2000}),
 							tfsdk.UseStateForUnknown(),
 						},
 					},
 					"min_latency": {
 						// Property: MinLatency
 						Description: "The minimum latency in milliseconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
-							DefaultValue(types.Number{Value: big.NewFloat(2000)}),
+							DefaultValue(types.Int64{Value: 2000}),
 							tfsdk.UseStateForUnknown(),
 						},
 					},
@@ -444,7 +443,7 @@ func flowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"recovery_window": {
 						// Property: RecoveryWindow
 						Description: "Search window time to look for dash-7 packets",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"state": {

--- a/internal/aws/mediaconnect/flow_singular_data_source_gen.go
+++ b/internal/aws/mediaconnect/flow_singular_data_source_gen.go
@@ -282,25 +282,25 @@ func flowDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"ingest_port": {
 						// Property: IngestPort
 						Description: "The port that the flow will be listening on for incoming content.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"max_bitrate": {
 						// Property: MaxBitrate
 						Description: "The smoothing max bitrate for RIST, RTP, and RTP-FEC streams.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"max_latency": {
 						// Property: MaxLatency
 						Description: "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"min_latency": {
 						// Property: MinLatency
 						Description: "The minimum latency in milliseconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"name": {
@@ -376,7 +376,7 @@ func flowDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"recovery_window": {
 						// Property: RecoveryWindow
 						Description: "Search window time to look for dash-7 packets",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"state": {

--- a/internal/aws/mediaconnect/flow_source_resource_gen.go
+++ b/internal/aws/mediaconnect/flow_source_resource_gen.go
@@ -4,7 +4,6 @@ package mediaconnect
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -215,7 +214,7 @@ func flowSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The port that the flow will be listening on for incoming content.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"max_bitrate": {
@@ -226,7 +225,7 @@ func flowSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The smoothing max bitrate for RIST, RTP, and RTP-FEC streams.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"max_latency": {
@@ -238,11 +237,11 @@ func flowSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				DefaultValue(types.Number{Value: big.NewFloat(2000)}),
+				DefaultValue(types.Int64{Value: 2000}),
 				tfsdk.UseStateForUnknown(),
 			},
 		},

--- a/internal/aws/mediaconnect/flow_source_singular_data_source_gen.go
+++ b/internal/aws/mediaconnect/flow_source_singular_data_source_gen.go
@@ -192,7 +192,7 @@ func flowSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The port that the flow will be listening on for incoming content.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"max_bitrate": {
@@ -203,7 +203,7 @@ func flowSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The smoothing max bitrate for RIST, RTP, and RTP-FEC streams.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"max_latency": {
@@ -215,7 +215,7 @@ func flowSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The maximum latency in milliseconds. This parameter applies only to RIST-based and Zixi-based streams.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {

--- a/internal/aws/mediapackage/origin_endpoint_resource_gen.go
+++ b/internal/aws/mediapackage/origin_endpoint_resource_gen.go
@@ -289,7 +289,7 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"key_rotation_interval_seconds": {
 									// Property: KeyRotationIntervalSeconds
 									Description: "Time (in seconds) between each encryption key rotation.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"speke_key_provider": {
@@ -420,13 +420,13 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"playlist_window_seconds": {
 									// Property: PlaylistWindowSeconds
 									Description: "Time window (in seconds) contained in each parent manifest.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"program_date_time_interval_seconds": {
 									// Property: ProgramDateTimeIntervalSeconds
 									Description: "The interval (in seconds) between each EXT-X-PROGRAM-DATE-TIME tag inserted into manifests. Additionally, when an interval is specified ID3Timed Metadata messages will be generated every 5 seconds using the ingest time of the content. If the interval is not specified, or set to 0, then no EXT-X-PROGRAM-DATE-TIME tags will be inserted into manifests and no ID3Timed Metadata messages will be generated. Note that irrespective of this parameter, if any ID3 Timed Metadata is found in HTTP Live Streaming (HLS) input, it will be passed through to HLS output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"url": {
@@ -443,7 +443,7 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each segment. Actual segments will be rounded to the nearest multiple of the source segment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"segment_prefix": {
@@ -460,13 +460,13 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"max_video_bits_per_second": {
 									// Property: MaxVideoBitsPerSecond
 									Description: "The maximum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"min_video_bits_per_second": {
 									// Property: MinVideoBitsPerSecond
 									Description: "The minimum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"stream_order": {
@@ -712,7 +712,7 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"key_rotation_interval_seconds": {
 									// Property: KeyRotationIntervalSeconds
 									Description: "Time (in seconds) between each encryption key rotation.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"speke_key_provider": {
@@ -773,19 +773,19 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"manifest_window_seconds": {
 						// Property: ManifestWindowSeconds
 						Description: "Time window (in seconds) contained in each manifest.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"min_buffer_time_seconds": {
 						// Property: MinBufferTimeSeconds
 						Description: "Minimum duration (in seconds) that a player will buffer media before starting the presentation.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"min_update_period_seconds": {
 						// Property: MinUpdatePeriodSeconds
 						Description: "Minimum duration (in seconds) between potential changes to the Dynamic Adaptive Streaming over HTTP (DASH) Media Presentation Description (MPD).",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"period_triggers": {
@@ -814,7 +814,7 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each segment. Actual segments will be rounded to the nearest multiple of the source segment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"segment_template_format": {
@@ -838,13 +838,13 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"max_video_bits_per_second": {
 									// Property: MaxVideoBitsPerSecond
 									Description: "The maximum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"min_video_bits_per_second": {
 									// Property: MinVideoBitsPerSecond
 									Description: "The minimum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"stream_order": {
@@ -867,7 +867,7 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"suggested_presentation_delay_seconds": {
 						// Property: SuggestedPresentationDelaySeconds
 						Description: "Duration (in seconds) to delay live content before presentation.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"utc_timing": {
@@ -1145,7 +1145,7 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"key_rotation_interval_seconds": {
 									// Property: KeyRotationIntervalSeconds
 									Description: "Interval (in seconds) between each encryption key rotation.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"repeat_ext_x_key": {
@@ -1219,19 +1219,19 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"playlist_window_seconds": {
 						// Property: PlaylistWindowSeconds
 						Description: "Time window (in seconds) contained in each parent manifest.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"program_date_time_interval_seconds": {
 						// Property: ProgramDateTimeIntervalSeconds
 						Description: "The interval (in seconds) between each EXT-X-PROGRAM-DATE-TIME tag inserted into manifests. Additionally, when an interval is specified ID3Timed Metadata messages will be generated every 5 seconds using the ingest time of the content. If the interval is not specified, or set to 0, then no EXT-X-PROGRAM-DATE-TIME tags will be inserted into manifests and no ID3Timed Metadata messages will be generated. Note that irrespective of this parameter, if any ID3 Timed Metadata is found in HTTP Live Streaming (HLS) input, it will be passed through to HLS output.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"stream_selection": {
@@ -1242,13 +1242,13 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"max_video_bits_per_second": {
 									// Property: MaxVideoBitsPerSecond
 									Description: "The maximum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"min_video_bits_per_second": {
 									// Property: MinVideoBitsPerSecond
 									Description: "The minimum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"stream_order": {
@@ -1451,13 +1451,13 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					"manifest_window_seconds": {
 						// Property: ManifestWindowSeconds
 						Description: "The time window (in seconds) contained in each manifest.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "The duration (in seconds) of each segment.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"stream_selection": {
@@ -1468,13 +1468,13 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"max_video_bits_per_second": {
 									// Property: MaxVideoBitsPerSecond
 									Description: "The maximum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"min_video_bits_per_second": {
 									// Property: MinVideoBitsPerSecond
 									Description: "The minimum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"stream_order": {
@@ -1527,7 +1527,7 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Maximum duration (seconds) of content to retain for startover playback. If not specified, startover playback will be disabled for the OriginEndpoint.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"tags": {
@@ -1583,7 +1583,7 @@ func originEndpointResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "Amount of delay (seconds) to enforce on the playback of live content. If not specified, there will be no time delay in effect for the OriginEndpoint.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"url": {

--- a/internal/aws/mediapackage/origin_endpoint_singular_data_source_gen.go
+++ b/internal/aws/mediapackage/origin_endpoint_singular_data_source_gen.go
@@ -282,7 +282,7 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"key_rotation_interval_seconds": {
 									// Property: KeyRotationIntervalSeconds
 									Description: "Time (in seconds) between each encryption key rotation.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"speke_key_provider": {
@@ -378,13 +378,13 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"playlist_window_seconds": {
 									// Property: PlaylistWindowSeconds
 									Description: "Time window (in seconds) contained in each parent manifest.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"program_date_time_interval_seconds": {
 									// Property: ProgramDateTimeIntervalSeconds
 									Description: "The interval (in seconds) between each EXT-X-PROGRAM-DATE-TIME tag inserted into manifests. Additionally, when an interval is specified ID3Timed Metadata messages will be generated every 5 seconds using the ingest time of the content. If the interval is not specified, or set to 0, then no EXT-X-PROGRAM-DATE-TIME tags will be inserted into manifests and no ID3Timed Metadata messages will be generated. Note that irrespective of this parameter, if any ID3 Timed Metadata is found in HTTP Live Streaming (HLS) input, it will be passed through to HLS output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"url": {
@@ -401,7 +401,7 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each segment. Actual segments will be rounded to the nearest multiple of the source segment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"segment_prefix": {
@@ -418,13 +418,13 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"max_video_bits_per_second": {
 									// Property: MaxVideoBitsPerSecond
 									Description: "The maximum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"min_video_bits_per_second": {
 									// Property: MinVideoBitsPerSecond
 									Description: "The minimum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"stream_order": {
@@ -643,7 +643,7 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"key_rotation_interval_seconds": {
 									// Property: KeyRotationIntervalSeconds
 									Description: "Time (in seconds) between each encryption key rotation.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"speke_key_provider": {
@@ -698,19 +698,19 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					"manifest_window_seconds": {
 						// Property: ManifestWindowSeconds
 						Description: "Time window (in seconds) contained in each manifest.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"min_buffer_time_seconds": {
 						// Property: MinBufferTimeSeconds
 						Description: "Minimum duration (in seconds) that a player will buffer media before starting the presentation.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"min_update_period_seconds": {
 						// Property: MinUpdatePeriodSeconds
 						Description: "Minimum duration (in seconds) between potential changes to the Dynamic Adaptive Streaming over HTTP (DASH) Media Presentation Description (MPD).",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"period_triggers": {
@@ -728,7 +728,7 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each segment. Actual segments will be rounded to the nearest multiple of the source segment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"segment_template_format": {
@@ -745,13 +745,13 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"max_video_bits_per_second": {
 									// Property: MaxVideoBitsPerSecond
 									Description: "The maximum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"min_video_bits_per_second": {
 									// Property: MinVideoBitsPerSecond
 									Description: "The minimum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"stream_order": {
@@ -767,7 +767,7 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					"suggested_presentation_delay_seconds": {
 						// Property: SuggestedPresentationDelaySeconds
 						Description: "Duration (in seconds) to delay live content before presentation.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"utc_timing": {
@@ -1004,7 +1004,7 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"key_rotation_interval_seconds": {
 									// Property: KeyRotationIntervalSeconds
 									Description: "Interval (in seconds) between each encryption key rotation.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"repeat_ext_x_key": {
@@ -1071,19 +1071,19 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					"playlist_window_seconds": {
 						// Property: PlaylistWindowSeconds
 						Description: "Time window (in seconds) contained in each parent manifest.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"program_date_time_interval_seconds": {
 						// Property: ProgramDateTimeIntervalSeconds
 						Description: "The interval (in seconds) between each EXT-X-PROGRAM-DATE-TIME tag inserted into manifests. Additionally, when an interval is specified ID3Timed Metadata messages will be generated every 5 seconds using the ingest time of the content. If the interval is not specified, or set to 0, then no EXT-X-PROGRAM-DATE-TIME tags will be inserted into manifests and no ID3Timed Metadata messages will be generated. Note that irrespective of this parameter, if any ID3 Timed Metadata is found in HTTP Live Streaming (HLS) input, it will be passed through to HLS output.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"stream_selection": {
@@ -1094,13 +1094,13 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"max_video_bits_per_second": {
 									// Property: MaxVideoBitsPerSecond
 									Description: "The maximum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"min_video_bits_per_second": {
 									// Property: MinVideoBitsPerSecond
 									Description: "The minimum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"stream_order": {
@@ -1290,13 +1290,13 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					"manifest_window_seconds": {
 						// Property: ManifestWindowSeconds
 						Description: "The time window (in seconds) contained in each manifest.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "The duration (in seconds) of each segment.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"stream_selection": {
@@ -1307,13 +1307,13 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"max_video_bits_per_second": {
 									// Property: MaxVideoBitsPerSecond
 									Description: "The maximum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"min_video_bits_per_second": {
 									// Property: MinVideoBitsPerSecond
 									Description: "The minimum video bitrate (bps) to include in output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"stream_order": {
@@ -1353,7 +1353,7 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "Maximum duration (seconds) of content to retain for startover playback. If not specified, startover playback will be disabled for the OriginEndpoint.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"tags": {
@@ -1406,7 +1406,7 @@ func originEndpointDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "Amount of delay (seconds) to enforce on the playback of live content. If not specified, there will be no time delay in effect for the OriginEndpoint.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"url": {

--- a/internal/aws/mediapackage/packaging_configuration_resource_gen.go
+++ b/internal/aws/mediapackage/packaging_configuration_resource_gen.go
@@ -224,7 +224,7 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 								"program_date_time_interval_seconds": {
 									// Property: ProgramDateTimeIntervalSeconds
 									Description: "The interval (in seconds) between each EXT-X-PROGRAM-DATE-TIME tag inserted into manifests. Additionally, when an interval is specified ID3Timed Metadata messages will be generated every 5 seconds using the ingest time of the content. If the interval is not specified, or set to 0, then no EXT-X-PROGRAM-DATE-TIME tags will be inserted into manifests and no ID3Timed Metadata messages will be generated. Note that irrespective of this parameter, if any ID3 Timed Metadata is found in HTTP Live Streaming (HLS) input, it will be passed through to HLS output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"repeat_ext_x_key": {
@@ -241,13 +241,13 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 											"max_video_bits_per_second": {
 												// Property: MaxVideoBitsPerSecond
 												Description: "The maximum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"min_video_bits_per_second": {
 												// Property: MinVideoBitsPerSecond
 												Description: "The minimum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"stream_order": {
@@ -281,7 +281,7 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 				},
@@ -453,7 +453,7 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 								"min_buffer_time_seconds": {
 									// Property: MinBufferTimeSeconds
 									Description: "Minimum duration (in seconds) that a player will buffer media before starting the presentation.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"profile": {
@@ -476,13 +476,13 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 											"max_video_bits_per_second": {
 												// Property: MaxVideoBitsPerSecond
 												Description: "The maximum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"min_video_bits_per_second": {
 												// Property: MinVideoBitsPerSecond
 												Description: "The minimum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"stream_order": {
@@ -563,7 +563,7 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"segment_template_format": {
@@ -803,7 +803,7 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 								"program_date_time_interval_seconds": {
 									// Property: ProgramDateTimeIntervalSeconds
 									Description: "The interval (in seconds) between each EXT-X-PROGRAM-DATE-TIME tag inserted into manifests. Additionally, when an interval is specified ID3Timed Metadata messages will be generated every 5 seconds using the ingest time of the content. If the interval is not specified, or set to 0, then no EXT-X-PROGRAM-DATE-TIME tags will be inserted into manifests and no ID3Timed Metadata messages will be generated. Note that irrespective of this parameter, if any ID3 Timed Metadata is found in HTTP Live Streaming (HLS) input, it will be passed through to HLS output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 								},
 								"repeat_ext_x_key": {
@@ -820,13 +820,13 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 											"max_video_bits_per_second": {
 												// Property: MaxVideoBitsPerSecond
 												Description: "The maximum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"min_video_bits_per_second": {
 												// Property: MinVideoBitsPerSecond
 												Description: "The minimum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"stream_order": {
@@ -854,7 +854,7 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"use_audio_rendition_group": {
@@ -1032,13 +1032,13 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 											"max_video_bits_per_second": {
 												// Property: MaxVideoBitsPerSecond
 												Description: "The maximum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"min_video_bits_per_second": {
 												// Property: MinVideoBitsPerSecond
 												Description: "The minimum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 											},
 											"stream_order": {
@@ -1066,7 +1066,7 @@ func packagingConfigurationResourceType(ctx context.Context) (tfsdk.ResourceType
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 				},

--- a/internal/aws/mediapackage/packaging_configuration_singular_data_source_gen.go
+++ b/internal/aws/mediapackage/packaging_configuration_singular_data_source_gen.go
@@ -213,7 +213,7 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 								"program_date_time_interval_seconds": {
 									// Property: ProgramDateTimeIntervalSeconds
 									Description: "The interval (in seconds) between each EXT-X-PROGRAM-DATE-TIME tag inserted into manifests. Additionally, when an interval is specified ID3Timed Metadata messages will be generated every 5 seconds using the ingest time of the content. If the interval is not specified, or set to 0, then no EXT-X-PROGRAM-DATE-TIME tags will be inserted into manifests and no ID3Timed Metadata messages will be generated. Note that irrespective of this parameter, if any ID3 Timed Metadata is found in HTTP Live Streaming (HLS) input, it will be passed through to HLS output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"repeat_ext_x_key": {
@@ -230,13 +230,13 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 											"max_video_bits_per_second": {
 												// Property: MaxVideoBitsPerSecond
 												Description: "The maximum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"min_video_bits_per_second": {
 												// Property: MinVideoBitsPerSecond
 												Description: "The minimum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"stream_order": {
@@ -263,7 +263,7 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -429,7 +429,7 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 								"min_buffer_time_seconds": {
 									// Property: MinBufferTimeSeconds
 									Description: "Minimum duration (in seconds) that a player will buffer media before starting the presentation.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"profile": {
@@ -446,13 +446,13 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 											"max_video_bits_per_second": {
 												// Property: MaxVideoBitsPerSecond
 												Description: "The maximum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"min_video_bits_per_second": {
 												// Property: MinVideoBitsPerSecond
 												Description: "The minimum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"stream_order": {
@@ -521,7 +521,7 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"segment_template_format": {
@@ -741,7 +741,7 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 								"program_date_time_interval_seconds": {
 									// Property: ProgramDateTimeIntervalSeconds
 									Description: "The interval (in seconds) between each EXT-X-PROGRAM-DATE-TIME tag inserted into manifests. Additionally, when an interval is specified ID3Timed Metadata messages will be generated every 5 seconds using the ingest time of the content. If the interval is not specified, or set to 0, then no EXT-X-PROGRAM-DATE-TIME tags will be inserted into manifests and no ID3Timed Metadata messages will be generated. Note that irrespective of this parameter, if any ID3 Timed Metadata is found in HTTP Live Streaming (HLS) input, it will be passed through to HLS output.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"repeat_ext_x_key": {
@@ -758,13 +758,13 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 											"max_video_bits_per_second": {
 												// Property: MaxVideoBitsPerSecond
 												Description: "The maximum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"min_video_bits_per_second": {
 												// Property: MinVideoBitsPerSecond
 												Description: "The minimum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"stream_order": {
@@ -785,7 +785,7 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"use_audio_rendition_group": {
@@ -960,13 +960,13 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 											"max_video_bits_per_second": {
 												// Property: MaxVideoBitsPerSecond
 												Description: "The maximum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"min_video_bits_per_second": {
 												// Property: MinVideoBitsPerSecond
 												Description: "The minimum video bitrate (bps) to include in output.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 											"stream_order": {
@@ -987,7 +987,7 @@ func packagingConfigurationDataSourceType(ctx context.Context) (tfsdk.DataSource
 					"segment_duration_seconds": {
 						// Property: SegmentDurationSeconds
 						Description: "Duration (in seconds) of each fragment. Actual fragments will be rounded to the nearest multiple of the source fragment duration.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/memorydb/cluster_resource_gen.go
+++ b/internal/aws/memorydb/cluster_resource_gen.go
@@ -90,7 +90,7 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"port": {
 						// Property: Port
 						Description: "The port number that the engine is listening on. ",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							tfsdk.UseStateForUnknown(),
@@ -194,7 +194,7 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of replicas to apply to each shard. The limit is 5.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"num_shards": {
@@ -205,7 +205,7 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of shards the cluster will contain.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"parameter_group_name": {
@@ -241,7 +241,7 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The port number on which each member of the cluster accepts connections.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
@@ -314,7 +314,7 @@ func clusterResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of days for which MemoryDB retains automatic snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, a snapshot that was taken today is retained for 5 days before being deleted.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"snapshot_window": {

--- a/internal/aws/memorydb/cluster_singular_data_source_gen.go
+++ b/internal/aws/memorydb/cluster_singular_data_source_gen.go
@@ -83,7 +83,7 @@ func clusterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"port": {
 						// Property: Port
 						Description: "The port number that the engine is listening on. ",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -176,7 +176,7 @@ func clusterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of replicas to apply to each shard. The limit is 5.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"num_shards": {
@@ -187,7 +187,7 @@ func clusterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of shards the cluster will contain.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"parameter_group_name": {
@@ -220,7 +220,7 @@ func clusterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The port number on which each member of the cluster accepts connections.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"security_group_ids": {
@@ -274,7 +274,7 @@ func clusterDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of days for which MemoryDB retains automatic snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, a snapshot that was taken today is retained for 5 days before being deleted.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"snapshot_window": {

--- a/internal/aws/mwaa/environment_resource_gen.go
+++ b/internal/aws/mwaa/environment_resource_gen.go
@@ -494,7 +494,7 @@ func environmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Maximum worker compute units.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(1),
@@ -509,7 +509,7 @@ func environmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Minimum worker compute units.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(1),
@@ -675,7 +675,7 @@ func environmentResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Scheduler compute units.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntAtLeast(1),

--- a/internal/aws/mwaa/environment_singular_data_source_gen.go
+++ b/internal/aws/mwaa/environment_singular_data_source_gen.go
@@ -410,7 +410,7 @@ func environmentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "integer"
 			// }
 			Description: "Maximum worker compute units.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"min_workers": {
@@ -422,7 +422,7 @@ func environmentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "integer"
 			// }
 			Description: "Minimum worker compute units.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"name": {
@@ -554,7 +554,7 @@ func environmentDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "type": "integer"
 			// }
 			Description: "Scheduler compute units.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"source_bucket_arn": {

--- a/internal/aws/networkfirewall/firewall_policy_resource_gen.go
+++ b/internal/aws/networkfirewall/firewall_policy_resource_gen.go
@@ -226,7 +226,7 @@ func firewallPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"priority": {
 									// Property: Priority
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 65535),
@@ -312,7 +312,7 @@ func firewallPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 							map[string]tfsdk.Attribute{
 								"priority": {
 									// Property: Priority
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Required: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 65535),

--- a/internal/aws/networkfirewall/firewall_policy_singular_data_source_gen.go
+++ b/internal/aws/networkfirewall/firewall_policy_singular_data_source_gen.go
@@ -216,7 +216,7 @@ func firewallPolicyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"priority": {
 									// Property: Priority
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"resource_arn": {
@@ -290,7 +290,7 @@ func firewallPolicyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 							map[string]tfsdk.Attribute{
 								"priority": {
 									// Property: Priority
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"resource_arn": {

--- a/internal/aws/networkfirewall/rule_group_resource_gen.go
+++ b/internal/aws/networkfirewall/rule_group_resource_gen.go
@@ -26,7 +26,7 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Required: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.RequiresReplace(),
@@ -835,7 +835,7 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 													map[string]tfsdk.Attribute{
 														"priority": {
 															// Property: Priority
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Required: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntBetween(1, 65535),
@@ -860,7 +860,7 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																						map[string]tfsdk.Attribute{
 																							"from_port": {
 																								// Property: FromPort
-																								Type:     types.NumberType,
+																								Type:     types.Int64Type,
 																								Required: true,
 																								Validators: []tfsdk.AttributeValidator{
 																									validate.IntBetween(0, 65535),
@@ -868,7 +868,7 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																							},
 																							"to_port": {
 																								// Property: ToPort
-																								Type:     types.NumberType,
+																								Type:     types.Int64Type,
 																								Required: true,
 																								Validators: []tfsdk.AttributeValidator{
 																									validate.IntBetween(0, 65535),
@@ -898,7 +898,7 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																				},
 																				"protocols": {
 																					// Property: Protocols
-																					Type:     types.SetType{ElemType: types.NumberType},
+																					Type:     types.SetType{ElemType: types.Int64Type},
 																					Optional: true,
 																					Validators: []tfsdk.AttributeValidator{
 																						validate.ArrayForEach(validate.IntBetween(0, 255)),
@@ -910,7 +910,7 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																						map[string]tfsdk.Attribute{
 																							"from_port": {
 																								// Property: FromPort
-																								Type:     types.NumberType,
+																								Type:     types.Int64Type,
 																								Required: true,
 																								Validators: []tfsdk.AttributeValidator{
 																									validate.IntBetween(0, 65535),
@@ -918,7 +918,7 @@ func ruleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																							},
 																							"to_port": {
 																								// Property: ToPort
-																								Type:     types.NumberType,
+																								Type:     types.Int64Type,
 																								Required: true,
 																								Validators: []tfsdk.AttributeValidator{
 																									validate.IntBetween(0, 65535),

--- a/internal/aws/networkfirewall/rule_group_singular_data_source_gen.go
+++ b/internal/aws/networkfirewall/rule_group_singular_data_source_gen.go
@@ -25,7 +25,7 @@ func ruleGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"description": {
@@ -744,7 +744,7 @@ func ruleGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 													map[string]tfsdk.Attribute{
 														"priority": {
 															// Property: Priority
-															Type:     types.NumberType,
+															Type:     types.Int64Type,
 															Computed: true,
 														},
 														"rule_definition": {
@@ -766,12 +766,12 @@ func ruleGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																						map[string]tfsdk.Attribute{
 																							"from_port": {
 																								// Property: FromPort
-																								Type:     types.NumberType,
+																								Type:     types.Int64Type,
 																								Computed: true,
 																							},
 																							"to_port": {
 																								// Property: ToPort
-																								Type:     types.NumberType,
+																								Type:     types.Int64Type,
 																								Computed: true,
 																							},
 																						},
@@ -795,7 +795,7 @@ func ruleGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																				},
 																				"protocols": {
 																					// Property: Protocols
-																					Type:     types.SetType{ElemType: types.NumberType},
+																					Type:     types.SetType{ElemType: types.Int64Type},
 																					Computed: true,
 																				},
 																				"source_ports": {
@@ -804,12 +804,12 @@ func ruleGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 																						map[string]tfsdk.Attribute{
 																							"from_port": {
 																								// Property: FromPort
-																								Type:     types.NumberType,
+																								Type:     types.Int64Type,
 																								Computed: true,
 																							},
 																							"to_port": {
 																								// Property: ToPort
-																								Type:     types.NumberType,
+																								Type:     types.Int64Type,
 																								Computed: true,
 																							},
 																						},

--- a/internal/aws/nimblestudio/launch_profile_resource_gen.go
+++ b/internal/aws/nimblestudio/launch_profile_resource_gen.go
@@ -243,7 +243,7 @@ func launchProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"max_session_length_in_minutes": {
 						// Property: MaxSessionLengthInMinutes
 						Description: "<p>The length of time, in minutes, that a streaming session can be active before it is\n            stopped or terminated. After this point, Nimble Studio automatically terminates or\n            stops the session. The default length of time is 690 minutes, and the maximum length of\n            time is 30 days.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(1.000000, 43200.000000),
@@ -252,7 +252,7 @@ func launchProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 					"max_stopped_session_length_in_minutes": {
 						// Property: MaxStoppedSessionLengthInMinutes
 						Description: "<p>Integer that determines if you can start and stop your sessions and how long a session\n            can stay in the STOPPED state. The default value is 0. The maximum value is 5760.</p>\n        <p>If the value is missing or set to 0, your sessions can’t be stopped. If you then call\n            StopStreamingSession, the session fails. If the time that a session stays in the READY\n            state exceeds the maxSessionLengthInMinutes value, the session will automatically be\n            terminated by AWS (instead of stopped).</p>\n        <p>If the value is set to a positive number, the session can be stopped. You can call\n            StopStreamingSession to stop sessions in the READY state. If the time that a session\n            stays in the READY state exceeds the maxSessionLengthInMinutes value, the session will\n            automatically be stopped by AWS (instead of terminated).</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 5760.000000),

--- a/internal/aws/nimblestudio/launch_profile_singular_data_source_gen.go
+++ b/internal/aws/nimblestudio/launch_profile_singular_data_source_gen.go
@@ -207,13 +207,13 @@ func launchProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 					"max_session_length_in_minutes": {
 						// Property: MaxSessionLengthInMinutes
 						Description: "<p>The length of time, in minutes, that a streaming session can be active before it is\n            stopped or terminated. After this point, Nimble Studio automatically terminates or\n            stops the session. The default length of time is 690 minutes, and the maximum length of\n            time is 30 days.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"max_stopped_session_length_in_minutes": {
 						// Property: MaxStoppedSessionLengthInMinutes
 						Description: "<p>Integer that determines if you can start and stop your sessions and how long a session\n            can stay in the STOPPED state. The default value is 0. The maximum value is 5760.</p>\n        <p>If the value is missing or set to 0, your sessions can’t be stopped. If you then call\n            StopStreamingSession, the session fails. If the time that a session stays in the READY\n            state exceeds the maxSessionLengthInMinutes value, the session will automatically be\n            terminated by AWS (instead of stopped).</p>\n        <p>If the value is set to a positive number, the session can be stopped. You can call\n            StopStreamingSession to stop sessions in the READY state. If the time that a session\n            stays in the READY state exceeds the maxSessionLengthInMinutes value, the session will\n            automatically be stopped by AWS (instead of terminated).</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"session_storage": {

--- a/internal/aws/panorama/application_instance_resource_gen.go
+++ b/internal/aws/panorama/application_instance_resource_gen.go
@@ -75,7 +75,7 @@ func applicationInstanceResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),
@@ -172,7 +172,7 @@ func applicationInstanceResourceType(ctx context.Context) (tfsdk.ResourceType, e
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/panorama/application_instance_singular_data_source_gen.go
+++ b/internal/aws/panorama/application_instance_singular_data_source_gen.go
@@ -60,7 +60,7 @@ func applicationInstanceDataSourceType(ctx context.Context) (tfsdk.DataSourceTyp
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"default_runtime_context_device": {
@@ -131,7 +131,7 @@ func applicationInstanceDataSourceType(ctx context.Context) (tfsdk.DataSourceTyp
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"manifest_overrides_payload": {

--- a/internal/aws/panorama/package_resource_gen.go
+++ b/internal/aws/panorama/package_resource_gen.go
@@ -40,7 +40,7 @@ func packageResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/panorama/package_singular_data_source_gen.go
+++ b/internal/aws/panorama/package_singular_data_source_gen.go
@@ -36,7 +36,7 @@ func packageDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"package_id": {

--- a/internal/aws/panorama/package_version_resource_gen.go
+++ b/internal/aws/panorama/package_version_resource_gen.go
@@ -150,7 +150,7 @@ func packageVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/panorama/package_version_singular_data_source_gen.go
+++ b/internal/aws/panorama/package_version_singular_data_source_gen.go
@@ -114,7 +114,7 @@ func packageVersionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			// {
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 		"status": {

--- a/internal/aws/pinpoint/in_app_template_resource_gen.go
+++ b/internal/aws/pinpoint/in_app_template_resource_gen.go
@@ -375,7 +375,7 @@ func inAppTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 											},
 											"border_radius": {
 												// Property: BorderRadius
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"button_action": {
@@ -503,7 +503,7 @@ func inAppTemplateResourceType(ctx context.Context) (tfsdk.ResourceType, error) 
 											},
 											"border_radius": {
 												// Property: BorderRadius
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"button_action": {

--- a/internal/aws/pinpoint/in_app_template_singular_data_source_gen.go
+++ b/internal/aws/pinpoint/in_app_template_singular_data_source_gen.go
@@ -350,7 +350,7 @@ func inAppTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 											},
 											"border_radius": {
 												// Property: BorderRadius
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"button_action": {
@@ -450,7 +450,7 @@ func inAppTemplateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, err
 											},
 											"border_radius": {
 												// Property: BorderRadius
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"button_action": {

--- a/internal/aws/quicksight/analysis_resource_gen.go
+++ b/internal/aws/quicksight/analysis_resource_gen.go
@@ -376,7 +376,7 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"values": {
 									// Property: Values
 									Description: "<p>The values for the decimal parameter.</p>",
-									Type:        types.ListType{ElemType: types.NumberType},
+									Type:        types.ListType{ElemType: types.Float64Type},
 									Required:    true,
 								},
 							},
@@ -401,7 +401,7 @@ func analysisResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"values": {
 									// Property: Values
 									Description: "<p>The values for the integer parameter.</p>",
-									Type:        types.ListType{ElemType: types.NumberType},
+									Type:        types.ListType{ElemType: types.Float64Type},
 									Required:    true,
 								},
 							},

--- a/internal/aws/quicksight/analysis_singular_data_source_gen.go
+++ b/internal/aws/quicksight/analysis_singular_data_source_gen.go
@@ -327,7 +327,7 @@ func analysisDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"values": {
 									// Property: Values
 									Description: "<p>The values for the decimal parameter.</p>",
-									Type:        types.ListType{ElemType: types.NumberType},
+									Type:        types.ListType{ElemType: types.Float64Type},
 									Computed:    true,
 								},
 							},
@@ -349,7 +349,7 @@ func analysisDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"values": {
 									// Property: Values
 									Description: "<p>The values for the integer parameter.</p>",
-									Type:        types.ListType{ElemType: types.NumberType},
+									Type:        types.ListType{ElemType: types.Float64Type},
 									Computed:    true,
 								},
 							},

--- a/internal/aws/quicksight/dashboard_resource_gen.go
+++ b/internal/aws/quicksight/dashboard_resource_gen.go
@@ -422,7 +422,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"values": {
 									// Property: Values
 									Description: "<p>The values for the decimal parameter.</p>",
-									Type:        types.ListType{ElemType: types.NumberType},
+									Type:        types.ListType{ElemType: types.Float64Type},
 									Required:    true,
 								},
 							},
@@ -447,7 +447,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"values": {
 									// Property: Values
 									Description: "<p>The values for the integer parameter.</p>",
-									Type:        types.ListType{ElemType: types.NumberType},
+									Type:        types.ListType{ElemType: types.Float64Type},
 									Required:    true,
 								},
 							},
@@ -969,7 +969,7 @@ func dashboardResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"version_number": {
 						// Property: VersionNumber
 						Description: "<p>Version number for this version of the dashboard.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatAtLeast(1.000000),

--- a/internal/aws/quicksight/dashboard_singular_data_source_gen.go
+++ b/internal/aws/quicksight/dashboard_singular_data_source_gen.go
@@ -370,7 +370,7 @@ func dashboardDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 								"values": {
 									// Property: Values
 									Description: "<p>The values for the decimal parameter.</p>",
-									Type:        types.ListType{ElemType: types.NumberType},
+									Type:        types.ListType{ElemType: types.Float64Type},
 									Computed:    true,
 								},
 							},
@@ -392,7 +392,7 @@ func dashboardDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 								"values": {
 									// Property: Values
 									Description: "<p>The values for the integer parameter.</p>",
-									Type:        types.ListType{ElemType: types.NumberType},
+									Type:        types.ListType{ElemType: types.Float64Type},
 									Computed:    true,
 								},
 							},
@@ -844,7 +844,7 @@ func dashboardDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) 
 					"version_number": {
 						// Property: VersionNumber
 						Description: "<p>Version number for this version of the dashboard.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/quicksight/data_set_resource_gen.go
+++ b/internal/aws/quicksight/data_set_resource_gen.go
@@ -4,7 +4,6 @@ package quicksight
 
 import (
 	"context"
-	"math/big"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -213,7 +212,7 @@ func dataSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "<p>The amount of SPICE capacity used by this dataset. This is 0 if the dataset isn't\n            imported into SPICE.</p>",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),
@@ -345,14 +344,14 @@ func dataSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"ingestion_wait_time_in_hours": {
 						// Property: IngestionWaitTimeInHours
 						Description: "<p>The maximum time (in hours) to wait for Ingestion to complete. Default timeout is 36 hours.\n Applicable only when DataSetImportMode mode is set to SPICE and WaitForSpiceIngestion is set to true.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Computed:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(1.000000, 36.000000),
 						},
 						PlanModifiers: []tfsdk.AttributePlanModifier{
-							DefaultValue(types.Number{Value: big.NewFloat(36.000000)}),
+							DefaultValue(types.Float64{Value: 36.000000}),
 							tfsdk.UseStateForUnknown(),
 						},
 					},
@@ -1643,7 +1642,7 @@ func dataSetResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"start_from_row": {
 												// Property: StartFromRow
 												Description: "<p>A row number to start reading data from.</p>",
-												Type:        types.NumberType,
+												Type:        types.Float64Type,
 												Optional:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.FloatAtLeast(1.000000),

--- a/internal/aws/quicksight/data_set_singular_data_source_gen.go
+++ b/internal/aws/quicksight/data_set_singular_data_source_gen.go
@@ -176,7 +176,7 @@ func dataSetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "number"
 			// }
 			Description: "<p>The amount of SPICE capacity used by this dataset. This is 0 if the dataset isn't\n            imported into SPICE.</p>",
-			Type:        types.NumberType,
+			Type:        types.Float64Type,
 			Computed:    true,
 		},
 		"created_time": {
@@ -284,7 +284,7 @@ func dataSetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"ingestion_wait_time_in_hours": {
 						// Property: IngestionWaitTimeInHours
 						Description: "<p>The maximum time (in hours) to wait for Ingestion to complete. Default timeout is 36 hours.\n Applicable only when DataSetImportMode mode is set to SPICE and WaitForSpiceIngestion is set to true.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"wait_for_spice_ingestion": {
@@ -1372,7 +1372,7 @@ func dataSetDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"start_from_row": {
 												// Property: StartFromRow
 												Description: "<p>A row number to start reading data from.</p>",
-												Type:        types.NumberType,
+												Type:        types.Float64Type,
 												Computed:    true,
 											},
 											"text_qualifier": {

--- a/internal/aws/quicksight/data_source_resource_gen.go
+++ b/internal/aws/quicksight/data_source_resource_gen.go
@@ -554,7 +554,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -590,7 +590,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -626,7 +626,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -662,7 +662,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -694,7 +694,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"port": {
 									// Property: Port
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Required: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -730,7 +730,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -766,7 +766,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -838,7 +838,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port. This field can be blank if the <code>ClusterId</code> is provided.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(0.000000, 65535.000000),
@@ -937,7 +937,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -973,7 +973,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -1009,7 +1009,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -1659,7 +1659,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -1695,7 +1695,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -1731,7 +1731,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -1767,7 +1767,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -1799,7 +1799,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														},
 														"port": {
 															// Property: Port
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Required: true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -1835,7 +1835,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -1871,7 +1871,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -1943,7 +1943,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port. This field can be blank if the <code>ClusterId</code> is provided.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Optional:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(0.000000, 65535.000000),
@@ -2042,7 +2042,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -2078,7 +2078,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -2114,7 +2114,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.FloatBetween(1.000000, 65535.000000),
@@ -2701,7 +2701,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -2737,7 +2737,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -2773,7 +2773,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -2809,7 +2809,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -2841,7 +2841,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"port": {
 									// Property: Port
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Required: true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -2877,7 +2877,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -2913,7 +2913,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -2985,7 +2985,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port. This field can be blank if the <code>ClusterId</code> is provided.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(0.000000, 65535.000000),
@@ -3084,7 +3084,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -3120,7 +3120,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),
@@ -3156,7 +3156,7 @@ func dataSourceResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(1.000000, 65535.000000),

--- a/internal/aws/quicksight/data_source_singular_data_source_gen.go
+++ b/internal/aws/quicksight/data_source_singular_data_source_gen.go
@@ -538,7 +538,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -565,7 +565,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -592,7 +592,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -619,7 +619,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -642,7 +642,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								},
 								"port": {
 									// Property: Port
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 							},
@@ -669,7 +669,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -696,7 +696,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -750,7 +750,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port. This field can be blank if the <code>ClusterId</code> is provided.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -828,7 +828,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -855,7 +855,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -882,7 +882,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -1497,7 +1497,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1524,7 +1524,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1551,7 +1551,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1578,7 +1578,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1601,7 +1601,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														},
 														"port": {
 															// Property: Port
-															Type:     types.NumberType,
+															Type:     types.Float64Type,
 															Computed: true,
 														},
 													},
@@ -1628,7 +1628,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1655,7 +1655,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1709,7 +1709,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port. This field can be blank if the <code>ClusterId</code> is provided.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1787,7 +1787,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1814,7 +1814,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -1841,7 +1841,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 														"port": {
 															// Property: Port
 															Description: "<p>Port.</p>",
-															Type:        types.NumberType,
+															Type:        types.Float64Type,
 															Computed:    true,
 														},
 													},
@@ -2395,7 +2395,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2422,7 +2422,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2449,7 +2449,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2476,7 +2476,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2499,7 +2499,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								},
 								"port": {
 									// Property: Port
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 							},
@@ -2526,7 +2526,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2553,7 +2553,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2607,7 +2607,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port. This field can be blank if the <code>ClusterId</code> is provided.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2685,7 +2685,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2712,7 +2712,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},
@@ -2739,7 +2739,7 @@ func dataSourceDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 								"port": {
 									// Property: Port
 									Description: "<p>Port.</p>",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 							},

--- a/internal/aws/quicksight/template_resource_gen.go
+++ b/internal/aws/quicksight/template_resource_gen.go
@@ -757,7 +757,7 @@ func templateResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"version_number": {
 						// Property: VersionNumber
 						Description: "<p>The version number of the template version.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatAtLeast(1.000000),

--- a/internal/aws/quicksight/template_singular_data_source_gen.go
+++ b/internal/aws/quicksight/template_singular_data_source_gen.go
@@ -665,7 +665,7 @@ func templateDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"version_number": {
 						// Property: VersionNumber
 						Description: "<p>The version number of the template version.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/quicksight/theme_resource_gen.go
+++ b/internal/aws/quicksight/theme_resource_gen.go
@@ -1323,7 +1323,7 @@ func themeResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"version_number": {
 						// Property: VersionNumber
 						Description: "<p>The version number of the theme.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatAtLeast(1.000000),

--- a/internal/aws/quicksight/theme_singular_data_source_gen.go
+++ b/internal/aws/quicksight/theme_singular_data_source_gen.go
@@ -1229,7 +1229,7 @@ func themeDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"version_number": {
 						// Property: VersionNumber
 						Description: "<p>The version number of the theme.</p>",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/rds/db_proxy_resource_gen.go
+++ b/internal/aws/rds/db_proxy_resource_gen.go
@@ -202,7 +202,7 @@ func dBProxyResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of seconds that a connection to the proxy can be inactive before the proxy disconnects it.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Optional:    true,
 		},
 		"require_tls": {

--- a/internal/aws/rds/db_proxy_singular_data_source_gen.go
+++ b/internal/aws/rds/db_proxy_singular_data_source_gen.go
@@ -166,7 +166,7 @@ func dBProxyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The number of seconds that a connection to the proxy can be inactive before the proxy disconnects it.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"require_tls": {

--- a/internal/aws/rds/db_proxy_target_group_resource_gen.go
+++ b/internal/aws/rds/db_proxy_target_group_resource_gen.go
@@ -60,7 +60,7 @@ func dBProxyTargetGroupResourceType(ctx context.Context) (tfsdk.ResourceType, er
 					"connection_borrow_timeout": {
 						// Property: ConnectionBorrowTimeout
 						Description: "The number of seconds for a proxy to wait for a connection to become available in the connection pool.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"init_query": {
@@ -72,7 +72,7 @@ func dBProxyTargetGroupResourceType(ctx context.Context) (tfsdk.ResourceType, er
 					"max_connections_percent": {
 						// Property: MaxConnectionsPercent
 						Description: "The maximum size of the connection pool for each target in a target group.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 100),
@@ -81,7 +81,7 @@ func dBProxyTargetGroupResourceType(ctx context.Context) (tfsdk.ResourceType, er
 					"max_idle_connections_percent": {
 						// Property: MaxIdleConnectionsPercent
 						Description: "Controls how actively the proxy closes idle database connections in the connection pool.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 100),

--- a/internal/aws/rds/db_proxy_target_group_singular_data_source_gen.go
+++ b/internal/aws/rds/db_proxy_target_group_singular_data_source_gen.go
@@ -59,7 +59,7 @@ func dBProxyTargetGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 					"connection_borrow_timeout": {
 						// Property: ConnectionBorrowTimeout
 						Description: "The number of seconds for a proxy to wait for a connection to become available in the connection pool.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"init_query": {
@@ -71,13 +71,13 @@ func dBProxyTargetGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 					"max_connections_percent": {
 						// Property: MaxConnectionsPercent
 						Description: "The maximum size of the connection pool for each target in a target group.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"max_idle_connections_percent": {
 						// Property: MaxIdleConnectionsPercent
 						Description: "Controls how actively the proxy closes idle database connections in the connection pool.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"session_pinning_filters": {

--- a/internal/aws/redshift/endpoint_access_resource_gen.go
+++ b/internal/aws/redshift/endpoint_access_resource_gen.go
@@ -100,7 +100,7 @@ func endpointAccessResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 			//   "type": "integer"
 			// }
 			Description: "The port number on which the cluster accepts incoming connections.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/redshift/endpoint_access_singular_data_source_gen.go
+++ b/internal/aws/redshift/endpoint_access_singular_data_source_gen.go
@@ -83,7 +83,7 @@ func endpointAccessDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 			//   "type": "integer"
 			// }
 			Description: "The port number on which the cluster accepts incoming connections.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"resource_owner": {

--- a/internal/aws/redshift/endpoint_authorization_resource_gen.go
+++ b/internal/aws/redshift/endpoint_authorization_resource_gen.go
@@ -119,7 +119,7 @@ func endpointAuthorizationResourceType(ctx context.Context) (tfsdk.ResourceType,
 			//   "type": "integer"
 			// }
 			Description: "The number of Redshift-managed VPC endpoints created for the authorization.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/redshift/endpoint_authorization_singular_data_source_gen.go
+++ b/internal/aws/redshift/endpoint_authorization_singular_data_source_gen.go
@@ -100,7 +100,7 @@ func endpointAuthorizationDataSourceType(ctx context.Context) (tfsdk.DataSourceT
 			//   "type": "integer"
 			// }
 			Description: "The number of Redshift-managed VPC endpoints created for the authorization.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"force": {

--- a/internal/aws/redshift/scheduled_action_resource_gen.go
+++ b/internal/aws/redshift/scheduled_action_resource_gen.go
@@ -243,7 +243,7 @@ func scheduledActionResourceType(ctx context.Context) (tfsdk.ResourceType, error
 								},
 								"number_of_nodes": {
 									// Property: NumberOfNodes
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 							},

--- a/internal/aws/redshift/scheduled_action_singular_data_source_gen.go
+++ b/internal/aws/redshift/scheduled_action_singular_data_source_gen.go
@@ -233,7 +233,7 @@ func scheduledActionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, e
 								},
 								"number_of_nodes": {
 									// Property: NumberOfNodes
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 							},

--- a/internal/aws/resiliencehub/resiliency_policy_resource_gen.go
+++ b/internal/aws/resiliencehub/resiliency_policy_resource_gen.go
@@ -77,13 +77,13 @@ func resiliencyPolicyResourceType(ctx context.Context) (tfsdk.ResourceType, erro
 					"rpo_in_secs": {
 						// Property: RpoInSecs
 						Description: "RPO in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 					"rto_in_secs": {
 						// Property: RtoInSecs
 						Description: "RTO in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 					},
 				},

--- a/internal/aws/resiliencehub/resiliency_policy_singular_data_source_gen.go
+++ b/internal/aws/resiliencehub/resiliency_policy_singular_data_source_gen.go
@@ -69,13 +69,13 @@ func resiliencyPolicyDataSourceType(ctx context.Context) (tfsdk.DataSourceType, 
 					"rpo_in_secs": {
 						// Property: RpoInSecs
 						Description: "RPO in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"rto_in_secs": {
 						// Property: RtoInSecs
 						Description: "RTO in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/route53/health_check_resource_gen.go
+++ b/internal/aws/route53/health_check_resource_gen.go
@@ -187,7 +187,7 @@ func healthCheckResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"failure_threshold": {
 						// Property: FailureThreshold
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 10),
@@ -203,7 +203,7 @@ func healthCheckResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"health_threshold": {
 						// Property: HealthThreshold
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 256),
@@ -246,7 +246,7 @@ func healthCheckResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"port": {
 						// Property: Port
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 65535),
@@ -265,7 +265,7 @@ func healthCheckResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					},
 					"request_interval": {
 						// Property: RequestInterval
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Computed: true,
 						Validators: []tfsdk.AttributeValidator{

--- a/internal/aws/route53/health_check_singular_data_source_gen.go
+++ b/internal/aws/route53/health_check_singular_data_source_gen.go
@@ -177,7 +177,7 @@ func healthCheckDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					},
 					"failure_threshold": {
 						// Property: FailureThreshold
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"fully_qualified_domain_name": {
@@ -187,7 +187,7 @@ func healthCheckDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					},
 					"health_threshold": {
 						// Property: HealthThreshold
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"ip_address": {
@@ -212,7 +212,7 @@ func healthCheckDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					},
 					"port": {
 						// Property: Port
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"regions": {
@@ -222,7 +222,7 @@ func healthCheckDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 					},
 					"request_interval": {
 						// Property: RequestInterval
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"resource_path": {

--- a/internal/aws/route53recoverycontrol/control_panel_resource_gen.go
+++ b/internal/aws/route53recoverycontrol/control_panel_resource_gen.go
@@ -88,7 +88,7 @@ func controlPanelResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "Count of associated routing controls",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/route53recoverycontrol/control_panel_singular_data_source_gen.go
+++ b/internal/aws/route53recoverycontrol/control_panel_singular_data_source_gen.go
@@ -73,7 +73,7 @@ func controlPanelDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 			//   "type": "integer"
 			// }
 			Description: "Count of associated routing controls",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"status": {

--- a/internal/aws/route53recoverycontrol/safety_rule_resource_gen.go
+++ b/internal/aws/route53recoverycontrol/safety_rule_resource_gen.go
@@ -61,7 +61,7 @@ func safetyRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"wait_period_ms": {
 						// Property: WaitPeriodMs
 						Description: "An evaluation period, in milliseconds (ms), during which any request against the target routing controls will fail. This helps prevent \"flapping\" of state. The wait period is 5000 ms by default, but you can choose a custom value.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 					},
 				},
@@ -143,7 +143,7 @@ func safetyRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"wait_period_ms": {
 						// Property: WaitPeriodMs
 						Description: "An evaluation period, in milliseconds (ms), during which any request against the target routing controls will fail. This helps prevent \"flapping\" of state. The wait period is 5000 ms by default, but you can choose a custom value.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 					},
 				},
@@ -205,7 +205,7 @@ func safetyRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"threshold": {
 						// Property: Threshold
 						Description: "The value of N, when you specify an ATLEAST rule type. That is, Threshold is the number of controls that must be set when you specify an ATLEAST type.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 					},
 					"type": {

--- a/internal/aws/route53recoverycontrol/safety_rule_singular_data_source_gen.go
+++ b/internal/aws/route53recoverycontrol/safety_rule_singular_data_source_gen.go
@@ -57,7 +57,7 @@ func safetyRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"wait_period_ms": {
 						// Property: WaitPeriodMs
 						Description: "An evaluation period, in milliseconds (ms), during which any request against the target routing controls will fail. This helps prevent \"flapping\" of state. The wait period is 5000 ms by default, but you can choose a custom value.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -128,7 +128,7 @@ func safetyRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"wait_period_ms": {
 						// Property: WaitPeriodMs
 						Description: "An evaluation period, in milliseconds (ms), during which any request against the target routing controls will fail. This helps prevent \"flapping\" of state. The wait period is 5000 ms by default, but you can choose a custom value.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -190,7 +190,7 @@ func safetyRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"threshold": {
 						// Property: Threshold
 						Description: "The value of N, when you specify an ATLEAST rule type. That is, Threshold is the number of controls that must be set when you specify an ATLEAST type.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"type": {

--- a/internal/aws/route53resolver/firewall_domain_list_resource_gen.go
+++ b/internal/aws/route53resolver/firewall_domain_list_resource_gen.go
@@ -77,7 +77,7 @@ func firewallDomainListResourceType(ctx context.Context) (tfsdk.ResourceType, er
 			//   "type": "integer"
 			// }
 			Description: "Count",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/route53resolver/firewall_domain_list_singular_data_source_gen.go
+++ b/internal/aws/route53resolver/firewall_domain_list_singular_data_source_gen.go
@@ -67,7 +67,7 @@ func firewallDomainListDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 			//   "type": "integer"
 			// }
 			Description: "Count",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"domain_file_url": {

--- a/internal/aws/route53resolver/firewall_rule_group_association_resource_gen.go
+++ b/internal/aws/route53resolver/firewall_rule_group_association_resource_gen.go
@@ -181,7 +181,7 @@ func firewallRuleGroupAssociationResourceType(ctx context.Context) (tfsdk.Resour
 			//   "type": "integer"
 			// }
 			Description: "Priority",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Required:    true,
 		},
 		"status": {

--- a/internal/aws/route53resolver/firewall_rule_group_association_singular_data_source_gen.go
+++ b/internal/aws/route53resolver/firewall_rule_group_association_singular_data_source_gen.go
@@ -147,7 +147,7 @@ func firewallRuleGroupAssociationDataSourceType(ctx context.Context) (tfsdk.Data
 			//   "type": "integer"
 			// }
 			Description: "Priority",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"status": {

--- a/internal/aws/route53resolver/firewall_rule_group_resource_gen.go
+++ b/internal/aws/route53resolver/firewall_rule_group_resource_gen.go
@@ -175,7 +175,7 @@ func firewallRuleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, err
 					"block_override_ttl": {
 						// Property: BlockOverrideTtl
 						Description: "BlockOverrideTtl",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 604800),
@@ -206,7 +206,7 @@ func firewallRuleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, err
 					"priority": {
 						// Property: Priority
 						Description: "Rule Priority",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 					},
 				},
@@ -292,7 +292,7 @@ func firewallRuleGroupResourceType(ctx context.Context) (tfsdk.ResourceType, err
 			//   "type": "integer"
 			// }
 			Description: "Count",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/route53resolver/firewall_rule_group_singular_data_source_gen.go
+++ b/internal/aws/route53resolver/firewall_rule_group_singular_data_source_gen.go
@@ -150,7 +150,7 @@ func firewallRuleGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType,
 					"block_override_ttl": {
 						// Property: BlockOverrideTtl
 						Description: "BlockOverrideTtl",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"block_response": {
@@ -168,7 +168,7 @@ func firewallRuleGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType,
 					"priority": {
 						// Property: Priority
 						Description: "Rule Priority",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -237,7 +237,7 @@ func firewallRuleGroupDataSourceType(ctx context.Context) (tfsdk.DataSourceType,
 			//   "type": "integer"
 			// }
 			Description: "Count",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"share_status": {

--- a/internal/aws/route53resolver/resolver_query_logging_config_resource_gen.go
+++ b/internal/aws/route53resolver/resolver_query_logging_config_resource_gen.go
@@ -44,7 +44,7 @@ func resolverQueryLoggingConfigResourceType(ctx context.Context) (tfsdk.Resource
 			//   "type": "integer"
 			// }
 			Description: "Count",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/route53resolver/resolver_query_logging_config_singular_data_source_gen.go
+++ b/internal/aws/route53resolver/resolver_query_logging_config_singular_data_source_gen.go
@@ -40,7 +40,7 @@ func resolverQueryLoggingConfigDataSourceType(ctx context.Context) (tfsdk.DataSo
 			//   "type": "integer"
 			// }
 			Description: "Count",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 		"creation_time": {

--- a/internal/aws/rum/app_monitor_resource_gen.go
+++ b/internal/aws/rum/app_monitor_resource_gen.go
@@ -178,7 +178,7 @@ func appMonitorResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"session_sample_rate": {
 						// Property: SessionSampleRate
 						Description: "Specifies the percentage of user sessions to use for RUM data collection. Choosing a higher percentage gives you more data but also incurs more costs. The number you specify is the percentage of user sessions that will be used. If you omit this parameter, the default of 10 is used.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 1.000000),

--- a/internal/aws/rum/app_monitor_singular_data_source_gen.go
+++ b/internal/aws/rum/app_monitor_singular_data_source_gen.go
@@ -154,7 +154,7 @@ func appMonitorDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error)
 					"session_sample_rate": {
 						// Property: SessionSampleRate
 						Description: "Specifies the percentage of user sessions to use for RUM data collection. Choosing a higher percentage gives you more data but also incurs more costs. The number you specify is the percentage of user sessions that will be used. If you omit this parameter, the default of 10 is used.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"telemetries": {

--- a/internal/aws/s3/bucket_resource_gen.go
+++ b/internal/aws/s3/bucket_resource_gen.go
@@ -589,7 +589,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"max_age": {
 									// Property: MaxAge
 									Description: "The time in seconds that your browser is to cache the preflight response for the specified resource.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(0),
@@ -798,7 +798,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"days": {
 									// Property: Days
 									Description: "The number of consecutive days of no access after which an object will be eligible to be transitioned to the corresponding tier. The minimum number of days specified for Archive Access tier must be at least 90 days and Deep Archive Access tier must be at least 180 days. The maximum can be up to 2 years (730 days).",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 								},
 							},
@@ -1274,7 +1274,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"days_after_initiation": {
 												// Property: DaysAfterInitiation
 												Description: "Specifies the number of days after which Amazon S3 aborts an incomplete multipart upload.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(0),
@@ -1292,7 +1292,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"expiration_in_days": {
 									// Property: ExpirationInDays
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"expired_object_delete_marker": {
@@ -1310,7 +1310,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"noncurrent_version_expiration_in_days": {
 									// Property: NoncurrentVersionExpirationInDays
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"noncurrent_version_transition": {
@@ -1338,7 +1338,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"transition_in_days": {
 												// Property: TransitionInDays
 												Description: "Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 											},
 										},
@@ -1369,7 +1369,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"transition_in_days": {
 												// Property: TransitionInDays
 												Description: "Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 											},
 										},
@@ -1447,7 +1447,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"transition_in_days": {
 												// Property: TransitionInDays
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -1482,7 +1482,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"transition_in_days": {
 												// Property: TransitionInDays
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2116,7 +2116,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 										map[string]tfsdk.Attribute{
 											"days": {
 												// Property: Days
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 											"mode": {
@@ -2132,7 +2132,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											},
 											"years": {
 												// Property: Years
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Optional: true,
 											},
 										},
@@ -2670,7 +2670,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"minutes": {
 																		// Property: Minutes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Required: true,
 																	},
 																},
@@ -2713,7 +2713,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"minutes": {
 																		// Property: Minutes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Required: true,
 																	},
 																},
@@ -2833,7 +2833,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								},
 								"priority": {
 									// Property: Priority
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Optional: true,
 								},
 								"source_selection_criteria": {

--- a/internal/aws/s3/bucket_singular_data_source_gen.go
+++ b/internal/aws/s3/bucket_singular_data_source_gen.go
@@ -515,7 +515,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"max_age": {
 									// Property: MaxAge
 									Description: "The time in seconds that your browser is to cache the preflight response for the specified resource.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -697,7 +697,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"days": {
 									// Property: Days
 									Description: "The number of consecutive days of no access after which an object will be eligible to be transitioned to the corresponding tier. The minimum number of days specified for Archive Access tier must be at least 90 days and Deep Archive Access tier must be at least 180 days. The maximum can be up to 2 years (730 days).",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -1128,7 +1128,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"days_after_initiation": {
 												// Property: DaysAfterInitiation
 												Description: "Specifies the number of days after which Amazon S3 aborts an incomplete multipart upload.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},
@@ -1143,7 +1143,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"expiration_in_days": {
 									// Property: ExpirationInDays
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"expired_object_delete_marker": {
@@ -1158,7 +1158,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"noncurrent_version_expiration_in_days": {
 									// Property: NoncurrentVersionExpirationInDays
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"noncurrent_version_transition": {
@@ -1175,7 +1175,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"transition_in_days": {
 												// Property: TransitionInDays
 												Description: "Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},
@@ -1195,7 +1195,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"transition_in_days": {
 												// Property: TransitionInDays
 												Description: "Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},
@@ -1250,7 +1250,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											},
 											"transition_in_days": {
 												// Property: TransitionInDays
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1274,7 +1274,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											},
 											"transition_in_days": {
 												// Property: TransitionInDays
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -1869,7 +1869,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 										map[string]tfsdk.Attribute{
 											"days": {
 												// Property: Days
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 											"mode": {
@@ -1879,7 +1879,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											},
 											"years": {
 												// Property: Years
-												Type:     types.NumberType,
+												Type:     types.Int64Type,
 												Computed: true,
 											},
 										},
@@ -2394,7 +2394,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"minutes": {
 																		// Property: Minutes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -2425,7 +2425,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 																map[string]tfsdk.Attribute{
 																	"minutes": {
 																		// Property: Minutes
-																		Type:     types.NumberType,
+																		Type:     types.Int64Type,
 																		Computed: true,
 																	},
 																},
@@ -2524,7 +2524,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								},
 								"priority": {
 									// Property: Priority
-									Type:     types.NumberType,
+									Type:     types.Int64Type,
 									Computed: true,
 								},
 								"source_selection_criteria": {

--- a/internal/aws/s3/storage_lens_resource_gen.go
+++ b/internal/aws/s3/storage_lens_resource_gen.go
@@ -350,13 +350,13 @@ func storageLensResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 																				"max_depth": {
 																					// Property: MaxDepth
 																					Description: "Max depth of prefixes of S3 key that Amazon S3 Storage Lens will analyze.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Optional:    true,
 																				},
 																				"min_storage_bytes_percentage": {
 																					// Property: MinStorageBytesPercentage
 																					Description: "The minimum storage bytes threshold for the prefixes to be included in the analysis.",
-																					Type:        types.NumberType,
+																					Type:        types.Float64Type,
 																					Optional:    true,
 																				},
 																			},

--- a/internal/aws/s3/storage_lens_singular_data_source_gen.go
+++ b/internal/aws/s3/storage_lens_singular_data_source_gen.go
@@ -349,13 +349,13 @@ func storageLensDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 																				"max_depth": {
 																					// Property: MaxDepth
 																					Description: "Max depth of prefixes of S3 key that Amazon S3 Storage Lens will analyze.",
-																					Type:        types.NumberType,
+																					Type:        types.Int64Type,
 																					Computed:    true,
 																				},
 																				"min_storage_bytes_percentage": {
 																					// Property: MinStorageBytesPercentage
 																					Description: "The minimum storage bytes threshold for the prefixes to be included in the analysis.",
-																					Type:        types.NumberType,
+																					Type:        types.Float64Type,
 																					Computed:    true,
 																				},
 																			},

--- a/internal/aws/s3outposts/bucket_resource_gen.go
+++ b/internal/aws/s3outposts/bucket_resource_gen.go
@@ -247,7 +247,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"days_after_initiation": {
 												// Property: DaysAfterInitiation
 												Description: "Specifies the number of days after which Amazon S3Outposts aborts an incomplete multipart upload.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(0),
@@ -266,7 +266,7 @@ func bucketResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"expiration_in_days": {
 									// Property: ExpirationInDays
 									Description: "Indicates the number of days after creation when objects are deleted from Amazon S3Outposts.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),

--- a/internal/aws/s3outposts/bucket_singular_data_source_gen.go
+++ b/internal/aws/s3outposts/bucket_singular_data_source_gen.go
@@ -237,7 +237,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"days_after_initiation": {
 												// Property: DaysAfterInitiation
 												Description: "Specifies the number of days after which Amazon S3Outposts aborts an incomplete multipart upload.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},
@@ -253,7 +253,7 @@ func bucketDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"expiration_in_days": {
 									// Property: ExpirationInDays
 									Description: "Indicates the number of days after creation when objects are deleted from Amazon S3Outposts.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"filter": {

--- a/internal/aws/sagemaker/app_image_config_resource_gen.go
+++ b/internal/aws/sagemaker/app_image_config_resource_gen.go
@@ -134,7 +134,7 @@ func appImageConfigResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"default_gid": {
 									// Property: DefaultGid
 									Description: "The default POSIX group ID (GID). If not specified, defaults to 100.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 65535),
@@ -143,7 +143,7 @@ func appImageConfigResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 								"default_uid": {
 									// Property: DefaultUid
 									Description: "The default POSIX user ID (UID). If not specified, defaults to 1000.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(0, 65535),

--- a/internal/aws/sagemaker/app_image_config_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/app_image_config_singular_data_source_gen.go
@@ -124,13 +124,13 @@ func appImageConfigDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 								"default_gid": {
 									// Property: DefaultGid
 									Description: "The default POSIX group ID (GID). If not specified, defaults to 100.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"default_uid": {
 									// Property: DefaultUid
 									Description: "The default POSIX user ID (UID). If not specified, defaults to 1000.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"mount_path": {

--- a/internal/aws/sagemaker/data_quality_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/data_quality_job_definition_resource_gen.go
@@ -608,7 +608,7 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 								"instance_count": {
 									// Property: InstanceCount
 									Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 100),
@@ -629,7 +629,7 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 								"volume_size_in_gb": {
 									// Property: VolumeSizeInGB
 									Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 16384),
@@ -795,7 +795,7 @@ func dataQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceTy
 					"max_runtime_in_seconds": {
 						// Property: MaxRuntimeInSeconds
 						Description: "The maximum runtime allowed in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 86400),

--- a/internal/aws/sagemaker/data_quality_job_definition_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/data_quality_job_definition_singular_data_source_gen.go
@@ -520,7 +520,7 @@ func dataQualityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSour
 								"instance_count": {
 									// Property: InstanceCount
 									Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"instance_type": {
@@ -538,7 +538,7 @@ func dataQualityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSour
 								"volume_size_in_gb": {
 									// Property: VolumeSizeInGB
 									Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -679,7 +679,7 @@ func dataQualityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSour
 					"max_runtime_in_seconds": {
 						// Property: MaxRuntimeInSeconds
 						Description: "The maximum runtime allowed in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/sagemaker/domain_resource_gen.go
+++ b/internal/aws/sagemaker/domain_resource_gen.go
@@ -408,7 +408,7 @@ func domainResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"image_version_number": {
 												// Property: ImageVersionNumber
 												Description: "The version number of the CustomImage.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(0),

--- a/internal/aws/sagemaker/domain_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/domain_singular_data_source_gen.go
@@ -336,7 +336,7 @@ func domainDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"image_version_number": {
 												// Property: ImageVersionNumber
 												Description: "The version number of the CustomImage.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},

--- a/internal/aws/sagemaker/image_version_resource_gen.go
+++ b/internal/aws/sagemaker/image_version_resource_gen.go
@@ -120,7 +120,7 @@ func imageVersionResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "type": "integer"
 			// }
 			Description: "The version number of the image version.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				tfsdk.UseStateForUnknown(),

--- a/internal/aws/sagemaker/image_version_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/image_version_singular_data_source_gen.go
@@ -98,7 +98,7 @@ func imageVersionDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 			//   "type": "integer"
 			// }
 			Description: "The version number of the image version.",
-			Type:        types.NumberType,
+			Type:        types.Int64Type,
 			Computed:    true,
 		},
 	}

--- a/internal/aws/sagemaker/model_bias_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_bias_job_definition_resource_gen.go
@@ -129,7 +129,7 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 								"instance_count": {
 									// Property: InstanceCount
 									Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 100),
@@ -150,7 +150,7 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 								"volume_size_in_gb": {
 									// Property: VolumeSizeInGB
 									Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 16384),
@@ -480,7 +480,7 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 								},
 								"probability_threshold_attribute": {
 									// Property: ProbabilityThresholdAttribute
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 								"s3_data_distribution_type": {
@@ -828,7 +828,7 @@ func modelBiasJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceType
 					"max_runtime_in_seconds": {
 						// Property: MaxRuntimeInSeconds
 						Description: "The maximum runtime allowed in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 86400),

--- a/internal/aws/sagemaker/model_bias_job_definition_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/model_bias_job_definition_singular_data_source_gen.go
@@ -114,7 +114,7 @@ func modelBiasJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSource
 								"instance_count": {
 									// Property: InstanceCount
 									Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"instance_type": {
@@ -132,7 +132,7 @@ func modelBiasJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSource
 								"volume_size_in_gb": {
 									// Property: VolumeSizeInGB
 									Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -418,7 +418,7 @@ func modelBiasJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSource
 								},
 								"probability_threshold_attribute": {
 									// Property: ProbabilityThresholdAttribute
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"s3_data_distribution_type": {
@@ -708,7 +708,7 @@ func modelBiasJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSource
 					"max_runtime_in_seconds": {
 						// Property: MaxRuntimeInSeconds
 						Description: "The maximum runtime allowed in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/sagemaker/model_explainability_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_explainability_job_definition_resource_gen.go
@@ -129,7 +129,7 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 								"instance_count": {
 									// Property: InstanceCount
 									Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 100),
@@ -150,7 +150,7 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 								"volume_size_in_gb": {
 									// Property: VolumeSizeInGB
 									Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 16384),
@@ -752,7 +752,7 @@ func modelExplainabilityJobDefinitionResourceType(ctx context.Context) (tfsdk.Re
 					"max_runtime_in_seconds": {
 						// Property: MaxRuntimeInSeconds
 						Description: "The maximum runtime allowed in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 86400),

--- a/internal/aws/sagemaker/model_explainability_job_definition_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/model_explainability_job_definition_singular_data_source_gen.go
@@ -114,7 +114,7 @@ func modelExplainabilityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.
 								"instance_count": {
 									// Property: InstanceCount
 									Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"instance_type": {
@@ -132,7 +132,7 @@ func modelExplainabilityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.
 								"volume_size_in_gb": {
 									// Property: VolumeSizeInGB
 									Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -641,7 +641,7 @@ func modelExplainabilityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.
 					"max_runtime_in_seconds": {
 						// Property: MaxRuntimeInSeconds
 						Description: "The maximum runtime allowed in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/sagemaker/model_quality_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_quality_job_definition_resource_gen.go
@@ -129,7 +129,7 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 								"instance_count": {
 									// Property: InstanceCount
 									Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 100),
@@ -150,7 +150,7 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 								"volume_size_in_gb": {
 									// Property: VolumeSizeInGB
 									Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Required:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 16384),
@@ -543,7 +543,7 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 								},
 								"probability_threshold_attribute": {
 									// Property: ProbabilityThresholdAttribute
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Optional: true,
 								},
 								"s3_data_distribution_type": {
@@ -891,7 +891,7 @@ func modelQualityJobDefinitionResourceType(ctx context.Context) (tfsdk.ResourceT
 					"max_runtime_in_seconds": {
 						// Property: MaxRuntimeInSeconds
 						Description: "The maximum runtime allowed in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 86400),

--- a/internal/aws/sagemaker/model_quality_job_definition_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/model_quality_job_definition_singular_data_source_gen.go
@@ -114,7 +114,7 @@ func modelQualityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSou
 								"instance_count": {
 									// Property: InstanceCount
 									Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"instance_type": {
@@ -132,7 +132,7 @@ func modelQualityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSou
 								"volume_size_in_gb": {
 									// Property: VolumeSizeInGB
 									Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -466,7 +466,7 @@ func modelQualityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSou
 								},
 								"probability_threshold_attribute": {
 									// Property: ProbabilityThresholdAttribute
-									Type:     types.NumberType,
+									Type:     types.Float64Type,
 									Computed: true,
 								},
 								"s3_data_distribution_type": {
@@ -756,7 +756,7 @@ func modelQualityJobDefinitionDataSourceType(ctx context.Context) (tfsdk.DataSou
 					"max_runtime_in_seconds": {
 						// Property: MaxRuntimeInSeconds
 						Description: "The maximum runtime allowed in seconds.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/sagemaker/monitoring_schedule_resource_gen.go
+++ b/internal/aws/sagemaker/monitoring_schedule_resource_gen.go
@@ -888,7 +888,7 @@ func monitoringScheduleResourceType(ctx context.Context) (tfsdk.ResourceType, er
 														"instance_count": {
 															// Property: InstanceCount
 															Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-															Type:        types.NumberType,
+															Type:        types.Int64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntBetween(1, 100),
@@ -909,7 +909,7 @@ func monitoringScheduleResourceType(ctx context.Context) (tfsdk.ResourceType, er
 														"volume_size_in_gb": {
 															// Property: VolumeSizeInGB
 															Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-															Type:        types.NumberType,
+															Type:        types.Int64Type,
 															Required:    true,
 															Validators: []tfsdk.AttributeValidator{
 																validate.IntBetween(1, 16384),
@@ -990,7 +990,7 @@ func monitoringScheduleResourceType(ctx context.Context) (tfsdk.ResourceType, er
 											"max_runtime_in_seconds": {
 												// Property: MaxRuntimeInSeconds
 												Description: "The maximum runtime allowed in seconds.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntBetween(1, 86400),

--- a/internal/aws/sagemaker/monitoring_schedule_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/monitoring_schedule_singular_data_source_gen.go
@@ -790,7 +790,7 @@ func monitoringScheduleDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 														"instance_count": {
 															// Property: InstanceCount
 															Description: "The number of ML compute instances to use in the model monitoring job. For distributed processing jobs, specify a value greater than 1. The default value is 1.",
-															Type:        types.NumberType,
+															Type:        types.Int64Type,
 															Computed:    true,
 														},
 														"instance_type": {
@@ -808,7 +808,7 @@ func monitoringScheduleDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 														"volume_size_in_gb": {
 															// Property: VolumeSizeInGB
 															Description: "The size of the ML storage volume, in gigabytes, that you want to provision. You must specify sufficient ML storage for your scenario.",
-															Type:        types.NumberType,
+															Type:        types.Int64Type,
 															Computed:    true,
 														},
 													},
@@ -875,7 +875,7 @@ func monitoringScheduleDataSourceType(ctx context.Context) (tfsdk.DataSourceType
 											"max_runtime_in_seconds": {
 												// Property: MaxRuntimeInSeconds
 												Description: "The maximum runtime allowed in seconds.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},

--- a/internal/aws/sagemaker/pipeline_resource_gen.go
+++ b/internal/aws/sagemaker/pipeline_resource_gen.go
@@ -42,7 +42,7 @@ func pipelineResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"max_parallel_execution_steps": {
 						// Property: MaxParallelExecutionSteps
 						Description: "Maximum parallel execution steps",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(1),

--- a/internal/aws/sagemaker/pipeline_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/pipeline_singular_data_source_gen.go
@@ -41,7 +41,7 @@ func pipelineDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"max_parallel_execution_steps": {
 						// Property: MaxParallelExecutionSteps
 						Description: "Maximum parallel execution steps",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},

--- a/internal/aws/sagemaker/user_profile_resource_gen.go
+++ b/internal/aws/sagemaker/user_profile_resource_gen.go
@@ -513,7 +513,7 @@ func userProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"image_version_number": {
 												// Property: ImageVersionNumber
 												Description: "The version number of the CustomImage.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Optional:    true,
 												Validators: []tfsdk.AttributeValidator{
 													validate.IntAtLeast(0),

--- a/internal/aws/sagemaker/user_profile_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/user_profile_singular_data_source_gen.go
@@ -418,7 +418,7 @@ func userProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 											"image_version_number": {
 												// Property: ImageVersionNumber
 												Description: "The version number of the CustomImage.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},

--- a/internal/aws/servicecatalog/cloudformation_provisioned_product_resource_gen.go
+++ b/internal/aws/servicecatalog/cloudformation_provisioned_product_resource_gen.go
@@ -322,7 +322,7 @@ func cloudFormationProvisionedProductResourceType(ctx context.Context) (tfsdk.Re
 					},
 					"stack_set_failure_tolerance_count": {
 						// Property: StackSetFailureToleranceCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -330,7 +330,7 @@ func cloudFormationProvisionedProductResourceType(ctx context.Context) (tfsdk.Re
 					},
 					"stack_set_failure_tolerance_percentage": {
 						// Property: StackSetFailureTolerancePercentage
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(0, 100),
@@ -338,7 +338,7 @@ func cloudFormationProvisionedProductResourceType(ctx context.Context) (tfsdk.Re
 					},
 					"stack_set_max_concurrency_count": {
 						// Property: StackSetMaxConcurrencyCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(1),
@@ -346,7 +346,7 @@ func cloudFormationProvisionedProductResourceType(ctx context.Context) (tfsdk.Re
 					},
 					"stack_set_max_concurrency_percentage": {
 						// Property: StackSetMaxConcurrencyPercentage
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 100),

--- a/internal/aws/servicecatalog/cloudformation_provisioned_product_singular_data_source_gen.go
+++ b/internal/aws/servicecatalog/cloudformation_provisioned_product_singular_data_source_gen.go
@@ -264,22 +264,22 @@ func cloudFormationProvisionedProductDataSourceType(ctx context.Context) (tfsdk.
 					},
 					"stack_set_failure_tolerance_count": {
 						// Property: StackSetFailureToleranceCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"stack_set_failure_tolerance_percentage": {
 						// Property: StackSetFailureTolerancePercentage
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"stack_set_max_concurrency_count": {
 						// Property: StackSetMaxConcurrencyCount
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"stack_set_max_concurrency_percentage": {
 						// Property: StackSetMaxConcurrencyPercentage
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 					"stack_set_operation_type": {

--- a/internal/aws/signer/signing_profile_resource_gen.go
+++ b/internal/aws/signer/signing_profile_resource_gen.go
@@ -139,7 +139,7 @@ func signingProfileResourceType(ctx context.Context) (tfsdk.ResourceType, error)
 					},
 					"value": {
 						// Property: Value
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Optional: true,
 					},
 				},

--- a/internal/aws/signer/signing_profile_singular_data_source_gen.go
+++ b/internal/aws/signer/signing_profile_singular_data_source_gen.go
@@ -111,7 +111,7 @@ func signingProfileDataSourceType(ctx context.Context) (tfsdk.DataSourceType, er
 					},
 					"value": {
 						// Property: Value
-						Type:     types.NumberType,
+						Type:     types.Int64Type,
 						Computed: true,
 					},
 				},

--- a/internal/aws/ssm/association_resource_gen.go
+++ b/internal/aws/ssm/association_resource_gen.go
@@ -388,7 +388,7 @@ func associationResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 			//   "minimum": 15,
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Optional: true,
 			Validators: []tfsdk.AttributeValidator{
 				validate.IntBetween(15, 172800),

--- a/internal/aws/ssm/association_singular_data_source_gen.go
+++ b/internal/aws/ssm/association_singular_data_source_gen.go
@@ -348,7 +348,7 @@ func associationDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error
 			//   "minimum": 15,
 			//   "type": "integer"
 			// }
-			Type:     types.NumberType,
+			Type:     types.Int64Type,
 			Computed: true,
 		},
 	}

--- a/internal/aws/ssmcontacts/contact_resource_gen.go
+++ b/internal/aws/ssmcontacts/contact_resource_gen.go
@@ -159,7 +159,7 @@ func contactResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"duration_in_minutes": {
 						// Property: DurationInMinutes
 						Description: "The time to wait until beginning the next stage.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 					},
 					"targets": {
@@ -181,7 +181,7 @@ func contactResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 											"retry_interval_in_minutes": {
 												// Property: RetryIntervalInMinutes
 												Description: "The number of minutes to wait to retry sending engagement in the case the engagement initially fails.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Required:    true,
 											},
 										},

--- a/internal/aws/ssmcontacts/contact_singular_data_source_gen.go
+++ b/internal/aws/ssmcontacts/contact_singular_data_source_gen.go
@@ -146,7 +146,7 @@ func contactDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 					"duration_in_minutes": {
 						// Property: DurationInMinutes
 						Description: "The time to wait until beginning the next stage.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"targets": {
@@ -168,7 +168,7 @@ func contactDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 											"retry_interval_in_minutes": {
 												// Property: RetryIntervalInMinutes
 												Description: "The number of minutes to wait to retry sending engagement in the case the engagement initially fails.",
-												Type:        types.NumberType,
+												Type:        types.Int64Type,
 												Computed:    true,
 											},
 										},

--- a/internal/aws/ssmincidents/response_plan_resource_gen.go
+++ b/internal/aws/ssmincidents/response_plan_resource_gen.go
@@ -376,7 +376,7 @@ func responsePlanResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"impact": {
 						// Property: Impact
 						Description: "The impact value.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 5),

--- a/internal/aws/ssmincidents/response_plan_singular_data_source_gen.go
+++ b/internal/aws/ssmincidents/response_plan_singular_data_source_gen.go
@@ -317,7 +317,7 @@ func responsePlanDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"impact": {
 						// Property: Impact
 						Description: "The impact value.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"notification_targets": {

--- a/internal/aws/transfer/workflow_resource_gen.go
+++ b/internal/aws/transfer/workflow_resource_gen.go
@@ -315,7 +315,7 @@ func workflowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"timeout_seconds": {
 									// Property: TimeoutSeconds
 									Description: "Timeout, in seconds, for the step.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 1800),
@@ -675,7 +675,7 @@ func workflowResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"timeout_seconds": {
 									// Property: TimeoutSeconds
 									Description: "Timeout, in seconds, for the step.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 1800),

--- a/internal/aws/transfer/workflow_singular_data_source_gen.go
+++ b/internal/aws/transfer/workflow_singular_data_source_gen.go
@@ -282,7 +282,7 @@ func workflowDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"timeout_seconds": {
 									// Property: TimeoutSeconds
 									Description: "Timeout, in seconds, for the step.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -586,7 +586,7 @@ func workflowDataSourceType(ctx context.Context) (tfsdk.DataSourceType, error) {
 								"timeout_seconds": {
 									// Property: TimeoutSeconds
 									Description: "Timeout, in seconds, for the step.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},

--- a/internal/aws/xray/sampling_rule_resource_gen.go
+++ b/internal/aws/xray/sampling_rule_resource_gen.go
@@ -144,7 +144,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"fixed_rate": {
 						// Property: FixedRate
 						Description: "The percentage of matching requests to instrument, after the reservoir is exhausted.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 1.000000),
@@ -171,7 +171,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"priority": {
 						// Property: Priority
 						Description: "The priority of the sampling rule.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 9999),
@@ -180,7 +180,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"reservoir_size": {
 						// Property: ReservoirSize
 						Description: "A fixed number of matching requests to instrument per second, prior to applying the fixed rate. The reservoir is not used directly by services, but applies to all services using the rule collectively.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),
@@ -240,7 +240,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"version": {
 						// Property: Version
 						Description: "The version of the sampling rule format (1)",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(1),
@@ -374,7 +374,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"fixed_rate": {
 									// Property: FixedRate
 									Description: "The percentage of matching requests to instrument, after the reservoir is exhausted.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.FloatBetween(0.000000, 1.000000),
@@ -401,7 +401,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"priority": {
 									// Property: Priority
 									Description: "The priority of the sampling rule.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntBetween(1, 9999),
@@ -410,7 +410,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"reservoir_size": {
 									// Property: ReservoirSize
 									Description: "A fixed number of matching requests to instrument per second, prior to applying the fixed rate. The reservoir is not used directly by services, but applies to all services using the rule collectively.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(0),
@@ -470,7 +470,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 								"version": {
 									// Property: Version
 									Description: "The version of the sampling rule format (1)",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Optional:    true,
 									Validators: []tfsdk.AttributeValidator{
 										validate.IntAtLeast(1),
@@ -573,7 +573,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"fixed_rate": {
 						// Property: FixedRate
 						Description: "The percentage of matching requests to instrument, after the reservoir is exhausted.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.FloatBetween(0.000000, 1.000000),
@@ -600,7 +600,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"priority": {
 						// Property: Priority
 						Description: "The priority of the sampling rule.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntBetween(1, 9999),
@@ -609,7 +609,7 @@ func samplingRuleResourceType(ctx context.Context) (tfsdk.ResourceType, error) {
 					"reservoir_size": {
 						// Property: ReservoirSize
 						Description: "A fixed number of matching requests to instrument per second, prior to applying the fixed rate. The reservoir is not used directly by services, but applies to all services using the rule collectively.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Optional:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.IntAtLeast(0),

--- a/internal/aws/xray/sampling_rule_singular_data_source_gen.go
+++ b/internal/aws/xray/sampling_rule_singular_data_source_gen.go
@@ -137,7 +137,7 @@ func samplingRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"fixed_rate": {
 						// Property: FixedRate
 						Description: "The percentage of matching requests to instrument, after the reservoir is exhausted.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"http_method": {
@@ -155,13 +155,13 @@ func samplingRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"priority": {
 						// Property: Priority
 						Description: "The priority of the sampling rule.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"reservoir_size": {
 						// Property: ReservoirSize
 						Description: "A fixed number of matching requests to instrument per second, prior to applying the fixed rate. The reservoir is not used directly by services, but applies to all services using the rule collectively.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"resource_arn": {
@@ -203,7 +203,7 @@ func samplingRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"version": {
 						// Property: Version
 						Description: "The version of the sampling rule format (1)",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 				},
@@ -334,7 +334,7 @@ func samplingRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								"fixed_rate": {
 									// Property: FixedRate
 									Description: "The percentage of matching requests to instrument, after the reservoir is exhausted.",
-									Type:        types.NumberType,
+									Type:        types.Float64Type,
 									Computed:    true,
 								},
 								"http_method": {
@@ -352,13 +352,13 @@ func samplingRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								"priority": {
 									// Property: Priority
 									Description: "The priority of the sampling rule.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"reservoir_size": {
 									// Property: ReservoirSize
 									Description: "A fixed number of matching requests to instrument per second, prior to applying the fixed rate. The reservoir is not used directly by services, but applies to all services using the rule collectively.",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 								"resource_arn": {
@@ -400,7 +400,7 @@ func samplingRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 								"version": {
 									// Property: Version
 									Description: "The version of the sampling rule format (1)",
-									Type:        types.NumberType,
+									Type:        types.Int64Type,
 									Computed:    true,
 								},
 							},
@@ -500,7 +500,7 @@ func samplingRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"fixed_rate": {
 						// Property: FixedRate
 						Description: "The percentage of matching requests to instrument, after the reservoir is exhausted.",
-						Type:        types.NumberType,
+						Type:        types.Float64Type,
 						Computed:    true,
 					},
 					"http_method": {
@@ -518,13 +518,13 @@ func samplingRuleDataSourceType(ctx context.Context) (tfsdk.DataSourceType, erro
 					"priority": {
 						// Property: Priority
 						Description: "The priority of the sampling rule.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"reservoir_size": {
 						// Property: ReservoirSize
 						Description: "A fixed number of matching requests to instrument per second, prior to applying the fixed rate. The reservoir is not used directly by services, but applies to all services using the rule collectively.",
-						Type:        types.NumberType,
+						Type:        types.Int64Type,
 						Computed:    true,
 					},
 					"resource_arn": {

--- a/internal/provider/generators/resource/main.go
+++ b/internal/provider/generators/resource/main.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main
@@ -113,7 +114,6 @@ package {{ .PackageName }}
 
 import (
 	"context"
-	{{ if .ImportMathBig }}"math/big"{{- end }}
 
 	{{if .ImportFrameworkAttr }}"github.com/hashicorp/terraform-plugin-framework/attr"{{- end}}
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"

--- a/internal/provider/generators/shared/codegen/emitter.go
+++ b/internal/provider/generators/shared/codegen/emitter.go
@@ -175,7 +175,7 @@ func (e Emitter) emitAttribute(attributeNameMap map[string]string, path []string
 				elementType = "types.BoolType"
 
 			case cfschema.PropertyTypeInteger:
-				elementType = "types.Int64Type" //nolint:goconst
+				elementType = "types.Int64Type"
 				validatorsGenerator = integerValidators
 
 			case cfschema.PropertyTypeNumber:

--- a/internal/provider/generators/shared/codegen/emitter.go
+++ b/internal/provider/generators/shared/codegen/emitter.go
@@ -928,7 +928,7 @@ func integerValidators(path []string, property *cfschema.Property) ([]string, er
 	return validators, nil
 }
 
-// numberValidators returns any validators for the specified integer Property.
+// numberValidators returns any validators for the specified number Property.
 func numberValidators(path []string, property *cfschema.Property) ([]string, error) {
 	if propertyType := property.Type.String(); propertyType != cfschema.PropertyTypeNumber {
 		return nil, fmt.Errorf("invalid property type: %s", propertyType)

--- a/internal/provider/generators/shared/generator.go
+++ b/internal/provider/generators/shared/generator.go
@@ -133,9 +133,6 @@ func (g *Generator) GenerateTemplateData(cfTypeSchemaFile, resType, tfResourceTy
 	if codeFeatures&codegen.UsesFrameworkAttr > 0 {
 		templateData.ImportFrameworkAttr = true
 	}
-	if codeFeatures&codegen.UsesMathBig > 0 {
-		templateData.ImportMathBig = true
-	}
 
 	if resType == DataSourceType {
 		templateData.SchemaDescription = fmt.Sprintf("Data Source schema for %s", cfTypeName)
@@ -192,7 +189,6 @@ type TemplateData struct {
 	HasRequiredAttribute         bool
 	HasUpdateMethod              bool
 	ImportFrameworkAttr          bool
-	ImportMathBig                bool
 	ImportValidate               bool
 	PackageName                  string
 	RequiredAttributesValidator  string

--- a/internal/validate/float.go
+++ b/internal/validate/float.go
@@ -138,9 +138,24 @@ func FloatAtMost(max float64) tfsdk.AttributeValidator {
 }
 
 func validateFloat(request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) (float64, bool) {
-	n, ok := request.AttributeConfig.(types.Number)
+	switch n := request.AttributeConfig.(type) {
+	case types.Float64:
+		if n.Unknown || n.Null {
+			return 0, false
+		}
 
-	if !ok {
+		return n.Value, true
+
+	case types.Number:
+		if n.Unknown || n.Null {
+			return 0, false
+		}
+
+		f, _ := n.Value.Float64()
+
+		return f, true
+
+	default:
 		response.Diagnostics.Append(diag.NewIncorrectValueTypeAttributeError(
 			request.AttributePath,
 			request.AttributeConfig,
@@ -148,12 +163,4 @@ func validateFloat(request tfsdk.ValidateAttributeRequest, response *tfsdk.Valid
 
 		return 0, false
 	}
-
-	if n.Unknown || n.Null {
-		return 0, false
-	}
-
-	f, _ := n.Value.Float64()
-
-	return f, true
 }

--- a/internal/validate/float_test.go
+++ b/internal/validate/float_test.go
@@ -39,38 +39,62 @@ func TestFloatBetweenValidator(t *testing.T) {
 			min: 0.90,
 			max: 3.10,
 		},
-		"valid integer": {
+		"valid integer as Number": {
 			val: tftypes.NewValue(tftypes.Number, 2),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 0.90,
 			max: 3.10,
 		},
-		"valid float": {
+		"valid integer as Float64": {
+			val: tftypes.NewValue(tftypes.Number, 2),
+			f:   types.Float64Type.ValueFromTerraform,
+			min: 0.90,
+			max: 3.10,
+		},
+		"valid float as Number": {
 			val: tftypes.NewValue(tftypes.Number, 2.2),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 0.90,
 			max: 3.10,
 		},
-		"valid float min": {
+		"valid float as Float64": {
+			val: tftypes.NewValue(tftypes.Number, 2.2),
+			f:   types.Float64Type.ValueFromTerraform,
+			min: 0.90,
+			max: 3.10,
+		},
+		"valid float as Number min": {
 			val: tftypes.NewValue(tftypes.Number, 0.9),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 0.90,
 			max: 3.10,
 		},
-		"valid float max": {
+		"valid float as Float64 min": {
+			val: tftypes.NewValue(tftypes.Number, 0.9),
+			f:   types.Float64Type.ValueFromTerraform,
+			min: 0.90,
+			max: 3.10,
+		},
+		"valid float as Number max": {
 			val: tftypes.NewValue(tftypes.Number, 3.10),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 0.90,
 			max: 3.10,
 		},
-		"too small float": {
+		"valid float as Float64 max": {
+			val: tftypes.NewValue(tftypes.Number, 3.10),
+			f:   types.Float64Type.ValueFromTerraform,
+			min: 0.90,
+			max: 3.10,
+		},
+		"too small float as Number": {
 			val:         tftypes.NewValue(tftypes.Number, -1.1111),
 			f:           types.NumberType.ValueFromTerraform,
 			min:         0.90,
 			max:         3.10,
 			expectError: true,
 		},
-		"too large float": {
+		"too large float as Number": {
 			val:         tftypes.NewValue(tftypes.Number, 4.2),
 			f:           types.NumberType.ValueFromTerraform,
 			min:         0.90,
@@ -132,22 +156,37 @@ func TestFloatAtLeastValidator(t *testing.T) {
 			f:   types.NumberType.ValueFromTerraform,
 			min: 0.90,
 		},
-		"valid integer": {
+		"valid integer as Number": {
 			val: tftypes.NewValue(tftypes.Number, 2),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 0.90,
 		},
-		"valid float": {
+		"valid integer as Float64": {
+			val: tftypes.NewValue(tftypes.Number, 2),
+			f:   types.Float64Type.ValueFromTerraform,
+			min: 0.90,
+		},
+		"valid float as Number": {
 			val: tftypes.NewValue(tftypes.Number, 2.2),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 0.90,
 		},
-		"valid float min": {
+		"valid float as Float64": {
+			val: tftypes.NewValue(tftypes.Number, 2.2),
+			f:   types.Float64Type.ValueFromTerraform,
+			min: 0.90,
+		},
+		"valid float as Number min": {
 			val: tftypes.NewValue(tftypes.Number, 0.9),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 0.90,
 		},
-		"too small float": {
+		"valid float as Float64 min": {
+			val: tftypes.NewValue(tftypes.Number, 0.9),
+			f:   types.Float64Type.ValueFromTerraform,
+			min: 0.90,
+		},
+		"too small float as Number": {
 			val:         tftypes.NewValue(tftypes.Number, -1.1111),
 			f:           types.NumberType.ValueFromTerraform,
 			min:         0.90,
@@ -208,22 +247,37 @@ func TestFloatAtMostValidator(t *testing.T) {
 			f:   types.NumberType.ValueFromTerraform,
 			max: 2.00,
 		},
-		"valid integer": {
+		"valid integer as Number": {
 			val: tftypes.NewValue(tftypes.Number, 1),
 			f:   types.NumberType.ValueFromTerraform,
 			max: 2.00,
 		},
-		"valid float": {
+		"valid integer as Float64": {
+			val: tftypes.NewValue(tftypes.Number, 1),
+			f:   types.Float64Type.ValueFromTerraform,
+			max: 2.00,
+		},
+		"valid float as Number": {
 			val: tftypes.NewValue(tftypes.Number, 1.1),
 			f:   types.NumberType.ValueFromTerraform,
 			max: 2.00,
 		},
-		"valid float max": {
+		"valid float as Float64": {
+			val: tftypes.NewValue(tftypes.Number, 1.1),
+			f:   types.Float64Type.ValueFromTerraform,
+			max: 2.00,
+		},
+		"valid float as Number max": {
 			val: tftypes.NewValue(tftypes.Number, 2.00),
 			f:   types.NumberType.ValueFromTerraform,
 			max: 2.00,
 		},
-		"too large float": {
+		"valid float as Float64 max": {
+			val: tftypes.NewValue(tftypes.Number, 2.00),
+			f:   types.Float64Type.ValueFromTerraform,
+			max: 2.00,
+		},
+		"too large float as Number": {
 			val:         tftypes.NewValue(tftypes.Number, 3.00),
 			f:           types.NumberType.ValueFromTerraform,
 			max:         2.00,

--- a/internal/validate/int_test.go
+++ b/internal/validate/int_test.go
@@ -46,34 +46,66 @@ func TestIntBetweenValidator(t *testing.T) {
 			max:         3,
 			expectError: true,
 		},
-		"valid integer": {
+		"valid integer as Number": {
 			val: tftypes.NewValue(tftypes.Number, 2),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 1,
 			max: 3,
 		},
-		"valid integer min": {
+		"valid integer as Int64": {
+			val: tftypes.NewValue(tftypes.Number, 2),
+			f:   types.Int64Type.ValueFromTerraform,
+			min: 1,
+			max: 3,
+		},
+		"valid integer as Number min": {
 			val: tftypes.NewValue(tftypes.Number, 1),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 1,
 			max: 3,
 		},
-		"valid integer max": {
+		"valid integer as Int64 min": {
+			val: tftypes.NewValue(tftypes.Number, 1),
+			f:   types.Int64Type.ValueFromTerraform,
+			min: 1,
+			max: 3,
+		},
+		"valid integer as Number max": {
 			val: tftypes.NewValue(tftypes.Number, 3),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 1,
 			max: 3,
 		},
-		"too small integer": {
+		"valid integer as Int64 max": {
+			val: tftypes.NewValue(tftypes.Number, 3),
+			f:   types.Int64Type.ValueFromTerraform,
+			min: 1,
+			max: 3,
+		},
+		"too small integer as Number": {
 			val:         tftypes.NewValue(tftypes.Number, -1),
 			f:           types.NumberType.ValueFromTerraform,
 			min:         1,
 			max:         3,
 			expectError: true,
 		},
-		"too large integer": {
+		"too small integer as Int64": {
+			val:         tftypes.NewValue(tftypes.Number, -1),
+			f:           types.Int64Type.ValueFromTerraform,
+			min:         1,
+			max:         3,
+			expectError: true,
+		},
+		"too large integer as Number": {
 			val:         tftypes.NewValue(tftypes.Number, 42),
 			f:           types.NumberType.ValueFromTerraform,
+			min:         1,
+			max:         3,
+			expectError: true,
+		},
+		"too large integer as Int64": {
+			val:         tftypes.NewValue(tftypes.Number, 42),
+			f:           types.Int64Type.ValueFromTerraform,
 			min:         1,
 			max:         3,
 			expectError: true,
@@ -139,17 +171,27 @@ func TestIntAtLeastValidator(t *testing.T) {
 			min:         1,
 			expectError: true,
 		},
-		"valid integer": {
+		"valid integer as Number": {
 			val: tftypes.NewValue(tftypes.Number, 2),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 1,
 		},
-		"valid integer min": {
+		"valid integer as Int64": {
+			val: tftypes.NewValue(tftypes.Number, 2),
+			f:   types.Int64Type.ValueFromTerraform,
+			min: 1,
+		},
+		"valid integer as Number min": {
 			val: tftypes.NewValue(tftypes.Number, 1),
 			f:   types.NumberType.ValueFromTerraform,
 			min: 1,
 		},
-		"too small integer": {
+		"valid integer as Int64 min": {
+			val: tftypes.NewValue(tftypes.Number, 1),
+			f:   types.Int64Type.ValueFromTerraform,
+			min: 1,
+		},
+		"too small integer as Number": {
 			val:         tftypes.NewValue(tftypes.Number, -1),
 			f:           types.NumberType.ValueFromTerraform,
 			min:         1,
@@ -216,17 +258,27 @@ func TestIntAtMostValidator(t *testing.T) {
 			max:         2,
 			expectError: true,
 		},
-		"valid integer": {
+		"valid integer as Number": {
 			val: tftypes.NewValue(tftypes.Number, 1),
 			f:   types.NumberType.ValueFromTerraform,
 			max: 2,
 		},
-		"valid integer min": {
+		"valid integer as Int64": {
+			val: tftypes.NewValue(tftypes.Number, 1),
+			f:   types.Int64Type.ValueFromTerraform,
+			max: 2,
+		},
+		"valid integer as Number min": {
 			val: tftypes.NewValue(tftypes.Number, 2),
 			f:   types.NumberType.ValueFromTerraform,
 			max: 2,
 		},
-		"too large integer": {
+		"valid integer as Int64 min": {
+			val: tftypes.NewValue(tftypes.Number, 2),
+			f:   types.Int64Type.ValueFromTerraform,
+			max: 2,
+		},
+		"too large integer as Number": {
 			val:         tftypes.NewValue(tftypes.Number, 4),
 			f:           types.NumberType.ValueFromTerraform,
 			max:         2,
@@ -290,12 +342,17 @@ func TestIntInSliceValidator(t *testing.T) {
 			f:           types.NumberType.ValueFromTerraform,
 			expectError: true,
 		},
-		"valid integer": {
+		"valid integer as Number": {
 			val:   tftypes.NewValue(tftypes.Number, 2),
 			f:     types.NumberType.ValueFromTerraform,
 			valid: []int{-1, 2, 42},
 		},
-		"invalid integer": {
+		"valid integer as Int64": {
+			val:   tftypes.NewValue(tftypes.Number, 2),
+			f:     types.Int64Type.ValueFromTerraform,
+			valid: []int{-1, 2, 42},
+		},
+		"invalid integer as Number": {
 			val:         tftypes.NewValue(tftypes.Number, 1),
 			f:           types.NumberType.ValueFromTerraform,
 			valid:       []int{-1, 2, 42},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #171.

```console
% make testacc PKG_NAME=internal/aws/logs TESTARGS='-run=TestAccAWSLogsLogGroup_'
TF_ACC=1 go test ./internal/aws/logs -v -count 1 -parallel 20 -run=TestAccAWSLogsLogGroup_ -timeout 180m
=== RUN   TestAccAWSLogsLogGroup_basic
=== PAUSE TestAccAWSLogsLogGroup_basic
=== RUN   TestAccAWSLogsLogGroup_disappears
=== PAUSE TestAccAWSLogsLogGroup_disappears
=== RUN   TestAccAWSLogsLogGroup_update
=== PAUSE TestAccAWSLogsLogGroup_update
=== CONT  TestAccAWSLogsLogGroup_basic
=== CONT  TestAccAWSLogsLogGroup_update
=== CONT  TestAccAWSLogsLogGroup_disappears
{"@level":"debug","@message":"FindResourceByTypeNameAndID","@module":"provider","@timestamp":"2022-02-09T08:08:50.309020-05:00","cfTypeName":"AWS::Logs::LogGroup","id":"ALJl0lORXvppLrB0UzwkaTlMs-8ab0dLvdal1X"}
{"@level":"debug","@message":"FindResourceByTypeNameAndID","@module":"provider","@timestamp":"2022-02-09T08:08:50.980767-05:00","cfTypeName":"AWS::Logs::LogGroup","id":"4R8TNmfI3GcL99lX5YwGuVDWF-W3rFwEppeM9v"}
{"@level":"debug","@message":"FindResourceByTypeNameAndID","@module":"provider","@timestamp":"2022-02-09T08:08:51.018565-05:00","cfTypeName":"AWS::Logs::LogGroup","id":"tf-acc-test-6637040298905400067"}
{"@level":"debug","@message":"ResourceDescription.ResourceModel","@module":"provider","@timestamp":"2022-02-09T08:08:51.458366-05:00","value":"{\"LogGroupName\":\"ALJl0lORXvppLrB0UzwkaTlMs-8ab0dLvdal1X\",\"Arn\":\"arn:aws:logs:us-west-2:187416307283:log-group:ALJl0lORXvppLrB0UzwkaTlMs-8ab0dLvdal1X:*\"}"}
{"@level":"debug","@message":"ResourceDescription.ResourceModel","@module":"provider","@timestamp":"2022-02-09T08:08:51.875833-05:00","value":"{\"RetentionInDays\":30,\"LogGroupName\":\"tf-acc-test-6637040298905400067\",\"Arn\":\"arn:aws:logs:us-west-2:187416307283:log-group:tf-acc-test-6637040298905400067:*\"}"}
{"@level":"debug","@message":"ResourceDescription.ResourceModel","@module":"provider","@timestamp":"2022-02-09T08:08:52.450882-05:00","value":"{\"LogGroupName\":\"4R8TNmfI3GcL99lX5YwGuVDWF-W3rFwEppeM9v\",\"Arn\":\"arn:aws:logs:us-west-2:187416307283:log-group:4R8TNmfI3GcL99lX5YwGuVDWF-W3rFwEppeM9v:*\"}"}
{"@level":"debug","@message":"DeleteResource","@module":"provider","@timestamp":"2022-02-09T08:08:52.450963-05:00","cfTypeName":"AWS::Logs::LogGroup","id":"4R8TNmfI3GcL99lX5YwGuVDWF-W3rFwEppeM9v"}
--- PASS: TestAccAWSLogsLogGroup_disappears (23.42s)
{"@level":"debug","@message":"FindResourceByTypeNameAndID","@module":"provider","@timestamp":"2022-02-09T08:09:05.885428-05:00","cfTypeName":"AWS::Logs::LogGroup","id":"ALJl0lORXvppLrB0UzwkaTlMs-8ab0dLvdal1X"}
--- PASS: TestAccAWSLogsLogGroup_basic (27.49s)
{"@level":"debug","@message":"FindResourceByTypeNameAndID","@module":"provider","@timestamp":"2022-02-09T08:09:10.303884-05:00","cfTypeName":"AWS::Logs::LogGroup","id":"tf-acc-test-6637040298905400067"}
{"@level":"debug","@message":"ResourceDescription.ResourceModel","@module":"provider","@timestamp":"2022-02-09T08:09:15.199675-05:00","value":"{\"RetentionInDays\":60,\"LogGroupName\":\"tf-acc-test-6637040298905400067\",\"Arn\":\"arn:aws:logs:us-west-2:187416307283:log-group:tf-acc-test-6637040298905400067:*\"}"}
{"@level":"debug","@message":"FindResourceByTypeNameAndID","@module":"provider","@timestamp":"2022-02-09T08:09:26.984877-05:00","cfTypeName":"AWS::Logs::LogGroup","id":"tf-acc-test-6637040298905400067"}
--- PASS: TestAccAWSLogsLogGroup_update (48.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-awscc/internal/aws/logs	49.607s
```