### PR TITLE
Add `AttributePlanModifier` that suppresses semantically insignificant differences between JSON strings

### DIFF
--- a/internal/generic/jsonstring.go
+++ b/internal/generic/jsonstring.go
@@ -1,0 +1,94 @@
+package generic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type jsonStringAttributePlanModifier struct {
+	tfsdk.AttributePlanModifier
+}
+
+// A JSONString is a string containing a valid JSON document.
+// This plan modifier suppresses semantically insignificant differences.
+func JSONString() tfsdk.AttributePlanModifier {
+	return jsonStringAttributePlanModifier{}
+}
+
+func (attributePlanModifier jsonStringAttributePlanModifier) Description(_ context.Context) string {
+	return "Suppresses semantically insignificant differences."
+}
+
+func (attributePlanModifier jsonStringAttributePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return attributePlanModifier.Description(ctx)
+}
+
+func (attributePlanModifier jsonStringAttributePlanModifier) Modify(ctx context.Context, request tfsdk.ModifyAttributePlanRequest, response *tfsdk.ModifyAttributePlanResponse) {
+	if request.AttributeState == nil {
+		response.AttributePlan = request.AttributePlan
+
+		return
+	}
+
+	// If the current value is semantically equivalent to the planned value
+	// then return the current value, else return the planned value.
+
+	var planned types.String
+	diags := tfsdk.ValueAs(ctx, request.AttributePlan, &planned)
+
+	if diags.HasError() {
+		response.Diagnostics = append(response.Diagnostics, diags...)
+
+		return
+	}
+
+	plannedMap, err := expandJSONFromString(planned.Value)
+
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Invalid JSON string",
+			fmt.Sprintf("unable to unmarshal JSON: %s", err.Error()),
+		)
+
+		return
+	}
+
+	var current types.String
+	diags = tfsdk.ValueAs(ctx, request.AttributeState, &current)
+
+	if diags.HasError() {
+		response.Diagnostics = append(response.Diagnostics, diags...)
+
+		return
+	}
+
+	currentMap, err := expandJSONFromString(current.Value)
+
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Invalid JSON string",
+			fmt.Sprintf("unable to unmarshal JSON: %s", err.Error()),
+		)
+
+		return
+	}
+
+	if reflect.DeepEqual(plannedMap, currentMap) {
+		response.AttributePlan = request.AttributeState
+	} else {
+		response.AttributePlan = request.AttributePlan
+	}
+}
+
+func expandJSONFromString(s string) (map[string]interface{}, error) {
+	var v map[string]interface{}
+
+	err := json.Unmarshal([]byte(s), &v)
+
+	return v, err
+}

--- a/internal/generic/jsonstring_test.go
+++ b/internal/generic/jsonstring_test.go
@@ -1,0 +1,82 @@
+package generic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-awscc/internal/tfresource"
+)
+
+func TestJSONString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		plannedValue  attr.Value
+		currentValue  attr.Value
+		expectedValue attr.Value
+		expectError   bool
+	}
+	tests := map[string]testCase{
+		"planned not string": {
+			plannedValue: types.Int64{Value: 1},
+			currentValue: types.String{Value: `{}`},
+			expectError:  true,
+		},
+		"current not string": {
+			plannedValue: types.String{Value: `{}`},
+			currentValue: types.Int64{Value: 1},
+			expectError:  true,
+		},
+		"exactly equal": {
+			plannedValue:  types.String{Value: `{}`},
+			currentValue:  types.String{Value: `{}`},
+			expectedValue: types.String{Value: `{}`},
+		},
+		"leading and trailing whitespace": {
+			plannedValue:  types.String{Value: ` {}`},
+			currentValue:  types.String{Value: `{}  `},
+			expectedValue: types.String{Value: `{}  `},
+		},
+		"not equal": {
+			plannedValue:  types.String{Value: `{"k1": 42}`},
+			currentValue:  types.String{Value: `{"k1": -1}`},
+			expectedValue: types.String{Value: `{"k1": 42}`},
+		},
+		"fields reordered": {
+			plannedValue:  types.String{Value: `{"k2": ["v2",  {"k3": true}],  "k1": 42 }`},
+			currentValue:  types.String{Value: `{"k1": 42, "k2": ["v2", {"k3": true}]}`},
+			expectedValue: types.String{Value: `{"k1": 42, "k2": ["v2", {"k3": true}]}`},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			ctx := context.TODO()
+			request := tfsdk.ModifyAttributePlanRequest{
+				AttributePath:  tftypes.NewAttributePath().WithAttributeName("test"),
+				AttributePlan:  test.plannedValue,
+				AttributeState: test.currentValue,
+			}
+			response := tfsdk.ModifyAttributePlanResponse{}
+			JSONString().Modify(ctx, request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", tfresource.DiagsError(response.Diagnostics))
+			}
+
+			if diff := cmp.Diff(response.AttributePlan, test.expectedValue); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates https://github.com/hashicorp/terraform-provider-awscc/issues/509.

```console
% go test -v -run=TestJSONString ./internal/generic 
=== RUN   TestJSONString
=== PAUSE TestJSONString
=== CONT  TestJSONString
=== RUN   TestJSONString/planned_not_string
=== RUN   TestJSONString/current_not_string
=== RUN   TestJSONString/exactly_equal
=== RUN   TestJSONString/leading_and_trailing_whitespace
=== RUN   TestJSONString/not_equal
=== RUN   TestJSONString/fields_reordered
--- PASS: TestJSONString (0.00s)
    --- PASS: TestJSONString/planned_not_string (0.00s)
    --- PASS: TestJSONString/current_not_string (0.00s)
    --- PASS: TestJSONString/exactly_equal (0.00s)
    --- PASS: TestJSONString/leading_and_trailing_whitespace (0.00s)
    --- PASS: TestJSONString/not_equal (0.00s)
    --- PASS: TestJSONString/fields_reordered (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-awscc/internal/generic	1.316s
```