### PR TITLE
Prevent infinite loop if an API error is returned when waiting for an async operation to complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ FEATURES:
 * **New Data Source:** `awscc_sagemaker_model_packages`
 * **New Resource:** `awscc_sagemaker_model_package`
 
+BUG FIXES:
+
+* Prevent infinite loop if waiting for any asynchronous operation to complete returns an AWS API error ([#510](https://github.com/hashicorp/terraform-provider-awscc/issues/510))
+
 ## [0.21.0](https://github.com/hashicorp/terraform-provider-awscc/releases/tag/v0.21.0) (May 12, 2022)
 
 FEATURES:

--- a/internal/aws/ec2/vpc_resource_test.go
+++ b/internal/aws/ec2/vpc_resource_test.go
@@ -36,7 +36,10 @@ func TestAccAWSEC2VPC_CidrBlock(t *testing.T) {
 func testAccAWSEC2VPCCidrBlockConfig(td *acctest.TestData, rName, cidrBlock string) string {
 	return fmt.Sprintf(`
 resource %[1]q %[2]q {
-  cidr_block = %[4]q
+  cidr_block           = %[4]q
+  enable_dns_hostnames = false
+  enable_dns_support   = true
+  instance_tenancy     = "default"
 
   tags = [
     {

--- a/internal/service/cloudcontrol/waiter.go
+++ b/internal/service/cloudcontrol/waiter.go
@@ -32,6 +32,6 @@ func RetryGetResourceRequestStatus(pProgressEvent **types.ProgressEvent) func(co
 			}
 		}
 
-		return true, nil
+		return true, err
 	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes https://github.com/hashicorp/terraform-provider-awscc/issues/486.

Testing with a resource that exercises the waiter:

```console
% TF_LOG=ERROR make testacc PKG_NAME=internal/aws/ec2 TESTARGS='-run=TestAccAWSEC2VPC_CidrBlock'
TF_ACC=1 go test ./internal/aws/ec2 -v -count 1 -parallel 20 -run=TestAccAWSEC2VPC_CidrBlock -timeout 180m
=== RUN   TestAccAWSEC2VPC_CidrBlock
=== PAUSE TestAccAWSEC2VPC_CidrBlock
=== CONT  TestAccAWSEC2VPC_CidrBlock
--- PASS: TestAccAWSEC2VPC_CidrBlock (36.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-awscc/internal/aws/ec2	37.826s
```
