### PR TITLE
Use `int64` in Int validators

### DIFF
--- a/internal/validate/int.go
+++ b/internal/validate/int.go
@@ -15,7 +15,7 @@ import (
 type intBetweenValidator struct {
 	tfsdk.AttributeValidator
 
-	min, max int
+	min, max int64
 }
 
 // Description describes the validation in plain text formatting.
@@ -35,7 +35,7 @@ func (validator intBetweenValidator) Validate(ctx context.Context, request tfsdk
 		return
 	}
 
-	if i < int64(validator.min) || i > int64(validator.max) {
+	if i < validator.min || i > validator.max {
 		response.Diagnostics.Append(ccdiag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be in the range [%d, %d], got %d", validator.min, validator.max, i),
@@ -46,7 +46,7 @@ func (validator intBetweenValidator) Validate(ctx context.Context, request tfsdk
 }
 
 // IntBetween returns a new integer value between validator.
-func IntBetween(min, max int) tfsdk.AttributeValidator {
+func IntBetween(min, max int64) tfsdk.AttributeValidator {
 	if min > max {
 		return nil
 	}
@@ -61,7 +61,7 @@ func IntBetween(min, max int) tfsdk.AttributeValidator {
 type intAtLeastValidator struct {
 	tfsdk.AttributeValidator
 
-	min int
+	min int64
 }
 
 // Description describes the validation in plain text formatting.
@@ -81,7 +81,7 @@ func (validator intAtLeastValidator) Validate(ctx context.Context, request tfsdk
 		return
 	}
 
-	if i < int64(validator.min) {
+	if i < validator.min {
 		response.Diagnostics.Append(ccdiag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be at least %d, got %d", validator.min, i),
@@ -92,7 +92,7 @@ func (validator intAtLeastValidator) Validate(ctx context.Context, request tfsdk
 }
 
 // IntAtLeast returns a new integer value at least validator.
-func IntAtLeast(min int) tfsdk.AttributeValidator {
+func IntAtLeast(min int64) tfsdk.AttributeValidator {
 	return intAtLeastValidator{
 		min: min,
 	}
@@ -102,7 +102,7 @@ func IntAtLeast(min int) tfsdk.AttributeValidator {
 type intAtMostValidator struct {
 	tfsdk.AttributeValidator
 
-	max int
+	max int64
 }
 
 // Description describes the validation in plain text formatting.
@@ -122,7 +122,7 @@ func (validator intAtMostValidator) Validate(ctx context.Context, request tfsdk.
 		return
 	}
 
-	if i > int64(validator.max) {
+	if i > validator.max {
 		response.Diagnostics.Append(ccdiag.NewInvalidValueAttributeError(
 			request.AttributePath,
 			fmt.Sprintf("expected value to be at most %d, got %d", validator.max, i),
@@ -133,7 +133,7 @@ func (validator intAtMostValidator) Validate(ctx context.Context, request tfsdk.
 }
 
 // IntAtMost returns a new integer value at most validator.
-func IntAtMost(max int) tfsdk.AttributeValidator {
+func IntAtMost(max int64) tfsdk.AttributeValidator {
 	return intAtMostValidator{
 		max: max,
 	}

--- a/internal/validate/int_test.go
+++ b/internal/validate/int_test.go
@@ -17,8 +17,8 @@ func TestIntBetweenValidator(t *testing.T) {
 	type testCase struct {
 		val         tftypes.Value
 		f           func(context.Context, tftypes.Value) (attr.Value, error)
-		min         int
-		max         int
+		min         int64
+		max         int64
 		expectError bool
 	}
 	tests := map[string]testCase{
@@ -146,7 +146,7 @@ func TestIntAtLeastValidator(t *testing.T) {
 	type testCase struct {
 		val         tftypes.Value
 		f           func(context.Context, tftypes.Value) (attr.Value, error)
-		min         int
+		min         int64
 		expectError bool
 	}
 	tests := map[string]testCase{
@@ -233,7 +233,7 @@ func TestIntAtMostValidator(t *testing.T) {
 	type testCase struct {
 		val         tftypes.Value
 		f           func(context.Context, tftypes.Value) (attr.Value, error)
-		max         int
+		max         int64
 		expectError bool
 	}
 	tests := map[string]testCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-awscc/issues/533.

```console
% go test -v ./internal/validate 
=== RUN   TestARNValidator
=== PAUSE TestARNValidator
=== RUN   TestIAMPolicyARNValidator
=== PAUSE TestIAMPolicyARNValidator
=== RUN   TestArrayLenBetweenValidator
=== PAUSE TestArrayLenBetweenValidator
=== RUN   TestArrayLenAtLeastValidator
=== PAUSE TestArrayLenAtLeastValidator
=== RUN   TestArrayLenAtMostValidator
=== PAUSE TestArrayLenAtMostValidator
=== RUN   TestFloatBetweenValidator
=== PAUSE TestFloatBetweenValidator
=== RUN   TestFloatAtLeastValidator
=== PAUSE TestFloatAtLeastValidator
=== RUN   TestFloatAtMostValidator
=== PAUSE TestFloatAtMostValidator
=== RUN   TestArrayForEachValidator
=== PAUSE TestArrayForEachValidator
=== RUN   TestIntBetweenValidator
=== PAUSE TestIntBetweenValidator
=== RUN   TestIntAtLeastValidator
=== PAUSE TestIntAtLeastValidator
=== RUN   TestIntAtMostValidator
=== PAUSE TestIntAtMostValidator
=== RUN   TestIntInSliceValidator
=== PAUSE TestIntInSliceValidator
=== RUN   TestAllValidator
=== PAUSE TestAllValidator
=== RUN   TestRequired
=== PAUSE TestRequired
=== RUN   TestAllOfRequired
=== PAUSE TestAllOfRequired
=== RUN   TestAnyOfRequired
=== PAUSE TestAnyOfRequired
=== RUN   TestOneOfRequired
=== PAUSE TestOneOfRequired
=== RUN   TestRequiredAttributesValidator_Object
=== PAUSE TestRequiredAttributesValidator_Object
=== RUN   TestRequiredAttributesValidator_List
=== PAUSE TestRequiredAttributesValidator_List
=== RUN   TestRequiredAttributesValidator_Set
=== PAUSE TestRequiredAttributesValidator_Set
=== RUN   TestResourceConfigRequiredAttributesValidator
=== PAUSE TestResourceConfigRequiredAttributesValidator
=== RUN   TestStringLenBetweenValidator
=== PAUSE TestStringLenBetweenValidator
=== RUN   TestStringLenAtLeastValidator
=== PAUSE TestStringLenAtLeastValidator
=== RUN   TestStringLenAtMostValidator
=== PAUSE TestStringLenAtMostValidator
=== RUN   TestStringInSliceValidator
=== PAUSE TestStringInSliceValidator
=== RUN   TestStringMatchValidator
=== PAUSE TestStringMatchValidator
=== RUN   TestStringIsJsonValidator
=== PAUSE TestStringIsJsonValidator
=== RUN   TestIsRFC3339TimeValidator
=== PAUSE TestIsRFC3339TimeValidator
=== RUN   TestUniqueItemsValidator
=== PAUSE TestUniqueItemsValidator
=== RUN   TestURIValidator
=== PAUSE TestURIValidator
=== CONT  TestARNValidator
=== RUN   TestARNValidator/unknown_string
=== CONT  TestAnyOfRequired
=== CONT  TestStringLenAtMostValidator
=== RUN   TestAnyOfRequired/some_required
=== CONT  TestURIValidator
=== RUN   TestStringLenAtMostValidator/null_string
=== CONT  TestUniqueItemsValidator
=== CONT  TestIsRFC3339TimeValidator
=== RUN   TestStringLenAtMostValidator/valid_string
=== RUN   TestURIValidator/not_a_string
=== CONT  TestStringIsJsonValidator
=== RUN   TestUniqueItemsValidator/empty_list
=== RUN   TestStringIsJsonValidator/not_a_string
=== CONT  TestStringMatchValidator
=== RUN   TestUniqueItemsValidator/duplicates_in_list_of_string
=== RUN   TestStringIsJsonValidator/unknown_string
=== RUN   TestARNValidator/null_string
=== RUN   TestAnyOfRequired/nested_allOf_OK
=== RUN   TestStringLenAtMostValidator/too_long_string
=== RUN   TestIsRFC3339TimeValidator/not_a_string
=== RUN   TestStringLenAtMostValidator/not_a_string
=== RUN   TestURIValidator/unknown_string
=== RUN   TestARNValidator/valid_string
=== RUN   TestIsRFC3339TimeValidator/unknown_string
=== RUN   TestAnyOfRequired/nested_allOf_error
=== RUN   TestStringLenAtMostValidator/unknown_string
=== RUN   TestIsRFC3339TimeValidator/null_string
=== RUN   TestAnyOfRequired/nested_anyOf_OK
=== RUN   TestARNValidator/invalid_string
=== RUN   TestURIValidator/null_string
--- PASS: TestStringLenAtMostValidator (0.00s)
    --- PASS: TestStringLenAtMostValidator/null_string (0.00s)
    --- PASS: TestStringLenAtMostValidator/valid_string (0.00s)
    --- PASS: TestStringLenAtMostValidator/too_long_string (0.00s)
    --- PASS: TestStringLenAtMostValidator/not_a_string (0.00s)
    --- PASS: TestStringLenAtMostValidator/unknown_string (0.00s)
=== RUN   TestStringIsJsonValidator/null_string
=== RUN   TestURIValidator/valid_string
=== RUN   TestStringMatchValidator/not_a_string
=== RUN   TestARNValidator/not_a_string
=== RUN   TestStringIsJsonValidator/valid_JSON_object
=== RUN   TestUniqueItemsValidator/duplicates_in_list_of_object
=== RUN   TestIsRFC3339TimeValidator/valid_date_string
--- PASS: TestARNValidator (0.00s)
    --- PASS: TestARNValidator/unknown_string (0.00s)
    --- PASS: TestARNValidator/null_string (0.00s)
    --- PASS: TestARNValidator/valid_string (0.00s)
    --- PASS: TestARNValidator/invalid_string (0.00s)
    --- PASS: TestARNValidator/not_a_string (0.00s)
=== CONT  TestArrayForEachValidator
=== RUN   TestStringIsJsonValidator/parsing_error
=== RUN   TestIsRFC3339TimeValidator/valid_date-time_string
=== RUN   TestStringIsJsonValidator/not_an_object
=== RUN   TestIsRFC3339TimeValidator/invalid_string
--- PASS: TestStringIsJsonValidator (0.00s)
    --- PASS: TestStringIsJsonValidator/not_a_string (0.00s)
    --- PASS: TestStringIsJsonValidator/unknown_string (0.00s)
    --- PASS: TestStringIsJsonValidator/null_string (0.00s)
    --- PASS: TestStringIsJsonValidator/valid_JSON_object (0.00s)
    --- PASS: TestStringIsJsonValidator/parsing_error (0.00s)
    --- PASS: TestStringIsJsonValidator/not_an_object (0.00s)
=== CONT  TestAllOfRequired
=== RUN   TestAllOfRequired/both_empty
--- PASS: TestIsRFC3339TimeValidator (0.00s)
    --- PASS: TestIsRFC3339TimeValidator/not_a_string (0.00s)
    --- PASS: TestIsRFC3339TimeValidator/unknown_string (0.00s)
    --- PASS: TestIsRFC3339TimeValidator/null_string (0.00s)
    --- PASS: TestIsRFC3339TimeValidator/valid_date_string (0.00s)
    --- PASS: TestIsRFC3339TimeValidator/valid_date-time_string (0.00s)
    --- PASS: TestIsRFC3339TimeValidator/invalid_string (0.00s)
=== CONT  TestRequired
=== RUN   TestAllOfRequired/none_required
=== RUN   TestArrayForEachValidator/null_list
=== RUN   TestRequired/some_required
=== CONT  TestStringInSliceValidator
=== RUN   TestRequired/all_required
=== RUN   TestAnyOfRequired/nested_anyOf_error
=== RUN   TestAllOfRequired/some_required
=== RUN   TestUniqueItemsValidator/unique_list_of_object_with_unknowns
=== RUN   TestURIValidator/invalid_string
=== RUN   TestRequired/missing_one
=== RUN   TestStringMatchValidator/unknown_string
=== RUN   TestStringInSliceValidator/not_a_string
=== RUN   TestRequired/missing_all
=== RUN   TestStringMatchValidator/null_string
--- PASS: TestURIValidator (0.00s)
    --- PASS: TestURIValidator/not_a_string (0.00s)
    --- PASS: TestURIValidator/unknown_string (0.00s)
    --- PASS: TestURIValidator/null_string (0.00s)
    --- PASS: TestURIValidator/valid_string (0.00s)
    --- PASS: TestURIValidator/invalid_string (0.00s)
=== CONT  TestAllValidator
=== RUN   TestAnyOfRequired/both_empty
=== RUN   TestStringMatchValidator/valid_string
=== RUN   TestStringInSliceValidator/unknown_string
=== RUN   TestAllOfRequired/all_required
=== RUN   TestStringInSliceValidator/null_string
=== RUN   TestAnyOfRequired/none_required
=== RUN   TestUniqueItemsValidator/duplicates_in_list_of_object_with_unknowns
=== RUN   TestStringInSliceValidator/valid_string
--- PASS: TestAnyOfRequired (0.00s)
    --- PASS: TestAnyOfRequired/some_required (0.00s)
    --- PASS: TestAnyOfRequired/nested_allOf_OK (0.00s)
    --- PASS: TestAnyOfRequired/nested_allOf_error (0.00s)
    --- PASS: TestAnyOfRequired/nested_anyOf_OK (0.00s)
    --- PASS: TestAnyOfRequired/nested_anyOf_error (0.00s)
    --- PASS: TestAnyOfRequired/both_empty (0.00s)
    --- PASS: TestAnyOfRequired/none_required (0.00s)
=== RUN   TestStringMatchValidator/invalid_string
=== RUN   TestArrayForEachValidator/invalid_list_of_string
=== CONT  TestIntInSliceValidator
=== RUN   TestStringInSliceValidator/invalid_string
=== RUN   TestAllOfRequired/missing_one
=== RUN   TestRequired/both_empty
=== RUN   TestAllValidator/valid_string
=== RUN   TestIntInSliceValidator/not_a_number
=== RUN   TestRequired/none_required
=== CONT  TestIntAtLeastValidator
--- PASS: TestStringInSliceValidator (0.00s)
    --- PASS: TestStringInSliceValidator/not_a_string (0.00s)
    --- PASS: TestStringInSliceValidator/unknown_string (0.00s)
    --- PASS: TestStringInSliceValidator/null_string (0.00s)
    --- PASS: TestStringInSliceValidator/valid_string (0.00s)
    --- PASS: TestStringInSliceValidator/invalid_string (0.00s)
=== CONT  TestIntAtMostValidator
=== CONT  TestIntBetweenValidator
--- PASS: TestRequired (0.00s)
    --- PASS: TestRequired/some_required (0.00s)
    --- PASS: TestRequired/all_required (0.00s)
    --- PASS: TestRequired/missing_one (0.00s)
    --- PASS: TestRequired/missing_all (0.00s)
    --- PASS: TestRequired/both_empty (0.00s)
    --- PASS: TestRequired/none_required (0.00s)
=== RUN   TestAllOfRequired/missing_all
=== RUN   TestIntAtMostValidator/unknown_number
=== RUN   TestIntInSliceValidator/unknown_number
=== RUN   TestAllValidator/invalid_string_single_match
--- PASS: TestAllOfRequired (0.00s)
    --- PASS: TestAllOfRequired/both_empty (0.00s)
    --- PASS: TestAllOfRequired/none_required (0.00s)
    --- PASS: TestAllOfRequired/some_required (0.00s)
    --- PASS: TestAllOfRequired/all_required (0.00s)
    --- PASS: TestAllOfRequired/missing_one (0.00s)
    --- PASS: TestAllOfRequired/missing_all (0.00s)
=== CONT  TestArrayLenAtMostValidator
=== RUN   TestUniqueItemsValidator/not_a_list
=== RUN   TestIntBetweenValidator/valid_integer_as_Number_min
=== RUN   TestIntInSliceValidator/null_number
=== RUN   TestIntAtMostValidator/not_an_integer
--- PASS: TestStringMatchValidator (0.00s)
    --- PASS: TestStringMatchValidator/not_a_string (0.00s)
    --- PASS: TestStringMatchValidator/unknown_string (0.00s)
    --- PASS: TestStringMatchValidator/null_string (0.00s)
    --- PASS: TestStringMatchValidator/valid_string (0.00s)
    --- PASS: TestStringMatchValidator/invalid_string (0.00s)
=== RUN   TestIntAtLeastValidator/not_a_number
=== RUN   TestArrayForEachValidator/list_of_string_with_unknown_element
=== RUN   TestIntInSliceValidator/not_an_integer
=== RUN   TestArrayLenAtMostValidator/null_list
=== RUN   TestAllValidator/invalid_string_multiple_matches
=== RUN   TestIntBetweenValidator/valid_integer_as_Int64_min
=== RUN   TestIntAtMostValidator/valid_integer_as_Int64
=== RUN   TestIntAtLeastValidator/unknown_number
=== RUN   TestArrayLenAtMostValidator/valid_list_of_string
=== RUN   TestIntAtLeastValidator/null_number
=== RUN   TestIntAtMostValidator/valid_integer_as_Number_min
=== RUN   TestIntInSliceValidator/valid_integer_as_Number
=== RUN   TestIntBetweenValidator/too_large_integer_as_Int64
=== RUN   TestAllValidator/unknown_string
=== RUN   TestUniqueItemsValidator/null_list
=== RUN   TestIntAtLeastValidator/not_an_integer
=== RUN   TestArrayLenAtMostValidator/invalid_list_of_string
=== RUN   TestArrayForEachValidator/null_set
=== RUN   TestIntAtMostValidator/not_a_number
=== RUN   TestUniqueItemsValidator/unique_list_of_string
=== RUN   TestIntInSliceValidator/valid_integer_as_Int64
=== RUN   TestAllValidator/null_string
=== RUN   TestIntBetweenValidator/unknown_number
=== RUN   TestIntAtMostValidator/null_number
=== RUN   TestIntAtLeastValidator/valid_integer_as_Int64
--- PASS: TestAllValidator (0.00s)
    --- PASS: TestAllValidator/valid_string (0.00s)
    --- PASS: TestAllValidator/invalid_string_single_match (0.00s)
    --- PASS: TestAllValidator/invalid_string_multiple_matches (0.00s)
    --- PASS: TestAllValidator/unknown_string (0.00s)
    --- PASS: TestAllValidator/null_string (0.00s)
=== RUN   TestArrayLenAtMostValidator/null_set
=== CONT  TestFloatAtMostValidator
=== RUN   TestIntInSliceValidator/invalid_integer_as_Number
=== RUN   TestIntBetweenValidator/valid_integer_as_Int64_max
=== RUN   TestIntAtMostValidator/valid_integer_as_Number
=== RUN   TestIntAtLeastValidator/valid_integer_as_Number_min
=== RUN   TestUniqueItemsValidator/unique_list_of_object
=== RUN   TestArrayForEachValidator/valid_set_of_string
--- PASS: TestIntInSliceValidator (0.00s)
    --- PASS: TestIntInSliceValidator/not_a_number (0.00s)
    --- PASS: TestIntInSliceValidator/unknown_number (0.00s)
    --- PASS: TestIntInSliceValidator/null_number (0.00s)
    --- PASS: TestIntInSliceValidator/not_an_integer (0.00s)
    --- PASS: TestIntInSliceValidator/valid_integer_as_Number (0.00s)
    --- PASS: TestIntInSliceValidator/valid_integer_as_Int64 (0.00s)
    --- PASS: TestIntInSliceValidator/invalid_integer_as_Number (0.00s)
=== CONT  TestFloatAtLeastValidator
=== RUN   TestFloatAtMostValidator/unknown_number
=== RUN   TestIntAtLeastValidator/too_small_integer_as_Number
=== RUN   TestIntAtMostValidator/valid_integer_as_Int64_min
=== RUN   TestFloatAtLeastValidator/valid_float_as_Float64
=== RUN   TestFloatAtMostValidator/valid_float_as_Float64_max
=== RUN   TestArrayLenAtMostValidator/valid_set_of_string
=== RUN   TestIntBetweenValidator/too_large_integer_as_Number
=== RUN   TestIntAtLeastValidator/valid_integer_as_Number
=== RUN   TestFloatAtMostValidator/too_large_float_as_Number
=== RUN   TestIntBetweenValidator/valid_integer_as_Int64
=== RUN   TestIntAtMostValidator/too_large_integer_as_Number
=== RUN   TestArrayForEachValidator/not_a_list
=== RUN   TestIntAtLeastValidator/valid_integer_as_Int64_min
=== RUN   TestIntBetweenValidator/valid_integer_as_Number
=== RUN   TestFloatAtMostValidator/valid_integer_as_Float64
=== CONT  TestFloatBetweenValidator
--- PASS: TestIntAtMostValidator (0.00s)
    --- PASS: TestIntAtMostValidator/unknown_number (0.00s)
    --- PASS: TestIntAtMostValidator/not_an_integer (0.00s)
    --- PASS: TestIntAtMostValidator/valid_integer_as_Int64 (0.00s)
    --- PASS: TestIntAtMostValidator/valid_integer_as_Number_min (0.00s)
    --- PASS: TestIntAtMostValidator/not_a_number (0.00s)
    --- PASS: TestIntAtMostValidator/null_number (0.00s)
    --- PASS: TestIntAtMostValidator/valid_integer_as_Number (0.00s)
    --- PASS: TestIntAtMostValidator/valid_integer_as_Int64_min (0.00s)
    --- PASS: TestIntAtMostValidator/too_large_integer_as_Number (0.00s)
=== RUN   TestArrayForEachValidator/empty_list
--- PASS: TestIntAtLeastValidator (0.00s)
    --- PASS: TestIntAtLeastValidator/not_a_number (0.00s)
    --- PASS: TestIntAtLeastValidator/unknown_number (0.00s)
    --- PASS: TestIntAtLeastValidator/null_number (0.00s)
    --- PASS: TestIntAtLeastValidator/not_an_integer (0.00s)
    --- PASS: TestIntAtLeastValidator/valid_integer_as_Int64 (0.00s)
    --- PASS: TestIntAtLeastValidator/valid_integer_as_Number_min (0.00s)
    --- PASS: TestIntAtLeastValidator/too_small_integer_as_Number (0.00s)
    --- PASS: TestIntAtLeastValidator/valid_integer_as_Number (0.00s)
    --- PASS: TestIntAtLeastValidator/valid_integer_as_Int64_min (0.00s)
=== RUN   TestArrayLenAtMostValidator/invalid_set_of_string
=== CONT  TestRequiredAttributesValidator_Set
=== RUN   TestArrayForEachValidator/valid_list_of_string
=== RUN   TestFloatAtLeastValidator/valid_float_as_Number_min
=== RUN   TestIntBetweenValidator/too_small_integer_as_Number
=== RUN   TestFloatAtMostValidator/valid_float_as_Number
=== RUN   TestArrayForEachValidator/unknown_set
=== RUN   TestFloatAtLeastValidator/valid_float_as_Float64_min
=== RUN   TestUniqueItemsValidator/unknown_list
=== RUN   TestFloatBetweenValidator/not_a_number
=== RUN   TestArrayLenAtMostValidator/not_a_list_or_set
=== RUN   TestFloatAtMostValidator/valid_float_as_Float64
=== CONT  TestStringLenAtLeastValidator
=== RUN   TestIntBetweenValidator/too_small_integer_as_Int64
--- PASS: TestUniqueItemsValidator (0.00s)
    --- PASS: TestUniqueItemsValidator/empty_list (0.00s)
    --- PASS: TestUniqueItemsValidator/duplicates_in_list_of_string (0.00s)
    --- PASS: TestUniqueItemsValidator/duplicates_in_list_of_object (0.00s)
    --- PASS: TestUniqueItemsValidator/unique_list_of_object_with_unknowns (0.00s)
    --- PASS: TestUniqueItemsValidator/duplicates_in_list_of_object_with_unknowns (0.00s)
    --- PASS: TestUniqueItemsValidator/not_a_list (0.00s)
    --- PASS: TestUniqueItemsValidator/null_list (0.00s)
    --- PASS: TestUniqueItemsValidator/unique_list_of_string (0.00s)
    --- PASS: TestUniqueItemsValidator/unique_list_of_object (0.00s)
    --- PASS: TestUniqueItemsValidator/unknown_list (0.00s)
=== RUN   TestStringLenAtLeastValidator/too_short_string
=== RUN   TestFloatAtMostValidator/valid_float_as_Number_max
=== RUN   TestFloatAtLeastValidator/not_a_number
=== RUN   TestArrayLenAtMostValidator/unknown_list
=== RUN   TestStringLenAtLeastValidator/not_a_string
=== RUN   TestIntBetweenValidator/not_an_integer
=== RUN   TestFloatAtLeastValidator/null_number
=== RUN   TestFloatBetweenValidator/null_number
=== RUN   TestArrayForEachValidator/empty_set
=== RUN   TestRequiredAttributesValidator_Set/empty_set
=== RUN   TestStringLenAtLeastValidator/unknown_string
=== RUN   TestArrayLenAtMostValidator/valid_empty_list
=== RUN   TestFloatAtLeastValidator/valid_float_as_Number
=== RUN   TestFloatAtMostValidator/not_a_number
=== RUN   TestStringLenAtLeastValidator/null_string
=== RUN   TestRequiredAttributesValidator_Set/not_fully_known_object
=== RUN   TestIntBetweenValidator/null_number
=== RUN   TestArrayForEachValidator/invalid_set_of_string
=== RUN   TestFloatAtMostValidator/null_number
=== RUN   TestArrayLenAtMostValidator/unknown_set
=== RUN   TestFloatAtMostValidator/valid_integer_as_Number
=== RUN   TestStringLenAtLeastValidator/valid_string
=== RUN   TestFloatAtLeastValidator/too_small_float_as_Number
=== RUN   TestRequiredAttributesValidator_Set/none_required
--- PASS: TestFloatAtMostValidator (0.00s)
    --- PASS: TestFloatAtMostValidator/unknown_number (0.00s)
    --- PASS: TestFloatAtMostValidator/valid_float_as_Float64_max (0.00s)
    --- PASS: TestFloatAtMostValidator/too_large_float_as_Number (0.00s)
    --- PASS: TestFloatAtMostValidator/valid_integer_as_Float64 (0.00s)
    --- PASS: TestFloatAtMostValidator/valid_float_as_Number (0.00s)
    --- PASS: TestFloatAtMostValidator/valid_float_as_Float64 (0.00s)
    --- PASS: TestFloatAtMostValidator/valid_float_as_Number_max (0.00s)
    --- PASS: TestFloatAtMostValidator/not_a_number (0.00s)
    --- PASS: TestFloatAtMostValidator/null_number (0.00s)
    --- PASS: TestFloatAtMostValidator/valid_integer_as_Number (0.00s)
=== CONT  TestStringLenBetweenValidator
--- PASS: TestStringLenAtLeastValidator (0.00s)
    --- PASS: TestStringLenAtLeastValidator/too_short_string (0.00s)
    --- PASS: TestStringLenAtLeastValidator/not_a_string (0.00s)
    --- PASS: TestStringLenAtLeastValidator/unknown_string (0.00s)
    --- PASS: TestStringLenAtLeastValidator/null_string (0.00s)
    --- PASS: TestStringLenAtLeastValidator/valid_string (0.00s)
=== RUN   TestIntBetweenValidator/valid_integer_as_Number_max
=== CONT  TestResourceConfigRequiredAttributesValidator
=== RUN   TestArrayLenAtMostValidator/valid_empty_set
=== RUN   TestStringLenBetweenValidator/too_long_string
=== RUN   TestIntBetweenValidator/not_a_number
=== RUN   TestFloatAtLeastValidator/unknown_number
=== RUN   TestFloatBetweenValidator/valid_integer_as_Number
=== RUN   TestStringLenBetweenValidator/too_short_string
=== RUN   TestFloatAtLeastValidator/valid_integer_as_Number
=== RUN   TestRequiredAttributesValidator_Set/one_required_OK
=== RUN   TestStringLenBetweenValidator/not_a_string
=== RUN   TestArrayForEachValidator/set_of_string_with_unknown_element
--- PASS: TestIntBetweenValidator (0.00s)
    --- PASS: TestIntBetweenValidator/valid_integer_as_Number_min (0.00s)
    --- PASS: TestIntBetweenValidator/valid_integer_as_Int64_min (0.00s)
    --- PASS: TestIntBetweenValidator/too_large_integer_as_Int64 (0.00s)
    --- PASS: TestIntBetweenValidator/unknown_number (0.00s)
    --- PASS: TestIntBetweenValidator/valid_integer_as_Int64_max (0.00s)
    --- PASS: TestIntBetweenValidator/too_large_integer_as_Number (0.00s)
    --- PASS: TestIntBetweenValidator/valid_integer_as_Int64 (0.00s)
    --- PASS: TestIntBetweenValidator/valid_integer_as_Number (0.00s)
    --- PASS: TestIntBetweenValidator/too_small_integer_as_Number (0.00s)
    --- PASS: TestIntBetweenValidator/too_small_integer_as_Int64 (0.00s)
    --- PASS: TestIntBetweenValidator/not_an_integer (0.00s)
    --- PASS: TestIntBetweenValidator/null_number (0.00s)
    --- PASS: TestIntBetweenValidator/valid_integer_as_Number_max (0.00s)
    --- PASS: TestIntBetweenValidator/not_a_number (0.00s)
=== RUN   TestFloatBetweenValidator/valid_float_as_Number
=== CONT  TestArrayLenBetweenValidator
=== RUN   TestFloatAtLeastValidator/valid_integer_as_Float64
--- PASS: TestArrayLenAtMostValidator (0.00s)
    --- PASS: TestArrayLenAtMostValidator/null_list (0.00s)
    --- PASS: TestArrayLenAtMostValidator/valid_list_of_string (0.00s)
    --- PASS: TestArrayLenAtMostValidator/invalid_list_of_string (0.00s)
    --- PASS: TestArrayLenAtMostValidator/null_set (0.00s)
    --- PASS: TestArrayLenAtMostValidator/valid_set_of_string (0.00s)
    --- PASS: TestArrayLenAtMostValidator/invalid_set_of_string (0.00s)
    --- PASS: TestArrayLenAtMostValidator/not_a_list_or_set (0.00s)
    --- PASS: TestArrayLenAtMostValidator/unknown_list (0.00s)
    --- PASS: TestArrayLenAtMostValidator/valid_empty_list (0.00s)
    --- PASS: TestArrayLenAtMostValidator/unknown_set (0.00s)
    --- PASS: TestArrayLenAtMostValidator/valid_empty_set (0.00s)
=== RUN   TestStringLenBetweenValidator/unknown_string
--- PASS: TestFloatAtLeastValidator (0.00s)
    --- PASS: TestFloatAtLeastValidator/valid_float_as_Float64 (0.00s)
    --- PASS: TestFloatAtLeastValidator/valid_float_as_Number_min (0.00s)
    --- PASS: TestFloatAtLeastValidator/valid_float_as_Float64_min (0.00s)
    --- PASS: TestFloatAtLeastValidator/not_a_number (0.00s)
    --- PASS: TestFloatAtLeastValidator/null_number (0.00s)
    --- PASS: TestFloatAtLeastValidator/valid_float_as_Number (0.00s)
    --- PASS: TestFloatAtLeastValidator/too_small_float_as_Number (0.00s)
    --- PASS: TestFloatAtLeastValidator/unknown_number (0.00s)
    --- PASS: TestFloatAtLeastValidator/valid_integer_as_Number (0.00s)
    --- PASS: TestFloatAtLeastValidator/valid_integer_as_Float64 (0.00s)
=== CONT  TestArrayLenAtLeastValidator
=== RUN   TestArrayLenBetweenValidator/null_set
=== RUN   TestResourceConfigRequiredAttributesValidator/one_required_OK
=== RUN   TestFloatBetweenValidator/valid_float_as_Float64_min
=== CONT  TestRequiredAttributesValidator_Object
=== RUN   TestArrayForEachValidator/unknown_list
=== RUN   TestRequiredAttributesValidator_Set/one_required_error
=== RUN   TestArrayLenBetweenValidator/valid_empty_set
=== RUN   TestResourceConfigRequiredAttributesValidator/two_required_error_oneOf
=== RUN   TestArrayLenAtLeastValidator/valid_set_of_string
--- PASS: TestArrayForEachValidator (0.00s)
    --- PASS: TestArrayForEachValidator/null_list (0.00s)
    --- PASS: TestArrayForEachValidator/invalid_list_of_string (0.00s)
    --- PASS: TestArrayForEachValidator/list_of_string_with_unknown_element (0.00s)
    --- PASS: TestArrayForEachValidator/null_set (0.00s)
    --- PASS: TestArrayForEachValidator/valid_set_of_string (0.00s)
    --- PASS: TestArrayForEachValidator/not_a_list (0.00s)
    --- PASS: TestArrayForEachValidator/empty_list (0.00s)
    --- PASS: TestArrayForEachValidator/valid_list_of_string (0.00s)
    --- PASS: TestArrayForEachValidator/unknown_set (0.00s)
    --- PASS: TestArrayForEachValidator/empty_set (0.00s)
    --- PASS: TestArrayForEachValidator/invalid_set_of_string (0.00s)
    --- PASS: TestArrayForEachValidator/set_of_string_with_unknown_element (0.00s)
    --- PASS: TestArrayForEachValidator/unknown_list (0.00s)
=== CONT  TestRequiredAttributesValidator_List
=== RUN   TestFloatBetweenValidator/valid_float_as_Number_max
=== RUN   TestResourceConfigRequiredAttributesValidator/none_required
=== RUN   TestArrayLenBetweenValidator/not_a_list_or_set
=== RUN   TestRequiredAttributesValidator_Object/one_required_error
=== RUN   TestResourceConfigRequiredAttributesValidator/nil_object
=== RUN   TestRequiredAttributesValidator_Set/unknown_set
=== RUN   TestFloatBetweenValidator/too_small_float_as_Number
=== RUN   TestArrayLenBetweenValidator/unknown_list
=== RUN   TestResourceConfigRequiredAttributesValidator/unknown_object
=== RUN   TestArrayLenAtLeastValidator/unknown_set
=== RUN   TestRequiredAttributesValidator_Set/null_set
=== RUN   TestResourceConfigRequiredAttributesValidator/not_fully_known_object
=== RUN   TestRequiredAttributesValidator_Object/two_required_OK_oneOf
=== RUN   TestArrayLenBetweenValidator/null_list
=== CONT  TestOneOfRequired
--- PASS: TestRequiredAttributesValidator_Set (0.00s)
    --- PASS: TestRequiredAttributesValidator_Set/empty_set (0.00s)
    --- PASS: TestRequiredAttributesValidator_Set/not_fully_known_object (0.00s)
    --- PASS: TestRequiredAttributesValidator_Set/none_required (0.00s)
    --- PASS: TestRequiredAttributesValidator_Set/one_required_OK (0.00s)
    --- PASS: TestRequiredAttributesValidator_Set/one_required_error (0.00s)
    --- PASS: TestRequiredAttributesValidator_Set/unknown_set (0.00s)
    --- PASS: TestRequiredAttributesValidator_Set/null_set (0.00s)
=== RUN   TestRequiredAttributesValidator_List/null_list
=== RUN   TestOneOfRequired/some_required_OK
=== RUN   TestStringLenBetweenValidator/null_string
=== RUN   TestArrayLenBetweenValidator/valid_empty_list
=== RUN   TestRequiredAttributesValidator_Object/not_an_object
=== RUN   TestRequiredAttributesValidator_List/empty_list
=== RUN   TestResourceConfigRequiredAttributesValidator/one_required_error
=== RUN   TestOneOfRequired/some_required_error
=== RUN   TestArrayLenAtLeastValidator/not_a_list_or_set
=== RUN   TestFloatBetweenValidator/unknown_number
=== RUN   TestRequiredAttributesValidator_Object/nil_object
=== RUN   TestRequiredAttributesValidator_List/not_fully_known_object
=== RUN   TestArrayLenBetweenValidator/valid_list_of_string
=== RUN   TestOneOfRequired/nested_allOf_OK
=== RUN   TestStringLenBetweenValidator/valid_string
=== RUN   TestResourceConfigRequiredAttributesValidator/two_required_OK_anyOf
=== RUN   TestOneOfRequired/nested_allOf_error
=== CONT  TestIAMPolicyARNValidator
=== RUN   TestRequiredAttributesValidator_Object/unknown_object
=== RUN   TestIAMPolicyARNValidator/not_a_string
=== RUN   TestArrayLenAtLeastValidator/unknown_list
=== RUN   TestFloatBetweenValidator/valid_integer_as_Float64
--- PASS: TestStringLenBetweenValidator (0.00s)
    --- PASS: TestStringLenBetweenValidator/too_long_string (0.00s)
    --- PASS: TestStringLenBetweenValidator/too_short_string (0.00s)
    --- PASS: TestStringLenBetweenValidator/not_a_string (0.00s)
    --- PASS: TestStringLenBetweenValidator/unknown_string (0.00s)
    --- PASS: TestStringLenBetweenValidator/null_string (0.00s)
    --- PASS: TestStringLenBetweenValidator/valid_string (0.00s)
=== RUN   TestArrayLenBetweenValidator/invalid_list_of_string
=== RUN   TestOneOfRequired/nested_anyOf_OK
=== RUN   TestRequiredAttributesValidator_Object/not_fully_known_object
=== RUN   TestIAMPolicyARNValidator/unknown_string
=== RUN   TestOneOfRequired/nested_anyOf_error
=== RUN   TestRequiredAttributesValidator_List/none_required
=== RUN   TestIAMPolicyARNValidator/null_string
=== RUN   TestOneOfRequired/both_empty
=== RUN   TestFloatBetweenValidator/valid_float_as_Float64
=== RUN   TestArrayLenAtLeastValidator/null_list
=== RUN   TestArrayLenBetweenValidator/invalid_set_of_string
=== RUN   TestResourceConfigRequiredAttributesValidator/two_required_OK_oneOf
=== RUN   TestFloatBetweenValidator/valid_float_as_Number_min
=== RUN   TestRequiredAttributesValidator_Object/one_required_OK
=== RUN   TestArrayLenAtLeastValidator/valid_empty_list
=== RUN   TestFloatBetweenValidator/valid_float_as_Float64_max
=== RUN   TestOneOfRequired/none_required
=== RUN   TestIAMPolicyARNValidator/valid_IAM_Policy_ARN
=== RUN   TestResourceConfigRequiredAttributesValidator/not_an_object
=== RUN   TestArrayLenBetweenValidator/invalid_empty_list
=== RUN   TestRequiredAttributesValidator_List/one_required_OK
=== RUN   TestFloatBetweenValidator/too_large_float_as_Number
--- PASS: TestOneOfRequired (0.00s)
    --- PASS: TestOneOfRequired/some_required_OK (0.00s)
    --- PASS: TestOneOfRequired/some_required_error (0.00s)
    --- PASS: TestOneOfRequired/nested_allOf_OK (0.00s)
    --- PASS: TestOneOfRequired/nested_allOf_error (0.00s)
    --- PASS: TestOneOfRequired/nested_anyOf_OK (0.00s)
    --- PASS: TestOneOfRequired/nested_anyOf_error (0.00s)
    --- PASS: TestOneOfRequired/both_empty (0.00s)
    --- PASS: TestOneOfRequired/none_required (0.00s)
--- PASS: TestResourceConfigRequiredAttributesValidator (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/one_required_OK (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/two_required_error_oneOf (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/none_required (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/nil_object (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/unknown_object (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/not_fully_known_object (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/one_required_error (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/two_required_OK_anyOf (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/two_required_OK_oneOf (0.00s)
    --- PASS: TestResourceConfigRequiredAttributesValidator/not_an_object (0.00s)
=== RUN   TestIAMPolicyARNValidator/invalid_ARN
=== RUN   TestArrayLenAtLeastValidator/invalid_empty_list
=== RUN   TestRequiredAttributesValidator_Object/none_required
--- PASS: TestFloatBetweenValidator (0.00s)
    --- PASS: TestFloatBetweenValidator/not_a_number (0.00s)
    --- PASS: TestFloatBetweenValidator/null_number (0.00s)
    --- PASS: TestFloatBetweenValidator/valid_integer_as_Number (0.00s)
    --- PASS: TestFloatBetweenValidator/valid_float_as_Number (0.00s)
    --- PASS: TestFloatBetweenValidator/valid_float_as_Float64_min (0.00s)
    --- PASS: TestFloatBetweenValidator/valid_float_as_Number_max (0.00s)
    --- PASS: TestFloatBetweenValidator/too_small_float_as_Number (0.00s)
    --- PASS: TestFloatBetweenValidator/unknown_number (0.00s)
    --- PASS: TestFloatBetweenValidator/valid_integer_as_Float64 (0.00s)
    --- PASS: TestFloatBetweenValidator/valid_float_as_Float64 (0.00s)
    --- PASS: TestFloatBetweenValidator/valid_float_as_Number_min (0.00s)
    --- PASS: TestFloatBetweenValidator/valid_float_as_Float64_max (0.00s)
    --- PASS: TestFloatBetweenValidator/too_large_float_as_Number (0.00s)
=== RUN   TestArrayLenBetweenValidator/unknown_set
=== RUN   TestRequiredAttributesValidator_Object/two_required_OK_anyOf
=== RUN   TestRequiredAttributesValidator_List/one_required_error
=== RUN   TestIAMPolicyARNValidator/not_an_ARN
=== RUN   TestArrayLenAtLeastValidator/valid_list_of_string
=== RUN   TestArrayLenBetweenValidator/invalid_empty_set
--- PASS: TestIAMPolicyARNValidator (0.00s)
    --- PASS: TestIAMPolicyARNValidator/not_a_string (0.00s)
    --- PASS: TestIAMPolicyARNValidator/unknown_string (0.00s)
    --- PASS: TestIAMPolicyARNValidator/null_string (0.00s)
    --- PASS: TestIAMPolicyARNValidator/valid_IAM_Policy_ARN (0.00s)
    --- PASS: TestIAMPolicyARNValidator/invalid_ARN (0.00s)
    --- PASS: TestIAMPolicyARNValidator/not_an_ARN (0.00s)
=== RUN   TestArrayLenAtLeastValidator/invalid_list_of_string
=== RUN   TestArrayLenBetweenValidator/valid_set_of_string
=== RUN   TestRequiredAttributesValidator_Object/two_required_error_oneOf
=== RUN   TestRequiredAttributesValidator_List/unknown_list
--- PASS: TestRequiredAttributesValidator_List (0.00s)
    --- PASS: TestRequiredAttributesValidator_List/null_list (0.00s)
    --- PASS: TestRequiredAttributesValidator_List/empty_list (0.00s)
    --- PASS: TestRequiredAttributesValidator_List/not_fully_known_object (0.00s)
    --- PASS: TestRequiredAttributesValidator_List/none_required (0.00s)
    --- PASS: TestRequiredAttributesValidator_List/one_required_OK (0.00s)
    --- PASS: TestRequiredAttributesValidator_List/one_required_error (0.00s)
    --- PASS: TestRequiredAttributesValidator_List/unknown_list (0.00s)
=== RUN   TestArrayLenAtLeastValidator/null_set
--- PASS: TestArrayLenBetweenValidator (0.00s)
    --- PASS: TestArrayLenBetweenValidator/null_set (0.00s)
    --- PASS: TestArrayLenBetweenValidator/valid_empty_set (0.00s)
    --- PASS: TestArrayLenBetweenValidator/not_a_list_or_set (0.00s)
    --- PASS: TestArrayLenBetweenValidator/unknown_list (0.00s)
    --- PASS: TestArrayLenBetweenValidator/null_list (0.00s)
    --- PASS: TestArrayLenBetweenValidator/valid_empty_list (0.00s)
    --- PASS: TestArrayLenBetweenValidator/valid_list_of_string (0.00s)
    --- PASS: TestArrayLenBetweenValidator/invalid_list_of_string (0.00s)
    --- PASS: TestArrayLenBetweenValidator/invalid_set_of_string (0.00s)
    --- PASS: TestArrayLenBetweenValidator/invalid_empty_list (0.00s)
    --- PASS: TestArrayLenBetweenValidator/unknown_set (0.00s)
    --- PASS: TestArrayLenBetweenValidator/invalid_empty_set (0.00s)
    --- PASS: TestArrayLenBetweenValidator/valid_set_of_string (0.00s)
--- PASS: TestRequiredAttributesValidator_Object (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/one_required_error (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/two_required_OK_oneOf (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/not_an_object (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/nil_object (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/unknown_object (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/not_fully_known_object (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/one_required_OK (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/none_required (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/two_required_OK_anyOf (0.00s)
    --- PASS: TestRequiredAttributesValidator_Object/two_required_error_oneOf (0.00s)
=== RUN   TestArrayLenAtLeastValidator/valid_empty_set
=== RUN   TestArrayLenAtLeastValidator/invalid_empty_set
=== RUN   TestArrayLenAtLeastValidator/invalid_set_of_string
--- PASS: TestArrayLenAtLeastValidator (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/valid_set_of_string (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/unknown_set (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/not_a_list_or_set (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/unknown_list (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/null_list (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/valid_empty_list (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/invalid_empty_list (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/valid_list_of_string (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/invalid_list_of_string (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/null_set (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/valid_empty_set (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/invalid_empty_set (0.00s)
    --- PASS: TestArrayLenAtLeastValidator/invalid_set_of_string (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-awscc/internal/validate	0.721s
```