### PR TITLE
.github/workflows/release: restore workflow trigger to tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,61 +1,16 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      release-version:
-        description: '(Optional) Release Version e.g. 1.x.x'
-        required: false
-        type: string
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 permissions:
   contents: write
 
 jobs:
-  release-tag:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: main
-      - if: ${{ !github.event.inputs.release-version }}
-        name: Get next tag
-        id: tag
-        run: |
-          PREVIOUS_RELEASE_TAG=$(git describe --abbrev=0 --match='v*.*.*' --tags)
-          NEW_RELEASE_TAG=v$(echo $PREVIOUS_RELEASE_TAG | awk -F. '{
-                        $1 = substr($1,2)
-                        $2 += 1
-                        printf("%s.%01d.0\n\n", $1, $2);
-                    }')
-          echo ::set-output name=new_release_tag::$NEW_RELEASE_TAG
-      - if: github.event.inputs.release-version
-        name: Create tag from input
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: "refs/tags/v${{ github.event.inputs.release-version }}",
-              sha: context.sha
-            })
-      - if: steps.tag.outputs.new_release_tag
-        name: Create computed tag
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: "refs/tags/${{ steps.tag.outputs.new_release_tag }}",
-              sha: context.sha
-            })
   go-version:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     outputs:
       version: ${{ steps.go-version.outputs.version }}
     steps:
@@ -63,7 +18,7 @@ jobs:
       - id: go-version
         run: echo "::set-output name=version::$(cat ./.go-version)"
   release-notes:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -77,7 +32,7 @@ jobs:
           retention-days: 1
   terraform-provider-release:
     name: 'Terraform Provider Release'
-    needs: [release-tag, go-version, release-notes]
+    needs: [go-version, release-notes]
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
     secrets:
       hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
@@ -94,16 +49,35 @@ jobs:
       setup-go-version: '${{ needs.go-version.outputs.version }}'
       # Product Version (e.g. v1.2.3 or github.ref_name)
       product-version: '${{ github.ref_name }}'
-  changelog:
-    needs: [terraform-provider-release]
-    runs-on: ubuntu-latest
+  highest-version-tag:
+    needs: [ terraform-provider-release ]
+    runs-on: macos-latest
+    outputs:
+      tag: ${{ steps.highest-version-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Allow tag to be fetched when ref is a commit
+          fetch-depth: 0
+      - name: Output highest version tag
+        id: highest-version-tag
+        run: |
+          HIGHEST=$(git tag | sort -V | tail -1)
+          echo ::set-output name=tag::$HIGHEST
+  changelog-newversion:
+    needs: [terraform-provider-release, highest-version-tag]
+    # write new changelog header only if release tag is the $HIGHEST i.e. exists on main
+    # and not a backport release branch (e.g. release/3.x). This results in
+    # manually updating the CHANGELOG header if releasing from the non-default branch.
+    # TODO: find a more deterministic way to determine release branch from tag commit
+    if: github.ref_name == needs.highest-version-tag.outputs.tag
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: main
       - name: Update Changelog Header
-        id: changelog
         run: |
           CHANGELOG_FILE_NAME="CHANGELOG.md"
           CURR_RELEASE_TAG=$(git describe --abbrev=0 --match='v*.*.*' --tags)
@@ -125,11 +99,9 @@ jobs:
           echo New minor version is: v$NEXT_RELEASE_LINE
 
           echo -e "## $NEXT_RELEASE_LINE (Unreleased)\n$(cat $CHANGELOG_FILE_NAME)" > $CHANGELOG_FILE_NAME
-
-          echo ::set-output name=curr_release_tag::$CURR_RELEASE_TAG
       - run: |
           git config --local user.email changelogbot@hashicorp.com
           git config --local user.name changelogbot
           git add CHANGELOG.md
-          git commit -m "Update CHANGELOG.md after ${{ steps.changelog.outputs.curr_release_tag }}"
+          git commit -m "Update CHANGELOG.md after ${{ github.ref_name }}"
           git push


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #453 

### Description:

* _product-version_  in the `terraform-provider-release` job is currently being set to the `github.ref_name` which evaluates to the branch or tag name that triggered the workflow run. In the case of this workflow, it's manually triggered on a branch so i don't believe it'll evaluate to a tag name as expected (this differs from other provider release workflows e.g. `aws` where a tag is created and pushed on the command line). i've changed this workflow to use the same trigger setup as the `aws` provider to ensure `product-version` is populated and to simplify future updates where needed across providers.
