### PR TITLE
10/19/2022 CloudFormation schema refresh

### DIFF
--- a/docs/data-sources/appflow_flow.md
+++ b/docs/data-sources/appflow_flow.md
@@ -190,6 +190,7 @@ Read-Only:
 
 Read-Only:
 
+- `data_transfer_api` (String)
 - `error_handling_config` (Attributes) (see [below for nested schema](#nestedatt--destination_flow_config_list--destination_connector_properties--salesforce--error_handling_config))
 - `id_field_names` (List of String) List of fields used as ID when performing a write operation.
 - `object` (String)
@@ -439,6 +440,7 @@ Read-Only:
 
 Read-Only:
 
+- `data_transfer_api` (String)
 - `enable_dynamic_field_update` (Boolean)
 - `include_deleted_records` (Boolean)
 - `object` (String)

--- a/docs/data-sources/connect_user.md
+++ b/docs/data-sources/connect_user.md
@@ -41,6 +41,8 @@ Read-Only:
 - `email` (String) The email address. If you are using SAML for identity management and include this parameter, an error is returned.
 - `first_name` (String) The first name. This is required if you are using Amazon Connect or SAML for identity management.
 - `last_name` (String) The last name. This is required if you are using Amazon Connect or SAML for identity management.
+- `mobile` (String) The mobile phone number.
+- `secondary_email` (String) The secondary email address. If you provide a secondary email, the user receives email notifications -- other than password reset notifications -- to this email address instead of to their primary email address.
 
 
 <a id="nestedatt--phone_config"></a>

--- a/docs/data-sources/ec2_vpc_endpoint.md
+++ b/docs/data-sources/ec2_vpc_endpoint.md
@@ -24,13 +24,13 @@ Data Source schema for AWS::EC2::VPCEndpoint
 - `creation_timestamp` (String)
 - `dns_entries` (List of String)
 - `network_interface_ids` (List of String)
-- `policy_document` (String) A policy to attach to the endpoint that controls access to the service.
-- `private_dns_enabled` (Boolean) Indicate whether to associate a private hosted zone with the specified VPC.
-- `route_table_ids` (Set of String) One or more route table IDs.
-- `security_group_ids` (Set of String) The ID of one or more security groups to associate with the endpoint network interface.
-- `service_name` (String) The service name.
-- `subnet_ids` (Set of String) The ID of one or more subnets in which to create an endpoint network interface.
+- `policy_document` (Map of String)
+- `private_dns_enabled` (Boolean)
+- `route_table_ids` (List of String)
+- `security_group_ids` (List of String)
+- `service_name` (String)
+- `subnet_ids` (List of String)
 - `vpc_endpoint_type` (String)
-- `vpc_id` (String) The ID of the VPC in which the endpoint will be used.
+- `vpc_id` (String)
 
 

--- a/docs/data-sources/lex_bot.md
+++ b/docs/data-sources/lex_bot.md
@@ -1065,6 +1065,7 @@ Read-Only:
 - `max_retries` (Number) The maximum number of times the bot tries to elicit a resonse from the user using this prompt.
 - `message_groups_list` (Attributes List) One to 5 message groups that contain update messages. Amazon Lex chooses one of the messages to play to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--message_groups_list))
 - `message_selection_strategy` (String) Indicates how a message is selected from a message group among retries.
+- `prompt_attempts_specification` (Attributes Map) Specifies the advanced settings on each attempt of the prompt. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification))
 
 <a id="nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--message_groups_list"></a>
 ### Nested Schema for `bot_locales.intents.intent_confirmation_setting.prompt_specification.message_groups_list`
@@ -1185,6 +1186,64 @@ Read-Only:
 
 
 
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.prompt_specification.prompt_attempts_specification`
+
+Read-Only:
+
+- `allow_interrupt` (Boolean) Indicates whether the user can interrupt a speech prompt attempt from the bot.
+- `allowed_input_types` (Attributes) Specifies the allowed input types. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--allowed_input_types))
+- `audio_and_dtmf_input_specification` (Attributes) Specifies the audio and DTMF input specification. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--audio_and_dtmf_input_specification))
+- `text_input_specification` (Attributes) Specifies the text input specifications. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--text_input_specification))
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--allowed_input_types"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Read-Only:
+
+- `allow_audio_input` (Boolean) Indicates whether audio input is allowed.
+- `allow_dtmf_input` (Boolean) Indicates whether DTMF input is allowed.
+
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--audio_and_dtmf_input_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Read-Only:
+
+- `audio_specification` (Attributes) Specifies the audio input specifications. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--audio_specification))
+- `dtmf_specification` (Attributes) Specifies the settings on DTMF input. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--dtmf_specification))
+- `start_timeout_ms` (Number) Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--audio_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.prompt_specification.prompt_attempts_specification.text_input_specification.start_timeout_ms`
+
+Read-Only:
+
+- `end_timeout_ms` (Number) Time for which a bot waits after the customer stops speaking to assume the utterance is finished.
+- `max_length_ms` (Number) Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.
+
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--dtmf_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.prompt_specification.prompt_attempts_specification.text_input_specification.start_timeout_ms`
+
+Read-Only:
+
+- `deletion_character` (String) The DTMF character that clears the accumulated DTMF digits and immediately ends the input.
+- `end_character` (String) The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.
+- `end_timeout_ms` (Number) How long the bot should wait after the last DTMF character input before assuming that the input has concluded.
+- `max_length` (Number) The maximum number of DTMF digits allowed in an utterance.
+
+
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--prompt_specification--prompt_attempts_specification--text_input_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Read-Only:
+
+- `start_timeout_ms` (Number) Time for which a bot waits before re-prompting a customer for text input.
+
+
+
 
 
 <a id="nestedatt--bot_locales--intents--kendra_configuration"></a>
@@ -1288,45 +1347,46 @@ Read-Only:
 - `max_retries` (Number) The maximum number of times the bot tries to elicit a resonse from the user using this prompt.
 - `message_groups_list` (Attributes List) One to 5 message groups that contain update messages. Amazon Lex chooses one of the messages to play to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_groups_list))
 - `message_selection_strategy` (String) Indicates how a message is selected from a message group among retries.
+- `prompt_attempts_specification` (Attributes Map) Specifies the advanced settings on each attempt of the prompt. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification))
 
 <a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_groups_list"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy`
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification`
 
 Read-Only:
 
-- `message` (Attributes) The primary message that Amazon Lex should send to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--message))
-- `variations` (Attributes List) Message variations to send to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations))
+- `message` (Attributes) The primary message that Amazon Lex should send to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--message))
+- `variations` (Attributes List) Message variations to send to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations))
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--message"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--message"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations`
 
 Read-Only:
 
-- `custom_payload` (Attributes) A message in a custom format defined by the client application. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--custom_payload))
-- `image_response_card` (Attributes) A message that defines a response card that the client application can show to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--image_response_card))
-- `plain_text_message` (Attributes) A message in plain text format. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--plain_text_message))
-- `ssml_message` (Attributes) A message in Speech Synthesis Markup Language (SSML). (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--ssml_message))
+- `custom_payload` (Attributes) A message in a custom format defined by the client application. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--custom_payload))
+- `image_response_card` (Attributes) A message that defines a response card that the client application can show to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--image_response_card))
+- `plain_text_message` (Attributes) A message in plain text format. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--plain_text_message))
+- `ssml_message` (Attributes) A message in Speech Synthesis Markup Language (SSML). (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message))
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--custom_payload"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--custom_payload"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Read-Only:
 
 - `value` (String) The string that is sent to your application.
 
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--image_response_card"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--image_response_card"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Read-Only:
 
-- `buttons` (Attributes List) A list of buttons that should be displayed on the response card. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--ssml_message--buttons))
+- `buttons` (Attributes List) A list of buttons that should be displayed on the response card. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message--buttons))
 - `image_url` (String) The URL of an image to display on the response card.
 - `subtitle` (String) The subtitle to display on the response card.
 - `title` (String) The title to display on the response card.
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--ssml_message--buttons"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message.buttons`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message--buttons"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message.buttons`
 
 Read-Only:
 
@@ -1335,16 +1395,16 @@ Read-Only:
 
 
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--plain_text_message"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--plain_text_message"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Read-Only:
 
 - `value` (String) The message to send to the user.
 
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--ssml_message"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Read-Only:
 
@@ -1352,36 +1412,36 @@ Read-Only:
 
 
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations`
 
 Read-Only:
 
-- `custom_payload` (Attributes) A message in a custom format defined by the client application. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--custom_payload))
-- `image_response_card` (Attributes) A message that defines a response card that the client application can show to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--image_response_card))
-- `plain_text_message` (Attributes) A message in plain text format. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--plain_text_message))
-- `ssml_message` (Attributes) A message in Speech Synthesis Markup Language (SSML). (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--ssml_message))
+- `custom_payload` (Attributes) A message in a custom format defined by the client application. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--custom_payload))
+- `image_response_card` (Attributes) A message that defines a response card that the client application can show to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--image_response_card))
+- `plain_text_message` (Attributes) A message in plain text format. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--plain_text_message))
+- `ssml_message` (Attributes) A message in Speech Synthesis Markup Language (SSML). (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message))
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--custom_payload"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--custom_payload"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Read-Only:
 
 - `value` (String) The string that is sent to your application.
 
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--image_response_card"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--image_response_card"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Read-Only:
 
-- `buttons` (Attributes List) A list of buttons that should be displayed on the response card. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--ssml_message--buttons))
+- `buttons` (Attributes List) A list of buttons that should be displayed on the response card. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message--buttons))
 - `image_url` (String) The URL of an image to display on the response card.
 - `subtitle` (String) The subtitle to display on the response card.
 - `title` (String) The title to display on the response card.
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--ssml_message--buttons"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message.buttons`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message--buttons"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message.buttons`
 
 Read-Only:
 
@@ -1390,21 +1450,79 @@ Read-Only:
 
 
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--plain_text_message"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--plain_text_message"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Read-Only:
 
 - `value` (String) The message to send to the user.
 
 
-<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--message_selection_strategy--variations--ssml_message"></a>
-### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Read-Only:
 
 - `value` (String) The SSML text that defines the prompt.
 
+
+
+
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification`
+
+Read-Only:
+
+- `allow_interrupt` (Boolean) Indicates whether the user can interrupt a speech prompt attempt from the bot.
+- `allowed_input_types` (Attributes) Specifies the allowed input types. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--allowed_input_types))
+- `audio_and_dtmf_input_specification` (Attributes) Specifies the audio and DTMF input specification. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--audio_and_dtmf_input_specification))
+- `text_input_specification` (Attributes) Specifies the text input specifications. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--text_input_specification))
+
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--allowed_input_types"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Read-Only:
+
+- `allow_audio_input` (Boolean) Indicates whether audio input is allowed.
+- `allow_dtmf_input` (Boolean) Indicates whether DTMF input is allowed.
+
+
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--audio_and_dtmf_input_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Read-Only:
+
+- `audio_specification` (Attributes) Specifies the audio input specifications. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--audio_specification))
+- `dtmf_specification` (Attributes) Specifies the settings on DTMF input. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--dtmf_specification))
+- `start_timeout_ms` (Number) Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.
+
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--audio_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.text_input_specification.start_timeout_ms`
+
+Read-Only:
+
+- `end_timeout_ms` (Number) Time for which a bot waits after the customer stops speaking to assume the utterance is finished.
+- `max_length_ms` (Number) Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.
+
+
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--dtmf_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.text_input_specification.start_timeout_ms`
+
+Read-Only:
+
+- `deletion_character` (String) The DTMF character that clears the accumulated DTMF digits and immediately ends the input.
+- `end_character` (String) The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.
+- `end_timeout_ms` (Number) How long the bot should wait after the last DTMF character input before assuming that the input has concluded.
+- `max_length` (Number) The maximum number of DTMF digits allowed in an utterance.
+
+
+
+<a id="nestedatt--bot_locales--intents--slots--value_elicitation_setting--prompt_specification--prompt_attempts_specification--text_input_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.value_elicitation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Read-Only:
+
+- `start_timeout_ms` (Number) Time for which a bot waits before re-prompting a customer for text input.
 
 
 

--- a/docs/data-sources/msk_cluster.md
+++ b/docs/data-sources/msk_cluster.md
@@ -33,6 +33,7 @@ Data Source schema for AWS::MSK::Cluster
 - `logging_info` (Attributes) (see [below for nested schema](#nestedatt--logging_info))
 - `number_of_broker_nodes` (Number)
 - `open_monitoring` (Attributes) (see [below for nested schema](#nestedatt--open_monitoring))
+- `storage_mode` (String)
 - `tags` (Map of String) A key-value pair to associate with a resource.
 
 <a id="nestedatt--broker_node_group_info"></a>

--- a/docs/data-sources/sagemaker_data_quality_job_definition.md
+++ b/docs/data-sources/sagemaker_data_quality_job_definition.md
@@ -79,7 +79,46 @@ Read-Only:
 
 Read-Only:
 
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--data_quality_job_input--batch_transform_input))
 - `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--data_quality_job_input--endpoint_input))
+
+<a id="nestedatt--data_quality_job_input--batch_transform_input"></a>
+### Nested Schema for `data_quality_job_input.batch_transform_input`
+
+Read-Only:
+
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--data_quality_job_input--batch_transform_input--dataset_format))
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+
+<a id="nestedatt--data_quality_job_input--batch_transform_input--dataset_format"></a>
+### Nested Schema for `data_quality_job_input.batch_transform_input.dataset_format`
+
+Read-Only:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--data_quality_job_input--batch_transform_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--data_quality_job_input--batch_transform_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicate if the dataset format is Parquet
+
+<a id="nestedatt--data_quality_job_input--batch_transform_input--dataset_format--csv"></a>
+### Nested Schema for `data_quality_job_input.batch_transform_input.dataset_format.parquet`
+
+Read-Only:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--data_quality_job_input--batch_transform_input--dataset_format--json"></a>
+### Nested Schema for `data_quality_job_input.batch_transform_input.dataset_format.parquet`
+
+Read-Only:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--data_quality_job_input--endpoint_input"></a>
 ### Nested Schema for `data_quality_job_input.endpoint_input`

--- a/docs/data-sources/sagemaker_model_bias_job_definition.md
+++ b/docs/data-sources/sagemaker_model_bias_job_definition.md
@@ -86,8 +86,53 @@ Read-Only:
 
 Read-Only:
 
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--model_bias_job_input--batch_transform_input))
 - `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_bias_job_input--endpoint_input))
 - `ground_truth_s3_input` (Attributes) Ground truth input provided in S3 (see [below for nested schema](#nestedatt--model_bias_job_input--ground_truth_s3_input))
+
+<a id="nestedatt--model_bias_job_input--batch_transform_input"></a>
+### Nested Schema for `model_bias_job_input.batch_transform_input`
+
+Read-Only:
+
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--model_bias_job_input--batch_transform_input--dataset_format))
+- `end_time_offset` (String) Monitoring end time offset, e.g. PT0H
+- `features_attribute` (String) JSONpath to locate features in JSONlines dataset
+- `inference_attribute` (String) Index or JSONpath to locate predicted label(s)
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+- `probability_attribute` (String) Index or JSONpath to locate probabilities
+- `probability_threshold_attribute` (Number)
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+- `start_time_offset` (String) Monitoring start time offset, e.g. -PT1H
+
+<a id="nestedatt--model_bias_job_input--batch_transform_input--dataset_format"></a>
+### Nested Schema for `model_bias_job_input.batch_transform_input.dataset_format`
+
+Read-Only:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--model_bias_job_input--batch_transform_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--model_bias_job_input--batch_transform_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicate if the dataset format is Parquet
+
+<a id="nestedatt--model_bias_job_input--batch_transform_input--dataset_format--csv"></a>
+### Nested Schema for `model_bias_job_input.batch_transform_input.dataset_format.parquet`
+
+Read-Only:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--model_bias_job_input--batch_transform_input--dataset_format--json"></a>
+### Nested Schema for `model_bias_job_input.batch_transform_input.dataset_format.parquet`
+
+Read-Only:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--model_bias_job_input--endpoint_input"></a>
 ### Nested Schema for `model_bias_job_input.endpoint_input`

--- a/docs/data-sources/sagemaker_model_explainability_job_definition.md
+++ b/docs/data-sources/sagemaker_model_explainability_job_definition.md
@@ -86,7 +86,49 @@ Read-Only:
 
 Read-Only:
 
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--model_explainability_job_input--batch_transform_input))
 - `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_explainability_job_input--endpoint_input))
+
+<a id="nestedatt--model_explainability_job_input--batch_transform_input"></a>
+### Nested Schema for `model_explainability_job_input.batch_transform_input`
+
+Read-Only:
+
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--model_explainability_job_input--batch_transform_input--dataset_format))
+- `features_attribute` (String) JSONpath to locate features in JSONlines dataset
+- `inference_attribute` (String) Index or JSONpath to locate predicted label(s)
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+- `probability_attribute` (String) Index or JSONpath to locate probabilities
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+
+<a id="nestedatt--model_explainability_job_input--batch_transform_input--dataset_format"></a>
+### Nested Schema for `model_explainability_job_input.batch_transform_input.dataset_format`
+
+Read-Only:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--model_explainability_job_input--batch_transform_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--model_explainability_job_input--batch_transform_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicating if the dataset format is Parquet
+
+<a id="nestedatt--model_explainability_job_input--batch_transform_input--dataset_format--csv"></a>
+### Nested Schema for `model_explainability_job_input.batch_transform_input.dataset_format.parquet`
+
+Read-Only:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--model_explainability_job_input--batch_transform_input--dataset_format--json"></a>
+### Nested Schema for `model_explainability_job_input.batch_transform_input.dataset_format.parquet`
+
+Read-Only:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--model_explainability_job_input--endpoint_input"></a>
 ### Nested Schema for `model_explainability_job_input.endpoint_input`

--- a/docs/data-sources/sagemaker_model_quality_job_definition.md
+++ b/docs/data-sources/sagemaker_model_quality_job_definition.md
@@ -90,8 +90,52 @@ Read-Only:
 
 Read-Only:
 
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--model_quality_job_input--batch_transform_input))
 - `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_quality_job_input--endpoint_input))
 - `ground_truth_s3_input` (Attributes) Ground truth input provided in S3 (see [below for nested schema](#nestedatt--model_quality_job_input--ground_truth_s3_input))
+
+<a id="nestedatt--model_quality_job_input--batch_transform_input"></a>
+### Nested Schema for `model_quality_job_input.batch_transform_input`
+
+Read-Only:
+
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--model_quality_job_input--batch_transform_input--dataset_format))
+- `end_time_offset` (String) Monitoring end time offset, e.g. PT0H
+- `inference_attribute` (String) Index or JSONpath to locate predicted label(s)
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+- `probability_attribute` (String) Index or JSONpath to locate probabilities
+- `probability_threshold_attribute` (Number)
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+- `start_time_offset` (String) Monitoring start time offset, e.g. -PT1H
+
+<a id="nestedatt--model_quality_job_input--batch_transform_input--dataset_format"></a>
+### Nested Schema for `model_quality_job_input.batch_transform_input.dataset_format`
+
+Read-Only:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--model_quality_job_input--batch_transform_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--model_quality_job_input--batch_transform_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicating if the dataset format is Parquet
+
+<a id="nestedatt--model_quality_job_input--batch_transform_input--dataset_format--csv"></a>
+### Nested Schema for `model_quality_job_input.batch_transform_input.dataset_format.parquet`
+
+Read-Only:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--model_quality_job_input--batch_transform_input--dataset_format--json"></a>
+### Nested Schema for `model_quality_job_input.batch_transform_input.dataset_format.parquet`
+
+Read-Only:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--model_quality_job_input--endpoint_input"></a>
 ### Nested Schema for `model_quality_job_input.endpoint_input`

--- a/docs/data-sources/sagemaker_monitoring_schedule.md
+++ b/docs/data-sources/sagemaker_monitoring_schedule.md
@@ -114,7 +114,46 @@ Read-Only:
 
 Read-Only:
 
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--batch_transform_input))
 - `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input))
+
+<a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--batch_transform_input"></a>
+### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input`
+
+Read-Only:
+
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format))
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+
+<a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format"></a>
+### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input.dataset_format`
+
+Read-Only:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicating if the dataset format is Parquet
+
+<a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format--csv"></a>
+### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input.dataset_format.parquet`
+
+Read-Only:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format--json"></a>
+### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input.dataset_format.parquet`
+
+Read-Only:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input"></a>
 ### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input`

--- a/docs/data-sources/ses_dedicated_ip_pool.md
+++ b/docs/data-sources/ses_dedicated_ip_pool.md
@@ -22,5 +22,6 @@ Data Source schema for AWS::SES::DedicatedIpPool
 ### Read-Only
 
 - `pool_name` (String) The name of the dedicated IP pool.
+- `scaling_mode` (String) Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD.
 
 

--- a/docs/resources/appflow_flow.md
+++ b/docs/resources/appflow_flow.md
@@ -215,6 +215,7 @@ Required:
 
 Optional:
 
+- `data_transfer_api` (String)
 - `error_handling_config` (Attributes) (see [below for nested schema](#nestedatt--destination_flow_config_list--destination_connector_properties--salesforce--error_handling_config))
 - `id_field_names` (List of String) List of fields used as ID when performing a write operation.
 - `write_operation_type` (String)
@@ -483,6 +484,7 @@ Required:
 
 Optional:
 
+- `data_transfer_api` (String)
 - `enable_dynamic_field_update` (Boolean)
 - `include_deleted_records` (Boolean)
 

--- a/docs/resources/connect_user.md
+++ b/docs/resources/connect_user.md
@@ -58,6 +58,8 @@ Optional:
 - `email` (String) The email address. If you are using SAML for identity management and include this parameter, an error is returned.
 - `first_name` (String) The first name. This is required if you are using Amazon Connect or SAML for identity management.
 - `last_name` (String) The last name. This is required if you are using Amazon Connect or SAML for identity management.
+- `mobile` (String) The mobile phone number.
+- `secondary_email` (String) The secondary email address. If you provide a secondary email, the user receives email notifications -- other than password reset notifications -- to this email address instead of to their primary email address.
 
 
 <a id="nestedatt--tags"></a>

--- a/docs/resources/ec2_vpc_endpoint.md
+++ b/docs/resources/ec2_vpc_endpoint.md
@@ -17,16 +17,16 @@ Resource Type definition for AWS::EC2::VPCEndpoint
 
 ### Required
 
-- `service_name` (String) The service name.
-- `vpc_id` (String) The ID of the VPC in which the endpoint will be used.
+- `service_name` (String)
+- `vpc_id` (String)
 
 ### Optional
 
-- `policy_document` (String) A policy to attach to the endpoint that controls access to the service.
-- `private_dns_enabled` (Boolean) Indicate whether to associate a private hosted zone with the specified VPC.
-- `route_table_ids` (Set of String) One or more route table IDs.
-- `security_group_ids` (Set of String) The ID of one or more security groups to associate with the endpoint network interface.
-- `subnet_ids` (Set of String) The ID of one or more subnets in which to create an endpoint network interface.
+- `policy_document` (Map of String)
+- `private_dns_enabled` (Boolean)
+- `route_table_ids` (List of String)
+- `security_group_ids` (List of String)
+- `subnet_ids` (List of String)
 - `vpc_endpoint_type` (String)
 
 ### Read-Only

--- a/docs/resources/identitystore_group_membership.md
+++ b/docs/resources/identitystore_group_membership.md
@@ -29,7 +29,7 @@ Resource Type Definition for AWS:IdentityStore::GroupMembership
 <a id="nestedatt--member_id"></a>
 ### Nested Schema for `member_id`
 
-Optional:
+Required:
 
 - `user_id` (String) The identifier for a user in the identity store.
 

--- a/docs/resources/lex_bot.md
+++ b/docs/resources/lex_bot.md
@@ -1187,6 +1187,7 @@ Optional:
 
 - `allow_interrupt` (Boolean) Indicates whether the user can interrupt a speech prompt from the bot.
 - `message_selection_strategy` (String) Indicates how a message is selected from a message group among retries.
+- `prompt_attempts_specification` (Attributes Map) Specifies the advanced settings on each attempt of the prompt. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification))
 
 <a id="nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--message_groups_list"></a>
 ### Nested Schema for `bot_locales.intents.intent_confirmation_setting.is_active.message_groups_list`
@@ -1316,6 +1317,67 @@ Required:
 
 
 
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.is_active.prompt_attempts_specification`
+
+Optional:
+
+- `allow_interrupt` (Boolean) Indicates whether the user can interrupt a speech prompt attempt from the bot.
+- `allowed_input_types` (Attributes) Specifies the allowed input types. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--allowed_input_types))
+- `audio_and_dtmf_input_specification` (Attributes) Specifies the audio and DTMF input specification. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--audio_and_dtmf_input_specification))
+- `text_input_specification` (Attributes) Specifies the text input specifications. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--text_input_specification))
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--allowed_input_types"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.is_active.prompt_attempts_specification.text_input_specification`
+
+Required:
+
+- `allow_audio_input` (Boolean) Indicates whether audio input is allowed.
+- `allow_dtmf_input` (Boolean) Indicates whether DTMF input is allowed.
+
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--audio_and_dtmf_input_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.is_active.prompt_attempts_specification.text_input_specification`
+
+Required:
+
+- `start_timeout_ms` (Number) Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.
+
+Optional:
+
+- `audio_specification` (Attributes) Specifies the audio input specifications. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--text_input_specification--audio_specification))
+- `dtmf_specification` (Attributes) Specifies the settings on DTMF input. (see [below for nested schema](#nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--text_input_specification--dtmf_specification))
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--text_input_specification--audio_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.is_active.prompt_attempts_specification.text_input_specification.dtmf_specification`
+
+Required:
+
+- `end_timeout_ms` (Number) Time for which a bot waits after the customer stops speaking to assume the utterance is finished.
+- `max_length_ms` (Number) Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.
+
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--text_input_specification--dtmf_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.is_active.prompt_attempts_specification.text_input_specification.dtmf_specification`
+
+Required:
+
+- `deletion_character` (String) The DTMF character that clears the accumulated DTMF digits and immediately ends the input.
+- `end_character` (String) The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.
+- `end_timeout_ms` (Number) How long the bot should wait after the last DTMF character input before assuming that the input has concluded.
+- `max_length` (Number) The maximum number of DTMF digits allowed in an utterance.
+
+
+
+<a id="nestedatt--bot_locales--intents--intent_confirmation_setting--is_active--prompt_attempts_specification--text_input_specification"></a>
+### Nested Schema for `bot_locales.intents.intent_confirmation_setting.is_active.prompt_attempts_specification.text_input_specification`
+
+Required:
+
+- `start_timeout_ms` (Number) Time for which a bot waits before re-prompting a customer for text input.
+
+
+
 
 
 <a id="nestedatt--bot_locales--intents--kendra_configuration"></a>
@@ -1415,38 +1477,39 @@ Optional:
 
 - `allow_interrupt` (Boolean) Indicates whether the user can interrupt a speech prompt from the bot.
 - `message_selection_strategy` (String) Indicates how a message is selected from a message group among retries.
+- `prompt_attempts_specification` (Attributes Map) Specifies the advanced settings on each attempt of the prompt. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification))
 
 <a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_groups_list"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy`
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification`
 
 Required:
 
-- `message` (Attributes) The primary message that Amazon Lex should send to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--message))
+- `message` (Attributes) The primary message that Amazon Lex should send to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--message))
 
 Optional:
 
-- `variations` (Attributes List) Message variations to send to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations))
+- `variations` (Attributes List) Message variations to send to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations))
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--message"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--message"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations`
 
 Optional:
 
-- `custom_payload` (Attributes) A message in a custom format defined by the client application. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--custom_payload))
-- `image_response_card` (Attributes) A message that defines a response card that the client application can show to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--image_response_card))
-- `plain_text_message` (Attributes) A message in plain text format. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--plain_text_message))
-- `ssml_message` (Attributes) A message in Speech Synthesis Markup Language (SSML). (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--ssml_message))
+- `custom_payload` (Attributes) A message in a custom format defined by the client application. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--custom_payload))
+- `image_response_card` (Attributes) A message that defines a response card that the client application can show to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--image_response_card))
+- `plain_text_message` (Attributes) A message in plain text format. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--plain_text_message))
+- `ssml_message` (Attributes) A message in Speech Synthesis Markup Language (SSML). (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message))
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--custom_payload"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--custom_payload"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Required:
 
 - `value` (String) The string that is sent to your application.
 
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--image_response_card"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--image_response_card"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Required:
 
@@ -1454,12 +1517,12 @@ Required:
 
 Optional:
 
-- `buttons` (Attributes List) A list of buttons that should be displayed on the response card. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--ssml_message--buttons))
+- `buttons` (Attributes List) A list of buttons that should be displayed on the response card. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message--buttons))
 - `image_url` (String) The URL of an image to display on the response card.
 - `subtitle` (String) The subtitle to display on the response card.
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--ssml_message--buttons"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message.buttons`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message--buttons"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message.buttons`
 
 Required:
 
@@ -1468,16 +1531,16 @@ Required:
 
 
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--plain_text_message"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--plain_text_message"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Required:
 
 - `value` (String) The message to send to the user.
 
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--ssml_message"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Required:
 
@@ -1485,26 +1548,26 @@ Required:
 
 
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations`
 
 Optional:
 
-- `custom_payload` (Attributes) A message in a custom format defined by the client application. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--custom_payload))
-- `image_response_card` (Attributes) A message that defines a response card that the client application can show to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--image_response_card))
-- `plain_text_message` (Attributes) A message in plain text format. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--plain_text_message))
-- `ssml_message` (Attributes) A message in Speech Synthesis Markup Language (SSML). (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--ssml_message))
+- `custom_payload` (Attributes) A message in a custom format defined by the client application. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--custom_payload))
+- `image_response_card` (Attributes) A message that defines a response card that the client application can show to the user. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--image_response_card))
+- `plain_text_message` (Attributes) A message in plain text format. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--plain_text_message))
+- `ssml_message` (Attributes) A message in Speech Synthesis Markup Language (SSML). (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message))
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--custom_payload"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--custom_payload"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Required:
 
 - `value` (String) The string that is sent to your application.
 
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--image_response_card"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--image_response_card"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Required:
 
@@ -1512,12 +1575,12 @@ Required:
 
 Optional:
 
-- `buttons` (Attributes List) A list of buttons that should be displayed on the response card. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--ssml_message--buttons))
+- `buttons` (Attributes List) A list of buttons that should be displayed on the response card. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message--buttons))
 - `image_url` (String) The URL of an image to display on the response card.
 - `subtitle` (String) The subtitle to display on the response card.
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--ssml_message--buttons"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message.buttons`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message--buttons"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message.buttons`
 
 Required:
 
@@ -1526,21 +1589,82 @@ Required:
 
 
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--plain_text_message"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--plain_text_message"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Required:
 
 - `value` (String) The message to send to the user.
 
 
-<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--message_selection_strategy--variations--ssml_message"></a>
-### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.message_selection_strategy.variations.ssml_message`
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--variations--ssml_message"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.variations.ssml_message`
 
 Required:
 
 - `value` (String) The SSML text that defines the prompt.
 
+
+
+
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification`
+
+Optional:
+
+- `allow_interrupt` (Boolean) Indicates whether the user can interrupt a speech prompt attempt from the bot.
+- `allowed_input_types` (Attributes) Specifies the allowed input types. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--allowed_input_types))
+- `audio_and_dtmf_input_specification` (Attributes) Specifies the audio and DTMF input specification. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--audio_and_dtmf_input_specification))
+- `text_input_specification` (Attributes) Specifies the text input specifications. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--text_input_specification))
+
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--allowed_input_types"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Required:
+
+- `allow_audio_input` (Boolean) Indicates whether audio input is allowed.
+- `allow_dtmf_input` (Boolean) Indicates whether DTMF input is allowed.
+
+
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--audio_and_dtmf_input_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Required:
+
+- `start_timeout_ms` (Number) Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.
+
+Optional:
+
+- `audio_specification` (Attributes) Specifies the audio input specifications. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--audio_specification))
+- `dtmf_specification` (Attributes) Specifies the settings on DTMF input. (see [below for nested schema](#nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--dtmf_specification))
+
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--audio_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.text_input_specification.dtmf_specification`
+
+Required:
+
+- `end_timeout_ms` (Number) Time for which a bot waits after the customer stops speaking to assume the utterance is finished.
+- `max_length_ms` (Number) Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.
+
+
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--text_input_specification--dtmf_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.text_input_specification.dtmf_specification`
+
+Required:
+
+- `deletion_character` (String) The DTMF character that clears the accumulated DTMF digits and immediately ends the input.
+- `end_character` (String) The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.
+- `end_timeout_ms` (Number) How long the bot should wait after the last DTMF character input before assuming that the input has concluded.
+- `max_length` (Number) The maximum number of DTMF digits allowed in an utterance.
+
+
+
+<a id="nestedatt--bot_locales--intents--slots--obfuscation_setting--prompt_specification--prompt_attempts_specification--text_input_specification"></a>
+### Nested Schema for `bot_locales.intents.slots.obfuscation_setting.prompt_specification.prompt_attempts_specification.text_input_specification`
+
+Required:
+
+- `start_timeout_ms` (Number) Time for which a bot waits before re-prompting a customer for text input.
 
 
 

--- a/docs/resources/msk_cluster.md
+++ b/docs/resources/msk_cluster.md
@@ -31,6 +31,7 @@ Resource Type definition for AWS::MSK::Cluster
 - `enhanced_monitoring` (String)
 - `logging_info` (Attributes) (see [below for nested schema](#nestedatt--logging_info))
 - `open_monitoring` (Attributes) (see [below for nested schema](#nestedatt--open_monitoring))
+- `storage_mode` (String)
 - `tags` (Map of String) A key-value pair to associate with a resource.
 
 ### Read-Only

--- a/docs/resources/redshift_endpoint_access.md
+++ b/docs/resources/redshift_endpoint_access.md
@@ -25,6 +25,8 @@ Resource schema for a Redshift-managed VPC endpoint.
 ### Optional
 
 - `resource_owner` (String) The AWS account ID of the owner of the cluster.
+- `vpc_endpoint` (Attributes) The connection endpoint for connecting to an Amazon Redshift cluster through the proxy. (see [below for nested schema](#nestedatt--vpc_endpoint))
+- `vpc_security_groups` (Attributes List) A list of Virtual Private Cloud (VPC) security groups to be associated with the endpoint. (see [below for nested schema](#nestedatt--vpc_security_groups))
 
 ### Read-Only
 
@@ -33,8 +35,6 @@ Resource schema for a Redshift-managed VPC endpoint.
 - `endpoint_status` (String) The status of the endpoint.
 - `id` (String) Uniquely identifies the resource.
 - `port` (Number) The port number on which the cluster accepts incoming connections.
-- `vpc_endpoint` (Attributes) The connection endpoint for connecting to an Amazon Redshift cluster through the proxy. (see [below for nested schema](#nestedatt--vpc_endpoint))
-- `vpc_security_groups` (Attributes List) A list of Virtual Private Cloud (VPC) security groups to be associated with the endpoint. (see [below for nested schema](#nestedatt--vpc_security_groups))
 
 <a id="nestedatt--vpc_endpoint"></a>
 ### Nested Schema for `vpc_endpoint`
@@ -42,6 +42,9 @@ Resource schema for a Redshift-managed VPC endpoint.
 Optional:
 
 - `network_interfaces` (Attributes List) One or more network interfaces of the endpoint. Also known as an interface endpoint. (see [below for nested schema](#nestedatt--vpc_endpoint--network_interfaces))
+
+Read-Only:
+
 - `vpc_endpoint_id` (String) The connection endpoint ID for connecting an Amazon Redshift cluster through the proxy.
 - `vpc_id` (String) The VPC identifier that the endpoint is associated.
 

--- a/docs/resources/sagemaker_data_quality_job_definition.md
+++ b/docs/resources/sagemaker_data_quality_job_definition.md
@@ -57,9 +57,51 @@ Optional:
 <a id="nestedatt--data_quality_job_input"></a>
 ### Nested Schema for `data_quality_job_input`
 
+Optional:
+
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--data_quality_job_input--batch_transform_input))
+- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--data_quality_job_input--endpoint_input))
+
+<a id="nestedatt--data_quality_job_input--batch_transform_input"></a>
+### Nested Schema for `data_quality_job_input.batch_transform_input`
+
 Required:
 
-- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--data_quality_job_input--endpoint_input))
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--data_quality_job_input--batch_transform_input--dataset_format))
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+
+Optional:
+
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+
+<a id="nestedatt--data_quality_job_input--batch_transform_input--dataset_format"></a>
+### Nested Schema for `data_quality_job_input.batch_transform_input.dataset_format`
+
+Optional:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--data_quality_job_input--batch_transform_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--data_quality_job_input--batch_transform_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicate if the dataset format is Parquet
+
+<a id="nestedatt--data_quality_job_input--batch_transform_input--dataset_format--csv"></a>
+### Nested Schema for `data_quality_job_input.batch_transform_input.dataset_format.parquet`
+
+Optional:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--data_quality_job_input--batch_transform_input--dataset_format--json"></a>
+### Nested Schema for `data_quality_job_input.batch_transform_input.dataset_format.parquet`
+
+Optional:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--data_quality_job_input--endpoint_input"></a>
 ### Nested Schema for `data_quality_job_input.endpoint_input`

--- a/docs/resources/sagemaker_model_bias_job_definition.md
+++ b/docs/resources/sagemaker_model_bias_job_definition.md
@@ -78,8 +78,67 @@ Optional:
 
 Required:
 
-- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_bias_job_input--endpoint_input))
 - `ground_truth_s3_input` (Attributes) Ground truth input provided in S3 (see [below for nested schema](#nestedatt--model_bias_job_input--ground_truth_s3_input))
+
+Optional:
+
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--model_bias_job_input--batch_transform_input))
+- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_bias_job_input--endpoint_input))
+
+<a id="nestedatt--model_bias_job_input--ground_truth_s3_input"></a>
+### Nested Schema for `model_bias_job_input.ground_truth_s3_input`
+
+Required:
+
+- `s3_uri` (String) A URI that identifies the Amazon S3 storage location where Amazon SageMaker saves the results of a monitoring job.
+
+
+<a id="nestedatt--model_bias_job_input--batch_transform_input"></a>
+### Nested Schema for `model_bias_job_input.batch_transform_input`
+
+Required:
+
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--model_bias_job_input--batch_transform_input--dataset_format))
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+
+Optional:
+
+- `end_time_offset` (String) Monitoring end time offset, e.g. PT0H
+- `features_attribute` (String) JSONpath to locate features in JSONlines dataset
+- `inference_attribute` (String) Index or JSONpath to locate predicted label(s)
+- `probability_attribute` (String) Index or JSONpath to locate probabilities
+- `probability_threshold_attribute` (Number)
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+- `start_time_offset` (String) Monitoring start time offset, e.g. -PT1H
+
+<a id="nestedatt--model_bias_job_input--batch_transform_input--dataset_format"></a>
+### Nested Schema for `model_bias_job_input.batch_transform_input.dataset_format`
+
+Optional:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--model_bias_job_input--batch_transform_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--model_bias_job_input--batch_transform_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicate if the dataset format is Parquet
+
+<a id="nestedatt--model_bias_job_input--batch_transform_input--dataset_format--csv"></a>
+### Nested Schema for `model_bias_job_input.batch_transform_input.dataset_format.parquet`
+
+Optional:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--model_bias_job_input--batch_transform_input--dataset_format--json"></a>
+### Nested Schema for `model_bias_job_input.batch_transform_input.dataset_format.parquet`
+
+Optional:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--model_bias_job_input--endpoint_input"></a>
 ### Nested Schema for `model_bias_job_input.endpoint_input`
@@ -99,14 +158,6 @@ Optional:
 - `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
 - `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
 - `start_time_offset` (String) Monitoring start time offset, e.g. -PT1H
-
-
-<a id="nestedatt--model_bias_job_input--ground_truth_s3_input"></a>
-### Nested Schema for `model_bias_job_input.ground_truth_s3_input`
-
-Required:
-
-- `s3_uri` (String) A URI that identifies the Amazon S3 storage location where Amazon SageMaker saves the results of a monitoring job.
 
 
 

--- a/docs/resources/sagemaker_model_explainability_job_definition.md
+++ b/docs/resources/sagemaker_model_explainability_job_definition.md
@@ -76,9 +76,54 @@ Optional:
 <a id="nestedatt--model_explainability_job_input"></a>
 ### Nested Schema for `model_explainability_job_input`
 
+Optional:
+
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--model_explainability_job_input--batch_transform_input))
+- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_explainability_job_input--endpoint_input))
+
+<a id="nestedatt--model_explainability_job_input--batch_transform_input"></a>
+### Nested Schema for `model_explainability_job_input.batch_transform_input`
+
 Required:
 
-- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_explainability_job_input--endpoint_input))
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--model_explainability_job_input--batch_transform_input--dataset_format))
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+
+Optional:
+
+- `features_attribute` (String) JSONpath to locate features in JSONlines dataset
+- `inference_attribute` (String) Index or JSONpath to locate predicted label(s)
+- `probability_attribute` (String) Index or JSONpath to locate probabilities
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+
+<a id="nestedatt--model_explainability_job_input--batch_transform_input--dataset_format"></a>
+### Nested Schema for `model_explainability_job_input.batch_transform_input.dataset_format`
+
+Optional:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--model_explainability_job_input--batch_transform_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--model_explainability_job_input--batch_transform_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicating if the dataset format is Parquet
+
+<a id="nestedatt--model_explainability_job_input--batch_transform_input--dataset_format--csv"></a>
+### Nested Schema for `model_explainability_job_input.batch_transform_input.dataset_format.parquet`
+
+Optional:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--model_explainability_job_input--batch_transform_input--dataset_format--json"></a>
+### Nested Schema for `model_explainability_job_input.batch_transform_input.dataset_format.parquet`
+
+Optional:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--model_explainability_job_input--endpoint_input"></a>
 ### Nested Schema for `model_explainability_job_input.endpoint_input`

--- a/docs/resources/sagemaker_model_quality_job_definition.md
+++ b/docs/resources/sagemaker_model_quality_job_definition.md
@@ -82,8 +82,66 @@ Optional:
 
 Required:
 
-- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_quality_job_input--endpoint_input))
 - `ground_truth_s3_input` (Attributes) Ground truth input provided in S3 (see [below for nested schema](#nestedatt--model_quality_job_input--ground_truth_s3_input))
+
+Optional:
+
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--model_quality_job_input--batch_transform_input))
+- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--model_quality_job_input--endpoint_input))
+
+<a id="nestedatt--model_quality_job_input--ground_truth_s3_input"></a>
+### Nested Schema for `model_quality_job_input.ground_truth_s3_input`
+
+Required:
+
+- `s3_uri` (String) A URI that identifies the Amazon S3 storage location where Amazon SageMaker saves the results of a monitoring job.
+
+
+<a id="nestedatt--model_quality_job_input--batch_transform_input"></a>
+### Nested Schema for `model_quality_job_input.batch_transform_input`
+
+Required:
+
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--model_quality_job_input--batch_transform_input--dataset_format))
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+
+Optional:
+
+- `end_time_offset` (String) Monitoring end time offset, e.g. PT0H
+- `inference_attribute` (String) Index or JSONpath to locate predicted label(s)
+- `probability_attribute` (String) Index or JSONpath to locate probabilities
+- `probability_threshold_attribute` (Number)
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+- `start_time_offset` (String) Monitoring start time offset, e.g. -PT1H
+
+<a id="nestedatt--model_quality_job_input--batch_transform_input--dataset_format"></a>
+### Nested Schema for `model_quality_job_input.batch_transform_input.dataset_format`
+
+Optional:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--model_quality_job_input--batch_transform_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--model_quality_job_input--batch_transform_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicating if the dataset format is Parquet
+
+<a id="nestedatt--model_quality_job_input--batch_transform_input--dataset_format--csv"></a>
+### Nested Schema for `model_quality_job_input.batch_transform_input.dataset_format.parquet`
+
+Optional:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--model_quality_job_input--batch_transform_input--dataset_format--json"></a>
+### Nested Schema for `model_quality_job_input.batch_transform_input.dataset_format.parquet`
+
+Optional:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--model_quality_job_input--endpoint_input"></a>
 ### Nested Schema for `model_quality_job_input.endpoint_input`
@@ -102,14 +160,6 @@ Optional:
 - `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
 - `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
 - `start_time_offset` (String) Monitoring start time offset, e.g. -PT1H
-
-
-<a id="nestedatt--model_quality_job_input--ground_truth_s3_input"></a>
-### Nested Schema for `model_quality_job_input.ground_truth_s3_input`
-
-Required:
-
-- `s3_uri` (String) A URI that identifies the Amazon S3 storage location where Amazon SageMaker saves the results of a monitoring job.
 
 
 

--- a/docs/resources/sagemaker_monitoring_schedule.md
+++ b/docs/resources/sagemaker_monitoring_schedule.md
@@ -81,9 +81,51 @@ Optional:
 <a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs"></a>
 ### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs`
 
+Optional:
+
+- `batch_transform_input` (Attributes) The batch transform input for a monitoring job. (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--batch_transform_input))
+- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input))
+
+<a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--batch_transform_input"></a>
+### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input`
+
 Required:
 
-- `endpoint_input` (Attributes) The endpoint for a monitoring job. (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input))
+- `data_captured_destination_s3_uri` (String) A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.
+- `dataset_format` (Attributes) The dataset format of the data to monitor (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format))
+- `local_path` (String) Path to the filesystem where the endpoint data is available to the container.
+
+Optional:
+
+- `s3_data_distribution_type` (String) Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated
+- `s3_input_mode` (String) Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.
+
+<a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format"></a>
+### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input.dataset_format`
+
+Optional:
+
+- `csv` (Attributes) The CSV format (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format--csv))
+- `json` (Attributes) The Json format (see [below for nested schema](#nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format--json))
+- `parquet` (Boolean) A flag indicating if the dataset format is Parquet
+
+<a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format--csv"></a>
+### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input.dataset_format.parquet`
+
+Optional:
+
+- `header` (Boolean) A boolean flag indicating if given CSV has header
+
+
+<a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input--dataset_format--json"></a>
+### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input.dataset_format.parquet`
+
+Optional:
+
+- `line` (Boolean) A boolean flag indicating if it is JSON line format
+
+
+
 
 <a id="nestedatt--monitoring_schedule_config--monitoring_job_definition--monitoring_inputs--endpoint_input"></a>
 ### Nested Schema for `monitoring_schedule_config.monitoring_job_definition.monitoring_inputs.endpoint_input`

--- a/docs/resources/ses_dedicated_ip_pool.md
+++ b/docs/resources/ses_dedicated_ip_pool.md
@@ -18,6 +18,7 @@ Resource Type definition for AWS::SES::DedicatedIpPool
 ### Optional
 
 - `pool_name` (String) The name of the dedicated IP pool.
+- `scaling_mode` (String) Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD.
 
 ### Read-Only
 

--- a/internal/aws/appflow/flow_resource_gen.go
+++ b/internal/aws/appflow/flow_resource_gen.go
@@ -418,6 +418,14 @@ func flowResource(ctx context.Context) (resource.Resource, error) {
 			//           "Salesforce": {
 			//             "additionalProperties": false,
 			//             "properties": {
+			//               "DataTransferApi": {
+			//                 "enum": [
+			//                   "AUTOMATIC",
+			//                   "BULKV2",
+			//                   "REST_SYNC"
+			//                 ],
+			//                 "type": "string"
+			//               },
 			//               "ErrorHandlingConfig": {
 			//                 "additionalProperties": false,
 			//                 "properties": {
@@ -1339,6 +1347,22 @@ func flowResource(ctx context.Context) (resource.Resource, error) {
 									// Property: Salesforce
 									Attributes: tfsdk.SingleNestedAttributes(
 										map[string]tfsdk.Attribute{
+											"data_transfer_api": {
+												// Property: DataTransferApi
+												Type:     types.StringType,
+												Optional: true,
+												Computed: true,
+												Validators: []tfsdk.AttributeValidator{
+													validate.StringInSlice([]string{
+														"AUTOMATIC",
+														"BULKV2",
+														"REST_SYNC",
+													}),
+												},
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
 											"error_handling_config": {
 												// Property: ErrorHandlingConfig
 												Attributes: tfsdk.SingleNestedAttributes(
@@ -2026,6 +2050,14 @@ func flowResource(ctx context.Context) (resource.Resource, error) {
 			//         "Salesforce": {
 			//           "additionalProperties": false,
 			//           "properties": {
+			//             "DataTransferApi": {
+			//               "enum": [
+			//                 "AUTOMATIC",
+			//                 "BULKV2",
+			//                 "REST_SYNC"
+			//               ],
+			//               "type": "string"
+			//             },
 			//             "EnableDynamicFieldUpdate": {
 			//               "type": "boolean"
 			//             },
@@ -2483,6 +2515,22 @@ func flowResource(ctx context.Context) (resource.Resource, error) {
 									// Property: Salesforce
 									Attributes: tfsdk.SingleNestedAttributes(
 										map[string]tfsdk.Attribute{
+											"data_transfer_api": {
+												// Property: DataTransferApi
+												Type:     types.StringType,
+												Optional: true,
+												Computed: true,
+												Validators: []tfsdk.AttributeValidator{
+													validate.StringInSlice([]string{
+														"AUTOMATIC",
+														"BULKV2",
+														"REST_SYNC",
+													}),
+												},
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
 											"enable_dynamic_field_update": {
 												// Property: EnableDynamicFieldUpdate
 												Type:     types.BoolType,
@@ -3125,7 +3173,8 @@ func flowResource(ctx context.Context) (resource.Resource, error) {
 			//                 "MATH_OPERATION_FIELDS_ORDER",
 			//                 "CONCAT_FORMAT",
 			//                 "SUBFIELD_CATEGORY_MAP",
-			//                 "EXCLUDE_SOURCE_FIELDS_LIST"
+			//                 "EXCLUDE_SOURCE_FIELDS_LIST",
+			//                 "INCLUDE_NEW_FIELDS"
 			//               ],
 			//               "type": "string"
 			//             },
@@ -3681,6 +3730,7 @@ func flowResource(ctx context.Context) (resource.Resource, error) {
 											"CONCAT_FORMAT",
 											"SUBFIELD_CATEGORY_MAP",
 											"EXCLUDE_SOURCE_FIELDS_LIST",
+											"INCLUDE_NEW_FIELDS",
 										}),
 									},
 								},
@@ -3945,6 +3995,7 @@ func flowResource(ctx context.Context) (resource.Resource, error) {
 		"custom_connector":                  "CustomConnector",
 		"custom_properties":                 "CustomProperties",
 		"data_pull_mode":                    "DataPullMode",
+		"data_transfer_api":                 "DataTransferApi",
 		"datadog":                           "Datadog",
 		"datetime_type_field_name":          "DatetimeTypeFieldName",
 		"description":                       "Description",

--- a/internal/aws/appflow/flow_singular_data_source_gen.go
+++ b/internal/aws/appflow/flow_singular_data_source_gen.go
@@ -408,6 +408,14 @@ func flowDataSource(ctx context.Context) (datasource.DataSource, error) {
 			//           "Salesforce": {
 			//             "additionalProperties": false,
 			//             "properties": {
+			//               "DataTransferApi": {
+			//                 "enum": [
+			//                   "AUTOMATIC",
+			//                   "BULKV2",
+			//                   "REST_SYNC"
+			//                 ],
+			//                 "type": "string"
+			//               },
 			//               "ErrorHandlingConfig": {
 			//                 "additionalProperties": false,
 			//                 "properties": {
@@ -979,6 +987,11 @@ func flowDataSource(ctx context.Context) (datasource.DataSource, error) {
 									// Property: Salesforce
 									Attributes: tfsdk.SingleNestedAttributes(
 										map[string]tfsdk.Attribute{
+											"data_transfer_api": {
+												// Property: DataTransferApi
+												Type:     types.StringType,
+												Computed: true,
+											},
 											"error_handling_config": {
 												// Property: ErrorHandlingConfig
 												Attributes: tfsdk.SingleNestedAttributes(
@@ -1447,6 +1460,14 @@ func flowDataSource(ctx context.Context) (datasource.DataSource, error) {
 			//         "Salesforce": {
 			//           "additionalProperties": false,
 			//           "properties": {
+			//             "DataTransferApi": {
+			//               "enum": [
+			//                 "AUTOMATIC",
+			//                 "BULKV2",
+			//                 "REST_SYNC"
+			//               ],
+			//               "type": "string"
+			//             },
 			//             "EnableDynamicFieldUpdate": {
 			//               "type": "boolean"
 			//             },
@@ -1759,6 +1780,11 @@ func flowDataSource(ctx context.Context) (datasource.DataSource, error) {
 									// Property: Salesforce
 									Attributes: tfsdk.SingleNestedAttributes(
 										map[string]tfsdk.Attribute{
+											"data_transfer_api": {
+												// Property: DataTransferApi
+												Type:     types.StringType,
+												Computed: true,
+											},
 											"enable_dynamic_field_update": {
 												// Property: EnableDynamicFieldUpdate
 												Type:     types.BoolType,
@@ -2307,7 +2333,8 @@ func flowDataSource(ctx context.Context) (datasource.DataSource, error) {
 			//                 "MATH_OPERATION_FIELDS_ORDER",
 			//                 "CONCAT_FORMAT",
 			//                 "SUBFIELD_CATEGORY_MAP",
-			//                 "EXCLUDE_SOURCE_FIELDS_LIST"
+			//                 "EXCLUDE_SOURCE_FIELDS_LIST",
+			//                 "INCLUDE_NEW_FIELDS"
 			//               ],
 			//               "type": "string"
 			//             },
@@ -2642,6 +2669,7 @@ func flowDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"custom_connector":                  "CustomConnector",
 		"custom_properties":                 "CustomProperties",
 		"data_pull_mode":                    "DataPullMode",
+		"data_transfer_api":                 "DataTransferApi",
 		"datadog":                           "Datadog",
 		"datetime_type_field_name":          "DatetimeTypeFieldName",
 		"description":                       "Description",

--- a/internal/aws/codestarnotifications/notification_rule_resource_gen.go
+++ b/internal/aws/codestarnotifications/notification_rule_resource_gen.go
@@ -175,7 +175,6 @@ func notificationRuleResource(ctx context.Context) (resource.Resource, error) {
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.UseStateForUnknown(),
-				resource.RequiresReplace(),
 			},
 		},
 		"target_address": {

--- a/internal/aws/connect/user_resource_gen.go
+++ b/internal/aws/connect/user_resource_gen.go
@@ -74,6 +74,16 @@ func userResource(ctx context.Context) (resource.Resource, error) {
 			//     "LastName": {
 			//       "description": "The last name. This is required if you are using Amazon Connect or SAML for identity management.",
 			//       "type": "string"
+			//     },
+			//     "Mobile": {
+			//       "description": "The mobile phone number.",
+			//       "pattern": "^\\+[1-9]\\d{1,14}$",
+			//       "type": "string"
+			//     },
+			//     "SecondaryEmail": {
+			//       "description": "The secondary email address. If you provide a secondary email, the user receives email notifications -- other than password reset notifications -- to this email address instead of to their primary email address.",
+			//       "pattern": "",
+			//       "type": "string"
 			//     }
 			//   },
 			//   "type": "object"
@@ -104,6 +114,29 @@ func userResource(ctx context.Context) (resource.Resource, error) {
 					"last_name": {
 						// Property: LastName
 						Description: "The last name. This is required if you are using Amazon Connect or SAML for identity management.",
+						Type:        types.StringType,
+						Optional:    true,
+						Computed:    true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
+					},
+					"mobile": {
+						// Property: Mobile
+						Description: "The mobile phone number.",
+						Type:        types.StringType,
+						Optional:    true,
+						Computed:    true,
+						Validators: []tfsdk.AttributeValidator{
+							validate.StringMatch(regexp.MustCompile("^\\+[1-9]\\d{1,14}$"), ""),
+						},
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
+					},
+					"secondary_email": {
+						// Property: SecondaryEmail
+						Description: "The secondary email address. If you provide a secondary email, the user receives email notifications -- other than password reset notifications -- to this email address instead of to their primary email address.",
 						Type:        types.StringType,
 						Optional:    true,
 						Computed:    true,
@@ -408,10 +441,12 @@ func userResource(ctx context.Context) (resource.Resource, error) {
 		"instance_arn":                  "InstanceArn",
 		"key":                           "Key",
 		"last_name":                     "LastName",
+		"mobile":                        "Mobile",
 		"password":                      "Password",
 		"phone_config":                  "PhoneConfig",
 		"phone_type":                    "PhoneType",
 		"routing_profile_arn":           "RoutingProfileArn",
+		"secondary_email":               "SecondaryEmail",
 		"security_profile_arns":         "SecurityProfileArns",
 		"tags":                          "Tags",
 		"user_arn":                      "UserArn",

--- a/internal/aws/connect/user_singular_data_source_gen.go
+++ b/internal/aws/connect/user_singular_data_source_gen.go
@@ -61,6 +61,16 @@ func userDataSource(ctx context.Context) (datasource.DataSource, error) {
 			//     "LastName": {
 			//       "description": "The last name. This is required if you are using Amazon Connect or SAML for identity management.",
 			//       "type": "string"
+			//     },
+			//     "Mobile": {
+			//       "description": "The mobile phone number.",
+			//       "pattern": "^\\+[1-9]\\d{1,14}$",
+			//       "type": "string"
+			//     },
+			//     "SecondaryEmail": {
+			//       "description": "The secondary email address. If you provide a secondary email, the user receives email notifications -- other than password reset notifications -- to this email address instead of to their primary email address.",
+			//       "pattern": "",
+			//       "type": "string"
 			//     }
 			//   },
 			//   "type": "object"
@@ -83,6 +93,18 @@ func userDataSource(ctx context.Context) (datasource.DataSource, error) {
 					"last_name": {
 						// Property: LastName
 						Description: "The last name. This is required if you are using Amazon Connect or SAML for identity management.",
+						Type:        types.StringType,
+						Computed:    true,
+					},
+					"mobile": {
+						// Property: Mobile
+						Description: "The mobile phone number.",
+						Type:        types.StringType,
+						Computed:    true,
+					},
+					"secondary_email": {
+						// Property: SecondaryEmail
+						Description: "The secondary email address. If you provide a secondary email, the user receives email notifications -- other than password reset notifications -- to this email address instead of to their primary email address.",
 						Type:        types.StringType,
 						Computed:    true,
 					},
@@ -319,10 +341,12 @@ func userDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"instance_arn":                  "InstanceArn",
 		"key":                           "Key",
 		"last_name":                     "LastName",
+		"mobile":                        "Mobile",
 		"password":                      "Password",
 		"phone_config":                  "PhoneConfig",
 		"phone_type":                    "PhoneType",
 		"routing_profile_arn":           "RoutingProfileArn",
+		"secondary_email":               "SecondaryEmail",
 		"security_profile_arns":         "SecurityProfileArns",
 		"tags":                          "Tags",
 		"user_arn":                      "UserArn",

--- a/internal/aws/ec2/vpc_endpoint_resource_gen.go
+++ b/internal/aws/ec2/vpc_endpoint_resource_gen.go
@@ -37,7 +37,6 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: DnsEntries
 			// CloudFormation resource type schema:
 			// {
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
@@ -47,7 +46,6 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			Type:     types.ListType{ElemType: types.StringType},
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				Multiset(),
 				resource.UseStateForUnknown(),
 			},
 		},
@@ -67,7 +65,6 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: NetworkInterfaceIds
 			// CloudFormation resource type schema:
 			// {
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
@@ -77,7 +74,6 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			Type:     types.ListType{ElemType: types.StringType},
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
-				Multiset(),
 				resource.UseStateForUnknown(),
 			},
 		},
@@ -85,13 +81,11 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: PolicyDocument
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "A policy to attach to the endpoint that controls access to the service.",
-			//   "type": "string"
+			//   "type": "object"
 			// }
-			Description: "A policy to attach to the endpoint that controls access to the service.",
-			Type:        types.StringType,
-			Optional:    true,
-			Computed:    true,
+			Type:     types.MapType{ElemType: types.StringType},
+			Optional: true,
+			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.UseStateForUnknown(),
 			},
@@ -100,13 +94,11 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: PrivateDnsEnabled
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "Indicate whether to associate a private hosted zone with the specified VPC.",
 			//   "type": "boolean"
 			// }
-			Description: "Indicate whether to associate a private hosted zone with the specified VPC.",
-			Type:        types.BoolType,
-			Optional:    true,
-			Computed:    true,
+			Type:     types.BoolType,
+			Optional: true,
+			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.UseStateForUnknown(),
 			},
@@ -115,18 +107,18 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: RouteTableIds
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "One or more route table IDs.",
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
-			Description: "One or more route table IDs.",
-			Type:        types.SetType{ElemType: types.StringType},
-			Optional:    true,
-			Computed:    true,
+			Type:     types.ListType{ElemType: types.StringType},
+			Optional: true,
+			Computed: true,
+			Validators: []tfsdk.AttributeValidator{
+				validate.UniqueItems(),
+			},
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.UseStateForUnknown(),
 			},
@@ -135,18 +127,18 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: SecurityGroupIds
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "The ID of one or more security groups to associate with the endpoint network interface.",
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
-			Description: "The ID of one or more security groups to associate with the endpoint network interface.",
-			Type:        types.SetType{ElemType: types.StringType},
-			Optional:    true,
-			Computed:    true,
+			Type:     types.ListType{ElemType: types.StringType},
+			Optional: true,
+			Computed: true,
+			Validators: []tfsdk.AttributeValidator{
+				validate.UniqueItems(),
+			},
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.UseStateForUnknown(),
 			},
@@ -155,12 +147,10 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: ServiceName
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "The service name.",
 			//   "type": "string"
 			// }
-			Description: "The service name.",
-			Type:        types.StringType,
-			Required:    true,
+			Type:     types.StringType,
+			Required: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.RequiresReplace(),
 			},
@@ -169,18 +159,18 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: SubnetIds
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "The ID of one or more subnets in which to create an endpoint network interface.",
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
-			Description: "The ID of one or more subnets in which to create an endpoint network interface.",
-			Type:        types.SetType{ElemType: types.StringType},
-			Optional:    true,
-			Computed:    true,
+			Type:     types.ListType{ElemType: types.StringType},
+			Optional: true,
+			Computed: true,
+			Validators: []tfsdk.AttributeValidator{
+				validate.UniqueItems(),
+			},
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.UseStateForUnknown(),
 			},
@@ -189,23 +179,11 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: VpcEndpointType
 			// CloudFormation resource type schema:
 			// {
-			//   "enum": [
-			//     "Interface",
-			//     "Gateway",
-			//     "GatewayLoadBalancer"
-			//   ],
 			//   "type": "string"
 			// }
 			Type:     types.StringType,
 			Optional: true,
 			Computed: true,
-			Validators: []tfsdk.AttributeValidator{
-				validate.StringInSlice([]string{
-					"Interface",
-					"Gateway",
-					"GatewayLoadBalancer",
-				}),
-			},
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.UseStateForUnknown(),
 				resource.RequiresReplace(),
@@ -215,12 +193,10 @@ func vPCEndpointResource(ctx context.Context) (resource.Resource, error) {
 			// Property: VpcId
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "The ID of the VPC in which the endpoint will be used.",
 			//   "type": "string"
 			// }
-			Description: "The ID of the VPC in which the endpoint will be used.",
-			Type:        types.StringType,
-			Required:    true,
+			Type:     types.StringType,
+			Required: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.RequiresReplace(),
 			},

--- a/internal/aws/ec2/vpc_endpoint_singular_data_source_gen.go
+++ b/internal/aws/ec2/vpc_endpoint_singular_data_source_gen.go
@@ -33,7 +33,6 @@ func vPCEndpointDataSource(ctx context.Context) (datasource.DataSource, error) {
 			// Property: DnsEntries
 			// CloudFormation resource type schema:
 			// {
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
@@ -56,7 +55,6 @@ func vPCEndpointDataSource(ctx context.Context) (datasource.DataSource, error) {
 			// Property: NetworkInterfaceIds
 			// CloudFormation resource type schema:
 			// {
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
@@ -70,92 +68,72 @@ func vPCEndpointDataSource(ctx context.Context) (datasource.DataSource, error) {
 			// Property: PolicyDocument
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "A policy to attach to the endpoint that controls access to the service.",
-			//   "type": "string"
+			//   "type": "object"
 			// }
-			Description: "A policy to attach to the endpoint that controls access to the service.",
-			Type:        types.StringType,
-			Computed:    true,
+			Type:     types.MapType{ElemType: types.StringType},
+			Computed: true,
 		},
 		"private_dns_enabled": {
 			// Property: PrivateDnsEnabled
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "Indicate whether to associate a private hosted zone with the specified VPC.",
 			//   "type": "boolean"
 			// }
-			Description: "Indicate whether to associate a private hosted zone with the specified VPC.",
-			Type:        types.BoolType,
-			Computed:    true,
+			Type:     types.BoolType,
+			Computed: true,
 		},
 		"route_table_ids": {
 			// Property: RouteTableIds
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "One or more route table IDs.",
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
-			Description: "One or more route table IDs.",
-			Type:        types.SetType{ElemType: types.StringType},
-			Computed:    true,
+			Type:     types.ListType{ElemType: types.StringType},
+			Computed: true,
 		},
 		"security_group_ids": {
 			// Property: SecurityGroupIds
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "The ID of one or more security groups to associate with the endpoint network interface.",
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
-			Description: "The ID of one or more security groups to associate with the endpoint network interface.",
-			Type:        types.SetType{ElemType: types.StringType},
-			Computed:    true,
+			Type:     types.ListType{ElemType: types.StringType},
+			Computed: true,
 		},
 		"service_name": {
 			// Property: ServiceName
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "The service name.",
 			//   "type": "string"
 			// }
-			Description: "The service name.",
-			Type:        types.StringType,
-			Computed:    true,
+			Type:     types.StringType,
+			Computed: true,
 		},
 		"subnet_ids": {
 			// Property: SubnetIds
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "The ID of one or more subnets in which to create an endpoint network interface.",
-			//   "insertionOrder": false,
 			//   "items": {
 			//     "type": "string"
 			//   },
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
-			Description: "The ID of one or more subnets in which to create an endpoint network interface.",
-			Type:        types.SetType{ElemType: types.StringType},
-			Computed:    true,
+			Type:     types.ListType{ElemType: types.StringType},
+			Computed: true,
 		},
 		"vpc_endpoint_type": {
 			// Property: VpcEndpointType
 			// CloudFormation resource type schema:
 			// {
-			//   "enum": [
-			//     "Interface",
-			//     "Gateway",
-			//     "GatewayLoadBalancer"
-			//   ],
 			//   "type": "string"
 			// }
 			Type:     types.StringType,
@@ -165,12 +143,10 @@ func vPCEndpointDataSource(ctx context.Context) (datasource.DataSource, error) {
 			// Property: VpcId
 			// CloudFormation resource type schema:
 			// {
-			//   "description": "The ID of the VPC in which the endpoint will be used.",
 			//   "type": "string"
 			// }
-			Description: "The ID of the VPC in which the endpoint will be used.",
-			Type:        types.StringType,
-			Computed:    true,
+			Type:     types.StringType,
+			Computed: true,
 		},
 	}
 

--- a/internal/aws/identitystore/group_membership_resource_gen.go
+++ b/internal/aws/identitystore/group_membership_resource_gen.go
@@ -65,6 +65,7 @@ func groupMembershipResource(ctx context.Context) (resource.Resource, error) {
 			// Property: MemberId
 			// CloudFormation resource type schema:
 			// {
+			//   "additionalProperties": false,
 			//   "description": "An object containing the identifier of a group member.",
 			//   "properties": {
 			//     "UserId": {
@@ -75,6 +76,9 @@ func groupMembershipResource(ctx context.Context) (resource.Resource, error) {
 			//       "type": "string"
 			//     }
 			//   },
+			//   "required": [
+			//     "UserId"
+			//   ],
 			//   "type": "object"
 			// }
 			Description: "An object containing the identifier of a group member.",
@@ -84,14 +88,10 @@ func groupMembershipResource(ctx context.Context) (resource.Resource, error) {
 						// Property: UserId
 						Description: "The identifier for a user in the identity store.",
 						Type:        types.StringType,
-						Optional:    true,
-						Computed:    true,
+						Required:    true,
 						Validators: []tfsdk.AttributeValidator{
 							validate.StringLenBetween(1, 47),
 							validate.StringMatch(regexp.MustCompile("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"), ""),
-						},
-						PlanModifiers: []tfsdk.AttributePlanModifier{
-							resource.UseStateForUnknown(),
 						},
 					},
 				},

--- a/internal/aws/identitystore/group_membership_singular_data_source_gen.go
+++ b/internal/aws/identitystore/group_membership_singular_data_source_gen.go
@@ -52,6 +52,7 @@ func groupMembershipDataSource(ctx context.Context) (datasource.DataSource, erro
 			// Property: MemberId
 			// CloudFormation resource type schema:
 			// {
+			//   "additionalProperties": false,
 			//   "description": "An object containing the identifier of a group member.",
 			//   "properties": {
 			//     "UserId": {
@@ -62,6 +63,9 @@ func groupMembershipDataSource(ctx context.Context) (datasource.DataSource, erro
 			//       "type": "string"
 			//     }
 			//   },
+			//   "required": [
+			//     "UserId"
+			//   ],
 			//   "type": "object"
 			// }
 			Description: "An object containing the identifier of a group member.",

--- a/internal/aws/lex/bot_resource_gen.go
+++ b/internal/aws/lex/bot_resource_gen.go
@@ -2402,6 +2402,131 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 			//                         "Ordered"
 			//                       ],
 			//                       "type": "string"
+			//                     },
+			//                     "PromptAttemptsSpecification": {
+			//                       "additionalProperties": false,
+			//                       "description": "Specifies the advanced settings on each attempt of the prompt.",
+			//                       "patternProperties": {
+			//                         "": {
+			//                           "additionalProperties": false,
+			//                           "description": "Specifies the settings on a prompt attempt.",
+			//                           "properties": {
+			//                             "AllowInterrupt": {
+			//                               "description": "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+			//                               "type": "boolean"
+			//                             },
+			//                             "AllowedInputTypes": {
+			//                               "additionalProperties": false,
+			//                               "description": "Specifies the allowed input types.",
+			//                               "properties": {
+			//                                 "AllowAudioInput": {
+			//                                   "description": "Indicates whether audio input is allowed.",
+			//                                   "type": "boolean"
+			//                                 },
+			//                                 "AllowDTMFInput": {
+			//                                   "description": "Indicates whether DTMF input is allowed.",
+			//                                   "type": "boolean"
+			//                                 }
+			//                               },
+			//                               "required": [
+			//                                 "AllowAudioInput",
+			//                                 "AllowDTMFInput"
+			//                               ],
+			//                               "type": "object"
+			//                             },
+			//                             "AudioAndDTMFInputSpecification": {
+			//                               "additionalProperties": false,
+			//                               "description": "Specifies the audio and DTMF input specification.",
+			//                               "properties": {
+			//                                 "AudioSpecification": {
+			//                                   "additionalProperties": false,
+			//                                   "description": "Specifies the audio input specifications.",
+			//                                   "properties": {
+			//                                     "EndTimeoutMs": {
+			//                                       "description": "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+			//                                       "minimum": 1,
+			//                                       "type": "integer"
+			//                                     },
+			//                                     "MaxLengthMs": {
+			//                                       "description": "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+			//                                       "minimum": 1,
+			//                                       "type": "integer"
+			//                                     }
+			//                                   },
+			//                                   "required": [
+			//                                     "EndTimeoutMs",
+			//                                     "MaxLengthMs"
+			//                                   ],
+			//                                   "type": "object"
+			//                                 },
+			//                                 "DTMFSpecification": {
+			//                                   "additionalProperties": false,
+			//                                   "description": "Specifies the settings on DTMF input.",
+			//                                   "properties": {
+			//                                     "DeletionCharacter": {
+			//                                       "description": "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+			//                                       "pattern": "^[A-D0-9#*]{1}$",
+			//                                       "type": "string"
+			//                                     },
+			//                                     "EndCharacter": {
+			//                                       "description": "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+			//                                       "pattern": "^[A-D0-9#*]{1}$",
+			//                                       "type": "string"
+			//                                     },
+			//                                     "EndTimeoutMs": {
+			//                                       "description": "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+			//                                       "minimum": 1,
+			//                                       "type": "integer"
+			//                                     },
+			//                                     "MaxLength": {
+			//                                       "description": "The maximum number of DTMF digits allowed in an utterance.",
+			//                                       "maximum": 1024,
+			//                                       "minimum": 1,
+			//                                       "type": "integer"
+			//                                     }
+			//                                   },
+			//                                   "required": [
+			//                                     "DeletionCharacter",
+			//                                     "EndCharacter",
+			//                                     "EndTimeoutMs",
+			//                                     "MaxLength"
+			//                                   ],
+			//                                   "type": "object"
+			//                                 },
+			//                                 "StartTimeoutMs": {
+			//                                   "description": "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+			//                                   "minimum": 1,
+			//                                   "type": "integer"
+			//                                 }
+			//                               },
+			//                               "required": [
+			//                                 "StartTimeoutMs"
+			//                               ],
+			//                               "type": "object"
+			//                             },
+			//                             "TextInputSpecification": {
+			//                               "additionalProperties": false,
+			//                               "description": "Specifies the text input specifications.",
+			//                               "properties": {
+			//                                 "StartTimeoutMs": {
+			//                                   "description": "Time for which a bot waits before re-prompting a customer for text input.",
+			//                                   "minimum": 1,
+			//                                   "type": "integer"
+			//                                 }
+			//                               },
+			//                               "required": [
+			//                                 "StartTimeoutMs"
+			//                               ],
+			//                               "type": "object"
+			//                             }
+			//                           },
+			//                           "required": [
+			//                             "AllowedInputTypes"
+			//                           ],
+			//                           "type": "object"
+			//                         }
+			//                       },
+			//                       "type": "object"
 			//                     }
 			//                   },
 			//                   "required": [
@@ -2895,6 +3020,131 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 			//                               "Ordered"
 			//                             ],
 			//                             "type": "string"
+			//                           },
+			//                           "PromptAttemptsSpecification": {
+			//                             "additionalProperties": false,
+			//                             "description": "Specifies the advanced settings on each attempt of the prompt.",
+			//                             "patternProperties": {
+			//                               "": {
+			//                                 "additionalProperties": false,
+			//                                 "description": "Specifies the settings on a prompt attempt.",
+			//                                 "properties": {
+			//                                   "AllowInterrupt": {
+			//                                     "description": "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+			//                                     "type": "boolean"
+			//                                   },
+			//                                   "AllowedInputTypes": {
+			//                                     "additionalProperties": false,
+			//                                     "description": "Specifies the allowed input types.",
+			//                                     "properties": {
+			//                                       "AllowAudioInput": {
+			//                                         "description": "Indicates whether audio input is allowed.",
+			//                                         "type": "boolean"
+			//                                       },
+			//                                       "AllowDTMFInput": {
+			//                                         "description": "Indicates whether DTMF input is allowed.",
+			//                                         "type": "boolean"
+			//                                       }
+			//                                     },
+			//                                     "required": [
+			//                                       "AllowAudioInput",
+			//                                       "AllowDTMFInput"
+			//                                     ],
+			//                                     "type": "object"
+			//                                   },
+			//                                   "AudioAndDTMFInputSpecification": {
+			//                                     "additionalProperties": false,
+			//                                     "description": "Specifies the audio and DTMF input specification.",
+			//                                     "properties": {
+			//                                       "AudioSpecification": {
+			//                                         "additionalProperties": false,
+			//                                         "description": "Specifies the audio input specifications.",
+			//                                         "properties": {
+			//                                           "EndTimeoutMs": {
+			//                                             "description": "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+			//                                             "minimum": 1,
+			//                                             "type": "integer"
+			//                                           },
+			//                                           "MaxLengthMs": {
+			//                                             "description": "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+			//                                             "minimum": 1,
+			//                                             "type": "integer"
+			//                                           }
+			//                                         },
+			//                                         "required": [
+			//                                           "EndTimeoutMs",
+			//                                           "MaxLengthMs"
+			//                                         ],
+			//                                         "type": "object"
+			//                                       },
+			//                                       "DTMFSpecification": {
+			//                                         "additionalProperties": false,
+			//                                         "description": "Specifies the settings on DTMF input.",
+			//                                         "properties": {
+			//                                           "DeletionCharacter": {
+			//                                             "description": "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+			//                                             "pattern": "^[A-D0-9#*]{1}$",
+			//                                             "type": "string"
+			//                                           },
+			//                                           "EndCharacter": {
+			//                                             "description": "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+			//                                             "pattern": "^[A-D0-9#*]{1}$",
+			//                                             "type": "string"
+			//                                           },
+			//                                           "EndTimeoutMs": {
+			//                                             "description": "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+			//                                             "minimum": 1,
+			//                                             "type": "integer"
+			//                                           },
+			//                                           "MaxLength": {
+			//                                             "description": "The maximum number of DTMF digits allowed in an utterance.",
+			//                                             "maximum": 1024,
+			//                                             "minimum": 1,
+			//                                             "type": "integer"
+			//                                           }
+			//                                         },
+			//                                         "required": [
+			//                                           "DeletionCharacter",
+			//                                           "EndCharacter",
+			//                                           "EndTimeoutMs",
+			//                                           "MaxLength"
+			//                                         ],
+			//                                         "type": "object"
+			//                                       },
+			//                                       "StartTimeoutMs": {
+			//                                         "description": "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+			//                                         "minimum": 1,
+			//                                         "type": "integer"
+			//                                       }
+			//                                     },
+			//                                     "required": [
+			//                                       "StartTimeoutMs"
+			//                                     ],
+			//                                     "type": "object"
+			//                                   },
+			//                                   "TextInputSpecification": {
+			//                                     "additionalProperties": false,
+			//                                     "description": "Specifies the text input specifications.",
+			//                                     "properties": {
+			//                                       "StartTimeoutMs": {
+			//                                         "description": "Time for which a bot waits before re-prompting a customer for text input.",
+			//                                         "minimum": 1,
+			//                                         "type": "integer"
+			//                                       }
+			//                                     },
+			//                                     "required": [
+			//                                       "StartTimeoutMs"
+			//                                     ],
+			//                                     "type": "object"
+			//                                   }
+			//                                 },
+			//                                 "required": [
+			//                                   "AllowedInputTypes"
+			//                                 ],
+			//                                 "type": "object"
+			//                               }
+			//                             },
+			//                             "type": "object"
 			//                           }
 			//                         },
 			//                         "required": [
@@ -7139,6 +7389,179 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 																resource.UseStateForUnknown(),
 															},
 														},
+														"prompt_attempts_specification": {
+															// Property: PromptAttemptsSpecification
+															Description: "Specifies the advanced settings on each attempt of the prompt.",
+															// Pattern: ""
+															Attributes: tfsdk.MapNestedAttributes(
+																map[string]tfsdk.Attribute{
+																	"allow_interrupt": {
+																		// Property: AllowInterrupt
+																		Description: "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+																		Type:        types.BoolType,
+																		Optional:    true,
+																		Computed:    true,
+																		PlanModifiers: []tfsdk.AttributePlanModifier{
+																			resource.UseStateForUnknown(),
+																		},
+																	},
+																	"allowed_input_types": {
+																		// Property: AllowedInputTypes
+																		Description: "Specifies the allowed input types.",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"allow_audio_input": {
+																					// Property: AllowAudioInput
+																					Description: "Indicates whether audio input is allowed.",
+																					Type:        types.BoolType,
+																					Required:    true,
+																				},
+																				"allow_dtmf_input": {
+																					// Property: AllowDTMFInput
+																					Description: "Indicates whether DTMF input is allowed.",
+																					Type:        types.BoolType,
+																					Required:    true,
+																				},
+																			},
+																		),
+																		Optional: true,
+																		Computed: true,
+																		PlanModifiers: []tfsdk.AttributePlanModifier{
+																			resource.UseStateForUnknown(),
+																		},
+																	},
+																	"audio_and_dtmf_input_specification": {
+																		// Property: AudioAndDTMFInputSpecification
+																		Description: "Specifies the audio and DTMF input specification.",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"audio_specification": {
+																					// Property: AudioSpecification
+																					Description: "Specifies the audio input specifications.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"end_timeout_ms": {
+																								// Property: EndTimeoutMs
+																								Description: "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+																								Type:        types.Int64Type,
+																								Required:    true,
+																								Validators: []tfsdk.AttributeValidator{
+																									validate.IntAtLeast(1),
+																								},
+																							},
+																							"max_length_ms": {
+																								// Property: MaxLengthMs
+																								Description: "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+																								Type:        types.Int64Type,
+																								Required:    true,
+																								Validators: []tfsdk.AttributeValidator{
+																									validate.IntAtLeast(1),
+																								},
+																							},
+																						},
+																					),
+																					Optional: true,
+																					Computed: true,
+																					PlanModifiers: []tfsdk.AttributePlanModifier{
+																						resource.UseStateForUnknown(),
+																					},
+																				},
+																				"dtmf_specification": {
+																					// Property: DTMFSpecification
+																					Description: "Specifies the settings on DTMF input.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"deletion_character": {
+																								// Property: DeletionCharacter
+																								Description: "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+																								Type:        types.StringType,
+																								Required:    true,
+																								Validators: []tfsdk.AttributeValidator{
+																									validate.StringMatch(regexp.MustCompile("^[A-D0-9#*]{1}$"), ""),
+																								},
+																							},
+																							"end_character": {
+																								// Property: EndCharacter
+																								Description: "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+																								Type:        types.StringType,
+																								Required:    true,
+																								Validators: []tfsdk.AttributeValidator{
+																									validate.StringMatch(regexp.MustCompile("^[A-D0-9#*]{1}$"), ""),
+																								},
+																							},
+																							"end_timeout_ms": {
+																								// Property: EndTimeoutMs
+																								Description: "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+																								Type:        types.Int64Type,
+																								Required:    true,
+																								Validators: []tfsdk.AttributeValidator{
+																									validate.IntAtLeast(1),
+																								},
+																							},
+																							"max_length": {
+																								// Property: MaxLength
+																								Description: "The maximum number of DTMF digits allowed in an utterance.",
+																								Type:        types.Int64Type,
+																								Required:    true,
+																								Validators: []tfsdk.AttributeValidator{
+																									validate.IntBetween(1, 1024),
+																								},
+																							},
+																						},
+																					),
+																					Optional: true,
+																					Computed: true,
+																					PlanModifiers: []tfsdk.AttributePlanModifier{
+																						resource.UseStateForUnknown(),
+																					},
+																				},
+																				"start_timeout_ms": {
+																					// Property: StartTimeoutMs
+																					Description: "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+																					Type:        types.Int64Type,
+																					Required:    true,
+																					Validators: []tfsdk.AttributeValidator{
+																						validate.IntAtLeast(1),
+																					},
+																				},
+																			},
+																		),
+																		Optional: true,
+																		Computed: true,
+																		PlanModifiers: []tfsdk.AttributePlanModifier{
+																			resource.UseStateForUnknown(),
+																		},
+																	},
+																	"text_input_specification": {
+																		// Property: TextInputSpecification
+																		Description: "Specifies the text input specifications.",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"start_timeout_ms": {
+																					// Property: StartTimeoutMs
+																					Description: "Time for which a bot waits before re-prompting a customer for text input.",
+																					Type:        types.Int64Type,
+																					Required:    true,
+																					Validators: []tfsdk.AttributeValidator{
+																						validate.IntAtLeast(1),
+																					},
+																				},
+																			},
+																		),
+																		Optional: true,
+																		Computed: true,
+																		PlanModifiers: []tfsdk.AttributePlanModifier{
+																			resource.UseStateForUnknown(),
+																		},
+																	},
+																},
+															),
+															Optional: true,
+															Computed: true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
 													},
 												),
 												Required: true,
@@ -7813,6 +8236,179 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 																				"Ordered",
 																			}),
 																		},
+																		PlanModifiers: []tfsdk.AttributePlanModifier{
+																			resource.UseStateForUnknown(),
+																		},
+																	},
+																	"prompt_attempts_specification": {
+																		// Property: PromptAttemptsSpecification
+																		Description: "Specifies the advanced settings on each attempt of the prompt.",
+																		// Pattern: ""
+																		Attributes: tfsdk.MapNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"allow_interrupt": {
+																					// Property: AllowInterrupt
+																					Description: "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+																					Type:        types.BoolType,
+																					Optional:    true,
+																					Computed:    true,
+																					PlanModifiers: []tfsdk.AttributePlanModifier{
+																						resource.UseStateForUnknown(),
+																					},
+																				},
+																				"allowed_input_types": {
+																					// Property: AllowedInputTypes
+																					Description: "Specifies the allowed input types.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"allow_audio_input": {
+																								// Property: AllowAudioInput
+																								Description: "Indicates whether audio input is allowed.",
+																								Type:        types.BoolType,
+																								Required:    true,
+																							},
+																							"allow_dtmf_input": {
+																								// Property: AllowDTMFInput
+																								Description: "Indicates whether DTMF input is allowed.",
+																								Type:        types.BoolType,
+																								Required:    true,
+																							},
+																						},
+																					),
+																					Optional: true,
+																					Computed: true,
+																					PlanModifiers: []tfsdk.AttributePlanModifier{
+																						resource.UseStateForUnknown(),
+																					},
+																				},
+																				"audio_and_dtmf_input_specification": {
+																					// Property: AudioAndDTMFInputSpecification
+																					Description: "Specifies the audio and DTMF input specification.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"audio_specification": {
+																								// Property: AudioSpecification
+																								Description: "Specifies the audio input specifications.",
+																								Attributes: tfsdk.SingleNestedAttributes(
+																									map[string]tfsdk.Attribute{
+																										"end_timeout_ms": {
+																											// Property: EndTimeoutMs
+																											Description: "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+																											Type:        types.Int64Type,
+																											Required:    true,
+																											Validators: []tfsdk.AttributeValidator{
+																												validate.IntAtLeast(1),
+																											},
+																										},
+																										"max_length_ms": {
+																											// Property: MaxLengthMs
+																											Description: "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+																											Type:        types.Int64Type,
+																											Required:    true,
+																											Validators: []tfsdk.AttributeValidator{
+																												validate.IntAtLeast(1),
+																											},
+																										},
+																									},
+																								),
+																								Optional: true,
+																								Computed: true,
+																								PlanModifiers: []tfsdk.AttributePlanModifier{
+																									resource.UseStateForUnknown(),
+																								},
+																							},
+																							"dtmf_specification": {
+																								// Property: DTMFSpecification
+																								Description: "Specifies the settings on DTMF input.",
+																								Attributes: tfsdk.SingleNestedAttributes(
+																									map[string]tfsdk.Attribute{
+																										"deletion_character": {
+																											// Property: DeletionCharacter
+																											Description: "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+																											Type:        types.StringType,
+																											Required:    true,
+																											Validators: []tfsdk.AttributeValidator{
+																												validate.StringMatch(regexp.MustCompile("^[A-D0-9#*]{1}$"), ""),
+																											},
+																										},
+																										"end_character": {
+																											// Property: EndCharacter
+																											Description: "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+																											Type:        types.StringType,
+																											Required:    true,
+																											Validators: []tfsdk.AttributeValidator{
+																												validate.StringMatch(regexp.MustCompile("^[A-D0-9#*]{1}$"), ""),
+																											},
+																										},
+																										"end_timeout_ms": {
+																											// Property: EndTimeoutMs
+																											Description: "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+																											Type:        types.Int64Type,
+																											Required:    true,
+																											Validators: []tfsdk.AttributeValidator{
+																												validate.IntAtLeast(1),
+																											},
+																										},
+																										"max_length": {
+																											// Property: MaxLength
+																											Description: "The maximum number of DTMF digits allowed in an utterance.",
+																											Type:        types.Int64Type,
+																											Required:    true,
+																											Validators: []tfsdk.AttributeValidator{
+																												validate.IntBetween(1, 1024),
+																											},
+																										},
+																									},
+																								),
+																								Optional: true,
+																								Computed: true,
+																								PlanModifiers: []tfsdk.AttributePlanModifier{
+																									resource.UseStateForUnknown(),
+																								},
+																							},
+																							"start_timeout_ms": {
+																								// Property: StartTimeoutMs
+																								Description: "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+																								Type:        types.Int64Type,
+																								Required:    true,
+																								Validators: []tfsdk.AttributeValidator{
+																									validate.IntAtLeast(1),
+																								},
+																							},
+																						},
+																					),
+																					Optional: true,
+																					Computed: true,
+																					PlanModifiers: []tfsdk.AttributePlanModifier{
+																						resource.UseStateForUnknown(),
+																					},
+																				},
+																				"text_input_specification": {
+																					// Property: TextInputSpecification
+																					Description: "Specifies the text input specifications.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"start_timeout_ms": {
+																								// Property: StartTimeoutMs
+																								Description: "Time for which a bot waits before re-prompting a customer for text input.",
+																								Type:        types.Int64Type,
+																								Required:    true,
+																								Validators: []tfsdk.AttributeValidator{
+																									validate.IntAtLeast(1),
+																								},
+																							},
+																						},
+																					),
+																					Optional: true,
+																					Computed: true,
+																					PlanModifiers: []tfsdk.AttributePlanModifier{
+																						resource.UseStateForUnknown(),
+																					},
+																				},
+																			},
+																		),
+																		Optional: true,
+																		Computed: true,
 																		PlanModifiers: []tfsdk.AttributePlanModifier{
 																			resource.UseStateForUnknown(),
 																		},
@@ -10074,11 +10670,16 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"active":                                "Active",
 		"advanced_recognition_setting":          "AdvancedRecognitionSetting",
+		"allow_audio_input":                     "AllowAudioInput",
+		"allow_dtmf_input":                      "AllowDTMFInput",
 		"allow_interrupt":                       "AllowInterrupt",
 		"allow_multiple_values":                 "AllowMultipleValues",
+		"allowed_input_types":                   "AllowedInputTypes",
 		"arn":                                   "Arn",
+		"audio_and_dtmf_input_specification":    "AudioAndDTMFInputSpecification",
 		"audio_log_settings":                    "AudioLogSettings",
 		"audio_recognition_strategy":            "AudioRecognitionStrategy",
+		"audio_specification":                   "AudioSpecification",
 		"auto_build_bot_locales":                "AutoBuildBotLocales",
 		"bot_alias_locale_setting":              "BotAliasLocaleSetting",
 		"bot_alias_locale_settings":             "BotAliasLocaleSettings",
@@ -10103,11 +10704,15 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 		"default_value_list":                    "DefaultValueList",
 		"default_value_specification":           "DefaultValueSpecification",
 		"delay_in_seconds":                      "DelayInSeconds",
+		"deletion_character":                    "DeletionCharacter",
 		"description":                           "Description",
 		"destination":                           "Destination",
 		"detect_sentiment":                      "DetectSentiment",
 		"dialog_code_hook":                      "DialogCodeHook",
+		"dtmf_specification":                    "DTMFSpecification",
 		"enabled":                               "Enabled",
+		"end_character":                         "EndCharacter",
+		"end_timeout_ms":                        "EndTimeoutMs",
 		"engine":                                "Engine",
 		"external_source_setting":               "ExternalSourceSetting",
 		"failure_response":                      "FailureResponse",
@@ -10132,6 +10737,8 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 		"lambda_code_hook":                      "LambdaCodeHook",
 		"locale_id":                             "LocaleId",
 		"log_prefix":                            "LogPrefix",
+		"max_length":                            "MaxLength",
+		"max_length_ms":                         "MaxLengthMs",
 		"max_retries":                           "MaxRetries",
 		"message":                               "Message",
 		"message_groups":                        "MessageGroups",
@@ -10150,6 +10757,7 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 		"plain_text_message":                    "PlainTextMessage",
 		"post_fulfillment_status_specification": "PostFulfillmentStatusSpecification",
 		"priority":                              "Priority",
+		"prompt_attempts_specification":         "PromptAttemptsSpecification",
 		"prompt_specification":                  "PromptSpecification",
 		"query_filter_string":                   "QueryFilterString",
 		"query_filter_string_enabled":           "QueryFilterStringEnabled",
@@ -10174,6 +10782,7 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 		"source":                                "Source",
 		"ssml_message":                          "SSMLMessage",
 		"start_response":                        "StartResponse",
+		"start_timeout_ms":                      "StartTimeoutMs",
 		"still_waiting_response":                "StillWaitingResponse",
 		"subtitle":                              "Subtitle",
 		"success_response":                      "SuccessResponse",
@@ -10181,6 +10790,7 @@ func botResource(ctx context.Context) (resource.Resource, error) {
 		"test_bot_alias_settings":               "TestBotAliasSettings",
 		"test_bot_alias_tags":                   "TestBotAliasTags",
 		"text":                                  "Text",
+		"text_input_specification":              "TextInputSpecification",
 		"text_log_settings":                     "TextLogSettings",
 		"time_to_live_in_seconds":               "TimeToLiveInSeconds",
 		"timeout_in_seconds":                    "TimeoutInSeconds",

--- a/internal/aws/lex/bot_singular_data_source_gen.go
+++ b/internal/aws/lex/bot_singular_data_source_gen.go
@@ -2372,6 +2372,131 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 			//                         "Ordered"
 			//                       ],
 			//                       "type": "string"
+			//                     },
+			//                     "PromptAttemptsSpecification": {
+			//                       "additionalProperties": false,
+			//                       "description": "Specifies the advanced settings on each attempt of the prompt.",
+			//                       "patternProperties": {
+			//                         "": {
+			//                           "additionalProperties": false,
+			//                           "description": "Specifies the settings on a prompt attempt.",
+			//                           "properties": {
+			//                             "AllowInterrupt": {
+			//                               "description": "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+			//                               "type": "boolean"
+			//                             },
+			//                             "AllowedInputTypes": {
+			//                               "additionalProperties": false,
+			//                               "description": "Specifies the allowed input types.",
+			//                               "properties": {
+			//                                 "AllowAudioInput": {
+			//                                   "description": "Indicates whether audio input is allowed.",
+			//                                   "type": "boolean"
+			//                                 },
+			//                                 "AllowDTMFInput": {
+			//                                   "description": "Indicates whether DTMF input is allowed.",
+			//                                   "type": "boolean"
+			//                                 }
+			//                               },
+			//                               "required": [
+			//                                 "AllowAudioInput",
+			//                                 "AllowDTMFInput"
+			//                               ],
+			//                               "type": "object"
+			//                             },
+			//                             "AudioAndDTMFInputSpecification": {
+			//                               "additionalProperties": false,
+			//                               "description": "Specifies the audio and DTMF input specification.",
+			//                               "properties": {
+			//                                 "AudioSpecification": {
+			//                                   "additionalProperties": false,
+			//                                   "description": "Specifies the audio input specifications.",
+			//                                   "properties": {
+			//                                     "EndTimeoutMs": {
+			//                                       "description": "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+			//                                       "minimum": 1,
+			//                                       "type": "integer"
+			//                                     },
+			//                                     "MaxLengthMs": {
+			//                                       "description": "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+			//                                       "minimum": 1,
+			//                                       "type": "integer"
+			//                                     }
+			//                                   },
+			//                                   "required": [
+			//                                     "EndTimeoutMs",
+			//                                     "MaxLengthMs"
+			//                                   ],
+			//                                   "type": "object"
+			//                                 },
+			//                                 "DTMFSpecification": {
+			//                                   "additionalProperties": false,
+			//                                   "description": "Specifies the settings on DTMF input.",
+			//                                   "properties": {
+			//                                     "DeletionCharacter": {
+			//                                       "description": "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+			//                                       "pattern": "^[A-D0-9#*]{1}$",
+			//                                       "type": "string"
+			//                                     },
+			//                                     "EndCharacter": {
+			//                                       "description": "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+			//                                       "pattern": "^[A-D0-9#*]{1}$",
+			//                                       "type": "string"
+			//                                     },
+			//                                     "EndTimeoutMs": {
+			//                                       "description": "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+			//                                       "minimum": 1,
+			//                                       "type": "integer"
+			//                                     },
+			//                                     "MaxLength": {
+			//                                       "description": "The maximum number of DTMF digits allowed in an utterance.",
+			//                                       "maximum": 1024,
+			//                                       "minimum": 1,
+			//                                       "type": "integer"
+			//                                     }
+			//                                   },
+			//                                   "required": [
+			//                                     "DeletionCharacter",
+			//                                     "EndCharacter",
+			//                                     "EndTimeoutMs",
+			//                                     "MaxLength"
+			//                                   ],
+			//                                   "type": "object"
+			//                                 },
+			//                                 "StartTimeoutMs": {
+			//                                   "description": "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+			//                                   "minimum": 1,
+			//                                   "type": "integer"
+			//                                 }
+			//                               },
+			//                               "required": [
+			//                                 "StartTimeoutMs"
+			//                               ],
+			//                               "type": "object"
+			//                             },
+			//                             "TextInputSpecification": {
+			//                               "additionalProperties": false,
+			//                               "description": "Specifies the text input specifications.",
+			//                               "properties": {
+			//                                 "StartTimeoutMs": {
+			//                                   "description": "Time for which a bot waits before re-prompting a customer for text input.",
+			//                                   "minimum": 1,
+			//                                   "type": "integer"
+			//                                 }
+			//                               },
+			//                               "required": [
+			//                                 "StartTimeoutMs"
+			//                               ],
+			//                               "type": "object"
+			//                             }
+			//                           },
+			//                           "required": [
+			//                             "AllowedInputTypes"
+			//                           ],
+			//                           "type": "object"
+			//                         }
+			//                       },
+			//                       "type": "object"
 			//                     }
 			//                   },
 			//                   "required": [
@@ -2865,6 +2990,131 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 			//                               "Ordered"
 			//                             ],
 			//                             "type": "string"
+			//                           },
+			//                           "PromptAttemptsSpecification": {
+			//                             "additionalProperties": false,
+			//                             "description": "Specifies the advanced settings on each attempt of the prompt.",
+			//                             "patternProperties": {
+			//                               "": {
+			//                                 "additionalProperties": false,
+			//                                 "description": "Specifies the settings on a prompt attempt.",
+			//                                 "properties": {
+			//                                   "AllowInterrupt": {
+			//                                     "description": "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+			//                                     "type": "boolean"
+			//                                   },
+			//                                   "AllowedInputTypes": {
+			//                                     "additionalProperties": false,
+			//                                     "description": "Specifies the allowed input types.",
+			//                                     "properties": {
+			//                                       "AllowAudioInput": {
+			//                                         "description": "Indicates whether audio input is allowed.",
+			//                                         "type": "boolean"
+			//                                       },
+			//                                       "AllowDTMFInput": {
+			//                                         "description": "Indicates whether DTMF input is allowed.",
+			//                                         "type": "boolean"
+			//                                       }
+			//                                     },
+			//                                     "required": [
+			//                                       "AllowAudioInput",
+			//                                       "AllowDTMFInput"
+			//                                     ],
+			//                                     "type": "object"
+			//                                   },
+			//                                   "AudioAndDTMFInputSpecification": {
+			//                                     "additionalProperties": false,
+			//                                     "description": "Specifies the audio and DTMF input specification.",
+			//                                     "properties": {
+			//                                       "AudioSpecification": {
+			//                                         "additionalProperties": false,
+			//                                         "description": "Specifies the audio input specifications.",
+			//                                         "properties": {
+			//                                           "EndTimeoutMs": {
+			//                                             "description": "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+			//                                             "minimum": 1,
+			//                                             "type": "integer"
+			//                                           },
+			//                                           "MaxLengthMs": {
+			//                                             "description": "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+			//                                             "minimum": 1,
+			//                                             "type": "integer"
+			//                                           }
+			//                                         },
+			//                                         "required": [
+			//                                           "EndTimeoutMs",
+			//                                           "MaxLengthMs"
+			//                                         ],
+			//                                         "type": "object"
+			//                                       },
+			//                                       "DTMFSpecification": {
+			//                                         "additionalProperties": false,
+			//                                         "description": "Specifies the settings on DTMF input.",
+			//                                         "properties": {
+			//                                           "DeletionCharacter": {
+			//                                             "description": "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+			//                                             "pattern": "^[A-D0-9#*]{1}$",
+			//                                             "type": "string"
+			//                                           },
+			//                                           "EndCharacter": {
+			//                                             "description": "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+			//                                             "pattern": "^[A-D0-9#*]{1}$",
+			//                                             "type": "string"
+			//                                           },
+			//                                           "EndTimeoutMs": {
+			//                                             "description": "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+			//                                             "minimum": 1,
+			//                                             "type": "integer"
+			//                                           },
+			//                                           "MaxLength": {
+			//                                             "description": "The maximum number of DTMF digits allowed in an utterance.",
+			//                                             "maximum": 1024,
+			//                                             "minimum": 1,
+			//                                             "type": "integer"
+			//                                           }
+			//                                         },
+			//                                         "required": [
+			//                                           "DeletionCharacter",
+			//                                           "EndCharacter",
+			//                                           "EndTimeoutMs",
+			//                                           "MaxLength"
+			//                                         ],
+			//                                         "type": "object"
+			//                                       },
+			//                                       "StartTimeoutMs": {
+			//                                         "description": "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+			//                                         "minimum": 1,
+			//                                         "type": "integer"
+			//                                       }
+			//                                     },
+			//                                     "required": [
+			//                                       "StartTimeoutMs"
+			//                                     ],
+			//                                     "type": "object"
+			//                                   },
+			//                                   "TextInputSpecification": {
+			//                                     "additionalProperties": false,
+			//                                     "description": "Specifies the text input specifications.",
+			//                                     "properties": {
+			//                                       "StartTimeoutMs": {
+			//                                         "description": "Time for which a bot waits before re-prompting a customer for text input.",
+			//                                         "minimum": 1,
+			//                                         "type": "integer"
+			//                                       }
+			//                                     },
+			//                                     "required": [
+			//                                       "StartTimeoutMs"
+			//                                     ],
+			//                                     "type": "object"
+			//                                   }
+			//                                 },
+			//                                 "required": [
+			//                                   "AllowedInputTypes"
+			//                                 ],
+			//                                 "type": "object"
+			//                               }
+			//                             },
+			//                             "type": "object"
 			//                           }
 			//                         },
 			//                         "required": [
@@ -5952,6 +6202,127 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 															Type:        types.StringType,
 															Computed:    true,
 														},
+														"prompt_attempts_specification": {
+															// Property: PromptAttemptsSpecification
+															Description: "Specifies the advanced settings on each attempt of the prompt.",
+															// Pattern: ""
+															Attributes: tfsdk.MapNestedAttributes(
+																map[string]tfsdk.Attribute{
+																	"allow_interrupt": {
+																		// Property: AllowInterrupt
+																		Description: "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+																		Type:        types.BoolType,
+																		Computed:    true,
+																	},
+																	"allowed_input_types": {
+																		// Property: AllowedInputTypes
+																		Description: "Specifies the allowed input types.",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"allow_audio_input": {
+																					// Property: AllowAudioInput
+																					Description: "Indicates whether audio input is allowed.",
+																					Type:        types.BoolType,
+																					Computed:    true,
+																				},
+																				"allow_dtmf_input": {
+																					// Property: AllowDTMFInput
+																					Description: "Indicates whether DTMF input is allowed.",
+																					Type:        types.BoolType,
+																					Computed:    true,
+																				},
+																			},
+																		),
+																		Computed: true,
+																	},
+																	"audio_and_dtmf_input_specification": {
+																		// Property: AudioAndDTMFInputSpecification
+																		Description: "Specifies the audio and DTMF input specification.",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"audio_specification": {
+																					// Property: AudioSpecification
+																					Description: "Specifies the audio input specifications.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"end_timeout_ms": {
+																								// Property: EndTimeoutMs
+																								Description: "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+																								Type:        types.Int64Type,
+																								Computed:    true,
+																							},
+																							"max_length_ms": {
+																								// Property: MaxLengthMs
+																								Description: "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+																								Type:        types.Int64Type,
+																								Computed:    true,
+																							},
+																						},
+																					),
+																					Computed: true,
+																				},
+																				"dtmf_specification": {
+																					// Property: DTMFSpecification
+																					Description: "Specifies the settings on DTMF input.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"deletion_character": {
+																								// Property: DeletionCharacter
+																								Description: "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+																								Type:        types.StringType,
+																								Computed:    true,
+																							},
+																							"end_character": {
+																								// Property: EndCharacter
+																								Description: "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+																								Type:        types.StringType,
+																								Computed:    true,
+																							},
+																							"end_timeout_ms": {
+																								// Property: EndTimeoutMs
+																								Description: "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+																								Type:        types.Int64Type,
+																								Computed:    true,
+																							},
+																							"max_length": {
+																								// Property: MaxLength
+																								Description: "The maximum number of DTMF digits allowed in an utterance.",
+																								Type:        types.Int64Type,
+																								Computed:    true,
+																							},
+																						},
+																					),
+																					Computed: true,
+																				},
+																				"start_timeout_ms": {
+																					// Property: StartTimeoutMs
+																					Description: "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+																					Type:        types.Int64Type,
+																					Computed:    true,
+																				},
+																			},
+																		),
+																		Computed: true,
+																	},
+																	"text_input_specification": {
+																		// Property: TextInputSpecification
+																		Description: "Specifies the text input specifications.",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"start_timeout_ms": {
+																					// Property: StartTimeoutMs
+																					Description: "Time for which a bot waits before re-prompting a customer for text input.",
+																					Type:        types.Int64Type,
+																					Computed:    true,
+																				},
+																			},
+																		),
+																		Computed: true,
+																	},
+																},
+															),
+															Computed: true,
+														},
 													},
 												),
 												Computed: true,
@@ -6378,6 +6749,127 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 																		Description: "Indicates how a message is selected from a message group among retries.",
 																		Type:        types.StringType,
 																		Computed:    true,
+																	},
+																	"prompt_attempts_specification": {
+																		// Property: PromptAttemptsSpecification
+																		Description: "Specifies the advanced settings on each attempt of the prompt.",
+																		// Pattern: ""
+																		Attributes: tfsdk.MapNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"allow_interrupt": {
+																					// Property: AllowInterrupt
+																					Description: "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+																					Type:        types.BoolType,
+																					Computed:    true,
+																				},
+																				"allowed_input_types": {
+																					// Property: AllowedInputTypes
+																					Description: "Specifies the allowed input types.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"allow_audio_input": {
+																								// Property: AllowAudioInput
+																								Description: "Indicates whether audio input is allowed.",
+																								Type:        types.BoolType,
+																								Computed:    true,
+																							},
+																							"allow_dtmf_input": {
+																								// Property: AllowDTMFInput
+																								Description: "Indicates whether DTMF input is allowed.",
+																								Type:        types.BoolType,
+																								Computed:    true,
+																							},
+																						},
+																					),
+																					Computed: true,
+																				},
+																				"audio_and_dtmf_input_specification": {
+																					// Property: AudioAndDTMFInputSpecification
+																					Description: "Specifies the audio and DTMF input specification.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"audio_specification": {
+																								// Property: AudioSpecification
+																								Description: "Specifies the audio input specifications.",
+																								Attributes: tfsdk.SingleNestedAttributes(
+																									map[string]tfsdk.Attribute{
+																										"end_timeout_ms": {
+																											// Property: EndTimeoutMs
+																											Description: "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+																											Type:        types.Int64Type,
+																											Computed:    true,
+																										},
+																										"max_length_ms": {
+																											// Property: MaxLengthMs
+																											Description: "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+																											Type:        types.Int64Type,
+																											Computed:    true,
+																										},
+																									},
+																								),
+																								Computed: true,
+																							},
+																							"dtmf_specification": {
+																								// Property: DTMFSpecification
+																								Description: "Specifies the settings on DTMF input.",
+																								Attributes: tfsdk.SingleNestedAttributes(
+																									map[string]tfsdk.Attribute{
+																										"deletion_character": {
+																											// Property: DeletionCharacter
+																											Description: "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+																											Type:        types.StringType,
+																											Computed:    true,
+																										},
+																										"end_character": {
+																											// Property: EndCharacter
+																											Description: "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+																											Type:        types.StringType,
+																											Computed:    true,
+																										},
+																										"end_timeout_ms": {
+																											// Property: EndTimeoutMs
+																											Description: "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+																											Type:        types.Int64Type,
+																											Computed:    true,
+																										},
+																										"max_length": {
+																											// Property: MaxLength
+																											Description: "The maximum number of DTMF digits allowed in an utterance.",
+																											Type:        types.Int64Type,
+																											Computed:    true,
+																										},
+																									},
+																								),
+																								Computed: true,
+																							},
+																							"start_timeout_ms": {
+																								// Property: StartTimeoutMs
+																								Description: "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+																								Type:        types.Int64Type,
+																								Computed:    true,
+																							},
+																						},
+																					),
+																					Computed: true,
+																				},
+																				"text_input_specification": {
+																					// Property: TextInputSpecification
+																					Description: "Specifies the text input specifications.",
+																					Attributes: tfsdk.SingleNestedAttributes(
+																						map[string]tfsdk.Attribute{
+																							"start_timeout_ms": {
+																								// Property: StartTimeoutMs
+																								Description: "Time for which a bot waits before re-prompting a customer for text input.",
+																								Type:        types.Int64Type,
+																								Computed:    true,
+																							},
+																						},
+																					),
+																					Computed: true,
+																				},
+																			},
+																		),
+																		Computed: true,
 																	},
 																},
 															),
@@ -7957,11 +8449,16 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"active":                                "Active",
 		"advanced_recognition_setting":          "AdvancedRecognitionSetting",
+		"allow_audio_input":                     "AllowAudioInput",
+		"allow_dtmf_input":                      "AllowDTMFInput",
 		"allow_interrupt":                       "AllowInterrupt",
 		"allow_multiple_values":                 "AllowMultipleValues",
+		"allowed_input_types":                   "AllowedInputTypes",
 		"arn":                                   "Arn",
+		"audio_and_dtmf_input_specification":    "AudioAndDTMFInputSpecification",
 		"audio_log_settings":                    "AudioLogSettings",
 		"audio_recognition_strategy":            "AudioRecognitionStrategy",
+		"audio_specification":                   "AudioSpecification",
 		"auto_build_bot_locales":                "AutoBuildBotLocales",
 		"bot_alias_locale_setting":              "BotAliasLocaleSetting",
 		"bot_alias_locale_settings":             "BotAliasLocaleSettings",
@@ -7986,11 +8483,15 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"default_value_list":                    "DefaultValueList",
 		"default_value_specification":           "DefaultValueSpecification",
 		"delay_in_seconds":                      "DelayInSeconds",
+		"deletion_character":                    "DeletionCharacter",
 		"description":                           "Description",
 		"destination":                           "Destination",
 		"detect_sentiment":                      "DetectSentiment",
 		"dialog_code_hook":                      "DialogCodeHook",
+		"dtmf_specification":                    "DTMFSpecification",
 		"enabled":                               "Enabled",
+		"end_character":                         "EndCharacter",
+		"end_timeout_ms":                        "EndTimeoutMs",
 		"engine":                                "Engine",
 		"external_source_setting":               "ExternalSourceSetting",
 		"failure_response":                      "FailureResponse",
@@ -8015,6 +8516,8 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"lambda_code_hook":                      "LambdaCodeHook",
 		"locale_id":                             "LocaleId",
 		"log_prefix":                            "LogPrefix",
+		"max_length":                            "MaxLength",
+		"max_length_ms":                         "MaxLengthMs",
 		"max_retries":                           "MaxRetries",
 		"message":                               "Message",
 		"message_groups":                        "MessageGroups",
@@ -8033,6 +8536,7 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"plain_text_message":                    "PlainTextMessage",
 		"post_fulfillment_status_specification": "PostFulfillmentStatusSpecification",
 		"priority":                              "Priority",
+		"prompt_attempts_specification":         "PromptAttemptsSpecification",
 		"prompt_specification":                  "PromptSpecification",
 		"query_filter_string":                   "QueryFilterString",
 		"query_filter_string_enabled":           "QueryFilterStringEnabled",
@@ -8057,6 +8561,7 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"source":                                "Source",
 		"ssml_message":                          "SSMLMessage",
 		"start_response":                        "StartResponse",
+		"start_timeout_ms":                      "StartTimeoutMs",
 		"still_waiting_response":                "StillWaitingResponse",
 		"subtitle":                              "Subtitle",
 		"success_response":                      "SuccessResponse",
@@ -8064,6 +8569,7 @@ func botDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"test_bot_alias_settings":               "TestBotAliasSettings",
 		"test_bot_alias_tags":                   "TestBotAliasTags",
 		"text":                                  "Text",
+		"text_input_specification":              "TextInputSpecification",
 		"text_log_settings":                     "TextLogSettings",
 		"time_to_live_in_seconds":               "TimeToLiveInSeconds",
 		"timeout_in_seconds":                    "TimeoutInSeconds",

--- a/internal/aws/msk/cluster_resource_gen.go
+++ b/internal/aws/msk/cluster_resource_gen.go
@@ -932,6 +932,32 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 				resource.UseStateForUnknown(),
 			},
 		},
+		"storage_mode": {
+			// Property: StorageMode
+			// CloudFormation resource type schema:
+			// {
+			//   "enum": [
+			//     "LOCAL",
+			//     "TIERED"
+			//   ],
+			//   "maxLength": 6,
+			//   "minLength": 5,
+			//   "type": "string"
+			// }
+			Type:     types.StringType,
+			Optional: true,
+			Computed: true,
+			Validators: []tfsdk.AttributeValidator{
+				validate.StringLenBetween(5, 6),
+				validate.StringInSlice([]string{
+					"LOCAL",
+					"TIERED",
+				}),
+			},
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				resource.UseStateForUnknown(),
+			},
+		},
 		"tags": {
 			// Property: Tags
 			// CloudFormation resource type schema:
@@ -1022,6 +1048,7 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		"scram":                          "Scram",
 		"security_groups":                "SecurityGroups",
 		"storage_info":                   "StorageInfo",
+		"storage_mode":                   "StorageMode",
 		"tags":                           "Tags",
 		"tls":                            "Tls",
 		"type":                           "Type",

--- a/internal/aws/msk/cluster_singular_data_source_gen.go
+++ b/internal/aws/msk/cluster_singular_data_source_gen.go
@@ -729,6 +729,21 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 			),
 			Computed: true,
 		},
+		"storage_mode": {
+			// Property: StorageMode
+			// CloudFormation resource type schema:
+			// {
+			//   "enum": [
+			//     "LOCAL",
+			//     "TIERED"
+			//   ],
+			//   "maxLength": 6,
+			//   "minLength": 5,
+			//   "type": "string"
+			// }
+			Type:     types.StringType,
+			Computed: true,
+		},
 		"tags": {
 			// Property: Tags
 			// CloudFormation resource type schema:
@@ -810,6 +825,7 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"scram":                          "Scram",
 		"security_groups":                "SecurityGroups",
 		"storage_info":                   "StorageInfo",
+		"storage_mode":                   "StorageMode",
 		"tags":                           "Tags",
 		"tls":                            "Tls",
 		"type":                           "Type",

--- a/internal/aws/redshift/endpoint_access_resource_gen.go
+++ b/internal/aws/redshift/endpoint_access_resource_gen.go
@@ -249,7 +249,6 @@ func endpointAccessResource(ctx context.Context) (resource.Resource, error) {
 						// Property: VpcEndpointId
 						Description: "The connection endpoint ID for connecting an Amazon Redshift cluster through the proxy.",
 						Type:        types.StringType,
-						Optional:    true,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							resource.UseStateForUnknown(),
@@ -259,7 +258,6 @@ func endpointAccessResource(ctx context.Context) (resource.Resource, error) {
 						// Property: VpcId
 						Description: "The VPC identifier that the endpoint is associated.",
 						Type:        types.StringType,
-						Optional:    true,
 						Computed:    true,
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							resource.UseStateForUnknown(),
@@ -267,6 +265,7 @@ func endpointAccessResource(ctx context.Context) (resource.Resource, error) {
 					},
 				},
 			),
+			Optional: true,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				resource.UseStateForUnknown(),
@@ -338,6 +337,7 @@ func endpointAccessResource(ctx context.Context) (resource.Resource, error) {
 					},
 				},
 			),
+			Optional: true,
 			Computed: true,
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				Multiset(),

--- a/internal/aws/sagemaker/data_quality_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/data_quality_job_definition_resource_gen.go
@@ -321,6 +321,76 @@ func dataQualityJobDefinitionResource(ctx context.Context) (resource.Resource, e
 			//   "additionalProperties": false,
 			//   "description": "The inputs for a monitoring job.",
 			//   "properties": {
+			//     "BatchTransformInput": {
+			//       "additionalProperties": false,
+			//       "description": "The batch transform input for a monitoring job.",
+			//       "properties": {
+			//         "DataCapturedDestinationS3Uri": {
+			//           "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//           "maxLength": 512,
+			//           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//           "type": "string"
+			//         },
+			//         "DatasetFormat": {
+			//           "description": "The dataset format of the data to monitor",
+			//           "properties": {
+			//             "Csv": {
+			//               "description": "The CSV format",
+			//               "properties": {
+			//                 "Header": {
+			//                   "description": "A boolean flag indicating if given CSV has header",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Json": {
+			//               "description": "The Json format",
+			//               "properties": {
+			//                 "Line": {
+			//                   "description": "A boolean flag indicating if it is JSON line format",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Parquet": {
+			//               "description": "A flag indicate if the dataset format is Parquet",
+			//               "type": "boolean"
+			//             }
+			//           },
+			//           "type": "object"
+			//         },
+			//         "LocalPath": {
+			//           "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//           "maxLength": 256,
+			//           "pattern": ".*",
+			//           "type": "string"
+			//         },
+			//         "S3DataDistributionType": {
+			//           "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//           "enum": [
+			//             "FullyReplicated",
+			//             "ShardedByS3Key"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "S3InputMode": {
+			//           "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//           "enum": [
+			//             "Pipe",
+			//             "File"
+			//           ],
+			//           "type": "string"
+			//         }
+			//       },
+			//       "required": [
+			//         "DataCapturedDestinationS3Uri",
+			//         "DatasetFormat",
+			//         "LocalPath"
+			//       ],
+			//       "type": "object"
+			//     },
 			//     "EndpointInput": {
 			//       "additionalProperties": false,
 			//       "description": "The endpoint for a monitoring job.",
@@ -361,14 +431,141 @@ func dataQualityJobDefinitionResource(ctx context.Context) (resource.Resource, e
 			//       "type": "object"
 			//     }
 			//   },
-			//   "required": [
-			//     "EndpointInput"
-			//   ],
 			//   "type": "object"
 			// }
 			Description: "The inputs for a monitoring job.",
 			Attributes: tfsdk.SingleNestedAttributes(
 				map[string]tfsdk.Attribute{
+					"batch_transform_input": {
+						// Property: BatchTransformInput
+						Description: "The batch transform input for a monitoring job.",
+						Attributes: tfsdk.SingleNestedAttributes(
+							map[string]tfsdk.Attribute{
+								"data_captured_destination_s3_uri": {
+									// Property: DataCapturedDestinationS3Uri
+									Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+									Type:        types.StringType,
+									Required:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(512),
+										validate.StringMatch(regexp.MustCompile("^(https|s3)://([^/]+)/?(.*)$"), ""),
+									},
+								},
+								"dataset_format": {
+									// Property: DatasetFormat
+									Description: "The dataset format of the data to monitor",
+									Attributes: tfsdk.SingleNestedAttributes(
+										map[string]tfsdk.Attribute{
+											"csv": {
+												// Property: Csv
+												Description: "The CSV format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"header": {
+															// Property: Header
+															Description: "A boolean flag indicating if given CSV has header",
+															Type:        types.BoolType,
+															Optional:    true,
+															Computed:    true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+											"json": {
+												// Property: Json
+												Description: "The Json format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"line": {
+															// Property: Line
+															Description: "A boolean flag indicating if it is JSON line format",
+															Type:        types.BoolType,
+															Optional:    true,
+															Computed:    true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+											"parquet": {
+												// Property: Parquet
+												Description: "A flag indicate if the dataset format is Parquet",
+												Type:        types.BoolType,
+												Optional:    true,
+												Computed:    true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+										},
+									),
+									Required: true,
+								},
+								"local_path": {
+									// Property: LocalPath
+									Description: "Path to the filesystem where the endpoint data is available to the container.",
+									Type:        types.StringType,
+									Required:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+										validate.StringMatch(regexp.MustCompile(".*"), ""),
+									},
+								},
+								"s3_data_distribution_type": {
+									// Property: S3DataDistributionType
+									Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringInSlice([]string{
+											"FullyReplicated",
+											"ShardedByS3Key",
+										}),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"s3_input_mode": {
+									// Property: S3InputMode
+									Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringInSlice([]string{
+											"Pipe",
+											"File",
+										}),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+							},
+						),
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
+					},
 					"endpoint_input": {
 						// Property: EndpointInput
 						Description: "The endpoint for a monitoring job.",
@@ -428,7 +625,11 @@ func dataQualityJobDefinitionResource(ctx context.Context) (resource.Resource, e
 								},
 							},
 						),
-						Required: true,
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
 					},
 				},
 			),
@@ -1010,32 +1211,40 @@ func dataQualityJobDefinitionResource(ctx context.Context) (resource.Resource, e
 	opts = opts.WithSyntheticIDAttribute(true)
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"baselining_job_name":                       "BaseliningJobName",
+		"batch_transform_input":                     "BatchTransformInput",
 		"cluster_config":                            "ClusterConfig",
 		"constraints_resource":                      "ConstraintsResource",
 		"container_arguments":                       "ContainerArguments",
 		"container_entrypoint":                      "ContainerEntrypoint",
 		"creation_time":                             "CreationTime",
+		"csv":                                       "Csv",
+		"data_captured_destination_s3_uri":          "DataCapturedDestinationS3Uri",
 		"data_quality_app_specification":            "DataQualityAppSpecification",
 		"data_quality_baseline_config":              "DataQualityBaselineConfig",
 		"data_quality_job_input":                    "DataQualityJobInput",
 		"data_quality_job_output_config":            "DataQualityJobOutputConfig",
+		"dataset_format":                            "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"endpoint_input":                            "EndpointInput",
 		"endpoint_name":                             "EndpointName",
 		"environment":                               "Environment",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"instance_count":                            "InstanceCount",
 		"instance_type":                             "InstanceType",
 		"job_definition_arn":                        "JobDefinitionArn",
 		"job_definition_name":                       "JobDefinitionName",
 		"job_resources":                             "JobResources",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"monitoring_outputs":                        "MonitoringOutputs",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"post_analytics_processor_source_uri":       "PostAnalyticsProcessorSourceUri",
 		"record_preprocessor_source_uri":            "RecordPreprocessorSourceUri",
 		"role_arn":                                  "RoleArn",

--- a/internal/aws/sagemaker/data_quality_job_definition_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/data_quality_job_definition_singular_data_source_gen.go
@@ -236,6 +236,76 @@ func dataQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSou
 			//   "additionalProperties": false,
 			//   "description": "The inputs for a monitoring job.",
 			//   "properties": {
+			//     "BatchTransformInput": {
+			//       "additionalProperties": false,
+			//       "description": "The batch transform input for a monitoring job.",
+			//       "properties": {
+			//         "DataCapturedDestinationS3Uri": {
+			//           "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//           "maxLength": 512,
+			//           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//           "type": "string"
+			//         },
+			//         "DatasetFormat": {
+			//           "description": "The dataset format of the data to monitor",
+			//           "properties": {
+			//             "Csv": {
+			//               "description": "The CSV format",
+			//               "properties": {
+			//                 "Header": {
+			//                   "description": "A boolean flag indicating if given CSV has header",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Json": {
+			//               "description": "The Json format",
+			//               "properties": {
+			//                 "Line": {
+			//                   "description": "A boolean flag indicating if it is JSON line format",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Parquet": {
+			//               "description": "A flag indicate if the dataset format is Parquet",
+			//               "type": "boolean"
+			//             }
+			//           },
+			//           "type": "object"
+			//         },
+			//         "LocalPath": {
+			//           "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//           "maxLength": 256,
+			//           "pattern": ".*",
+			//           "type": "string"
+			//         },
+			//         "S3DataDistributionType": {
+			//           "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//           "enum": [
+			//             "FullyReplicated",
+			//             "ShardedByS3Key"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "S3InputMode": {
+			//           "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//           "enum": [
+			//             "Pipe",
+			//             "File"
+			//           ],
+			//           "type": "string"
+			//         }
+			//       },
+			//       "required": [
+			//         "DataCapturedDestinationS3Uri",
+			//         "DatasetFormat",
+			//         "LocalPath"
+			//       ],
+			//       "type": "object"
+			//     },
 			//     "EndpointInput": {
 			//       "additionalProperties": false,
 			//       "description": "The endpoint for a monitoring job.",
@@ -276,14 +346,89 @@ func dataQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSou
 			//       "type": "object"
 			//     }
 			//   },
-			//   "required": [
-			//     "EndpointInput"
-			//   ],
 			//   "type": "object"
 			// }
 			Description: "The inputs for a monitoring job.",
 			Attributes: tfsdk.SingleNestedAttributes(
 				map[string]tfsdk.Attribute{
+					"batch_transform_input": {
+						// Property: BatchTransformInput
+						Description: "The batch transform input for a monitoring job.",
+						Attributes: tfsdk.SingleNestedAttributes(
+							map[string]tfsdk.Attribute{
+								"data_captured_destination_s3_uri": {
+									// Property: DataCapturedDestinationS3Uri
+									Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"dataset_format": {
+									// Property: DatasetFormat
+									Description: "The dataset format of the data to monitor",
+									Attributes: tfsdk.SingleNestedAttributes(
+										map[string]tfsdk.Attribute{
+											"csv": {
+												// Property: Csv
+												Description: "The CSV format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"header": {
+															// Property: Header
+															Description: "A boolean flag indicating if given CSV has header",
+															Type:        types.BoolType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
+											"json": {
+												// Property: Json
+												Description: "The Json format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"line": {
+															// Property: Line
+															Description: "A boolean flag indicating if it is JSON line format",
+															Type:        types.BoolType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
+											"parquet": {
+												// Property: Parquet
+												Description: "A flag indicate if the dataset format is Parquet",
+												Type:        types.BoolType,
+												Computed:    true,
+											},
+										},
+									),
+									Computed: true,
+								},
+								"local_path": {
+									// Property: LocalPath
+									Description: "Path to the filesystem where the endpoint data is available to the container.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"s3_data_distribution_type": {
+									// Property: S3DataDistributionType
+									Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"s3_input_mode": {
+									// Property: S3InputMode
+									Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+							},
+						),
+						Computed: true,
+					},
 					"endpoint_input": {
 						// Property: EndpointInput
 						Description: "The endpoint for a monitoring job.",
@@ -770,32 +915,40 @@ func dataQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSou
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"baselining_job_name":                       "BaseliningJobName",
+		"batch_transform_input":                     "BatchTransformInput",
 		"cluster_config":                            "ClusterConfig",
 		"constraints_resource":                      "ConstraintsResource",
 		"container_arguments":                       "ContainerArguments",
 		"container_entrypoint":                      "ContainerEntrypoint",
 		"creation_time":                             "CreationTime",
+		"csv":                                       "Csv",
+		"data_captured_destination_s3_uri":          "DataCapturedDestinationS3Uri",
 		"data_quality_app_specification":            "DataQualityAppSpecification",
 		"data_quality_baseline_config":              "DataQualityBaselineConfig",
 		"data_quality_job_input":                    "DataQualityJobInput",
 		"data_quality_job_output_config":            "DataQualityJobOutputConfig",
+		"dataset_format":                            "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"endpoint_input":                            "EndpointInput",
 		"endpoint_name":                             "EndpointName",
 		"environment":                               "Environment",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"instance_count":                            "InstanceCount",
 		"instance_type":                             "InstanceType",
 		"job_definition_arn":                        "JobDefinitionArn",
 		"job_definition_name":                       "JobDefinitionName",
 		"job_resources":                             "JobResources",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"monitoring_outputs":                        "MonitoringOutputs",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"post_analytics_processor_source_uri":       "PostAnalyticsProcessorSourceUri",
 		"record_preprocessor_source_uri":            "RecordPreprocessorSourceUri",
 		"role_arn":                                  "RoleArn",

--- a/internal/aws/sagemaker/model_bias_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_bias_job_definition_resource_gen.go
@@ -369,6 +369,109 @@ func modelBiasJobDefinitionResource(ctx context.Context) (resource.Resource, err
 			//   "additionalProperties": false,
 			//   "description": "The inputs for a monitoring job.",
 			//   "properties": {
+			//     "BatchTransformInput": {
+			//       "additionalProperties": false,
+			//       "description": "The batch transform input for a monitoring job.",
+			//       "properties": {
+			//         "DataCapturedDestinationS3Uri": {
+			//           "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//           "maxLength": 512,
+			//           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//           "type": "string"
+			//         },
+			//         "DatasetFormat": {
+			//           "description": "The dataset format of the data to monitor",
+			//           "properties": {
+			//             "Csv": {
+			//               "description": "The CSV format",
+			//               "properties": {
+			//                 "Header": {
+			//                   "description": "A boolean flag indicating if given CSV has header",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Json": {
+			//               "description": "The Json format",
+			//               "properties": {
+			//                 "Line": {
+			//                   "description": "A boolean flag indicating if it is JSON line format",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Parquet": {
+			//               "description": "A flag indicate if the dataset format is Parquet",
+			//               "type": "boolean"
+			//             }
+			//           },
+			//           "type": "object"
+			//         },
+			//         "EndTimeOffset": {
+			//           "description": "Monitoring end time offset, e.g. PT0H",
+			//           "maxLength": 15,
+			//           "minLength": 1,
+			//           "pattern": "^.?P.*",
+			//           "type": "string"
+			//         },
+			//         "FeaturesAttribute": {
+			//           "description": "JSONpath to locate features in JSONlines dataset",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "InferenceAttribute": {
+			//           "description": "Index or JSONpath to locate predicted label(s)",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "LocalPath": {
+			//           "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//           "maxLength": 256,
+			//           "pattern": ".*",
+			//           "type": "string"
+			//         },
+			//         "ProbabilityAttribute": {
+			//           "description": "Index or JSONpath to locate probabilities",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "ProbabilityThresholdAttribute": {
+			//           "format": "double",
+			//           "type": "number"
+			//         },
+			//         "S3DataDistributionType": {
+			//           "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//           "enum": [
+			//             "FullyReplicated",
+			//             "ShardedByS3Key"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "S3InputMode": {
+			//           "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//           "enum": [
+			//             "Pipe",
+			//             "File"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "StartTimeOffset": {
+			//           "description": "Monitoring start time offset, e.g. -PT1H",
+			//           "maxLength": 15,
+			//           "minLength": 1,
+			//           "pattern": "^.?P.*",
+			//           "type": "string"
+			//         }
+			//       },
+			//       "required": [
+			//         "DataCapturedDestinationS3Uri",
+			//         "DatasetFormat",
+			//         "LocalPath"
+			//       ],
+			//       "type": "object"
+			//     },
 			//     "EndpointInput": {
 			//       "additionalProperties": false,
 			//       "description": "The endpoint for a monitoring job.",
@@ -459,7 +562,6 @@ func modelBiasJobDefinitionResource(ctx context.Context) (resource.Resource, err
 			//     }
 			//   },
 			//   "required": [
-			//     "EndpointInput",
 			//     "GroundTruthS3Input"
 			//   ],
 			//   "type": "object"
@@ -467,6 +569,212 @@ func modelBiasJobDefinitionResource(ctx context.Context) (resource.Resource, err
 			Description: "The inputs for a monitoring job.",
 			Attributes: tfsdk.SingleNestedAttributes(
 				map[string]tfsdk.Attribute{
+					"batch_transform_input": {
+						// Property: BatchTransformInput
+						Description: "The batch transform input for a monitoring job.",
+						Attributes: tfsdk.SingleNestedAttributes(
+							map[string]tfsdk.Attribute{
+								"data_captured_destination_s3_uri": {
+									// Property: DataCapturedDestinationS3Uri
+									Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+									Type:        types.StringType,
+									Required:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(512),
+										validate.StringMatch(regexp.MustCompile("^(https|s3)://([^/]+)/?(.*)$"), ""),
+									},
+								},
+								"dataset_format": {
+									// Property: DatasetFormat
+									Description: "The dataset format of the data to monitor",
+									Attributes: tfsdk.SingleNestedAttributes(
+										map[string]tfsdk.Attribute{
+											"csv": {
+												// Property: Csv
+												Description: "The CSV format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"header": {
+															// Property: Header
+															Description: "A boolean flag indicating if given CSV has header",
+															Type:        types.BoolType,
+															Optional:    true,
+															Computed:    true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+											"json": {
+												// Property: Json
+												Description: "The Json format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"line": {
+															// Property: Line
+															Description: "A boolean flag indicating if it is JSON line format",
+															Type:        types.BoolType,
+															Optional:    true,
+															Computed:    true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+											"parquet": {
+												// Property: Parquet
+												Description: "A flag indicate if the dataset format is Parquet",
+												Type:        types.BoolType,
+												Optional:    true,
+												Computed:    true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+										},
+									),
+									Required: true,
+								},
+								"end_time_offset": {
+									// Property: EndTimeOffset
+									Description: "Monitoring end time offset, e.g. PT0H",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenBetween(1, 15),
+										validate.StringMatch(regexp.MustCompile("^.?P.*"), ""),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"features_attribute": {
+									// Property: FeaturesAttribute
+									Description: "JSONpath to locate features in JSONlines dataset",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"inference_attribute": {
+									// Property: InferenceAttribute
+									Description: "Index or JSONpath to locate predicted label(s)",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"local_path": {
+									// Property: LocalPath
+									Description: "Path to the filesystem where the endpoint data is available to the container.",
+									Type:        types.StringType,
+									Required:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+										validate.StringMatch(regexp.MustCompile(".*"), ""),
+									},
+								},
+								"probability_attribute": {
+									// Property: ProbabilityAttribute
+									Description: "Index or JSONpath to locate probabilities",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"probability_threshold_attribute": {
+									// Property: ProbabilityThresholdAttribute
+									Type:     types.Float64Type,
+									Optional: true,
+									Computed: true,
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"s3_data_distribution_type": {
+									// Property: S3DataDistributionType
+									Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringInSlice([]string{
+											"FullyReplicated",
+											"ShardedByS3Key",
+										}),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"s3_input_mode": {
+									// Property: S3InputMode
+									Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringInSlice([]string{
+											"Pipe",
+											"File",
+										}),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"start_time_offset": {
+									// Property: StartTimeOffset
+									Description: "Monitoring start time offset, e.g. -PT1H",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenBetween(1, 15),
+										validate.StringMatch(regexp.MustCompile("^.?P.*"), ""),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+							},
+						),
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
+					},
 					"endpoint_input": {
 						// Property: EndpointInput
 						Description: "The endpoint for a monitoring job.",
@@ -602,7 +910,11 @@ func modelBiasJobDefinitionResource(ctx context.Context) (resource.Resource, err
 								},
 							},
 						),
-						Required: true,
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
 					},
 					"ground_truth_s3_input": {
 						// Property: GroundTruthS3Input
@@ -1043,11 +1355,15 @@ func modelBiasJobDefinitionResource(ctx context.Context) (resource.Resource, err
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithSyntheticIDAttribute(true)
 	opts = opts.WithAttributeNameMap(map[string]string{
-		"baselining_job_name":  "BaseliningJobName",
-		"cluster_config":       "ClusterConfig",
-		"config_uri":           "ConfigUri",
-		"constraints_resource": "ConstraintsResource",
-		"creation_time":        "CreationTime",
+		"baselining_job_name":              "BaseliningJobName",
+		"batch_transform_input":            "BatchTransformInput",
+		"cluster_config":                   "ClusterConfig",
+		"config_uri":                       "ConfigUri",
+		"constraints_resource":             "ConstraintsResource",
+		"creation_time":                    "CreationTime",
+		"csv":                              "Csv",
+		"data_captured_destination_s3_uri": "DataCapturedDestinationS3Uri",
+		"dataset_format":                   "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"end_time_offset":                           "EndTimeOffset",
@@ -1056,6 +1372,7 @@ func modelBiasJobDefinitionResource(ctx context.Context) (resource.Resource, err
 		"environment":                               "Environment",
 		"features_attribute":                        "FeaturesAttribute",
 		"ground_truth_s3_input":                     "GroundTruthS3Input",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"inference_attribute":                       "InferenceAttribute",
 		"instance_count":                            "InstanceCount",
@@ -1063,8 +1380,10 @@ func modelBiasJobDefinitionResource(ctx context.Context) (resource.Resource, err
 		"job_definition_arn":                        "JobDefinitionArn",
 		"job_definition_name":                       "JobDefinitionName",
 		"job_resources":                             "JobResources",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"model_bias_app_specification":              "ModelBiasAppSpecification",
@@ -1073,6 +1392,7 @@ func modelBiasJobDefinitionResource(ctx context.Context) (resource.Resource, err
 		"model_bias_job_output_config":              "ModelBiasJobOutputConfig",
 		"monitoring_outputs":                        "MonitoringOutputs",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"probability_attribute":                     "ProbabilityAttribute",
 		"probability_threshold_attribute":           "ProbabilityThresholdAttribute",
 		"role_arn":                                  "RoleArn",

--- a/internal/aws/sagemaker/model_bias_job_definition_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/model_bias_job_definition_singular_data_source_gen.go
@@ -291,6 +291,109 @@ func modelBiasJobDefinitionDataSource(ctx context.Context) (datasource.DataSourc
 			//   "additionalProperties": false,
 			//   "description": "The inputs for a monitoring job.",
 			//   "properties": {
+			//     "BatchTransformInput": {
+			//       "additionalProperties": false,
+			//       "description": "The batch transform input for a monitoring job.",
+			//       "properties": {
+			//         "DataCapturedDestinationS3Uri": {
+			//           "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//           "maxLength": 512,
+			//           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//           "type": "string"
+			//         },
+			//         "DatasetFormat": {
+			//           "description": "The dataset format of the data to monitor",
+			//           "properties": {
+			//             "Csv": {
+			//               "description": "The CSV format",
+			//               "properties": {
+			//                 "Header": {
+			//                   "description": "A boolean flag indicating if given CSV has header",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Json": {
+			//               "description": "The Json format",
+			//               "properties": {
+			//                 "Line": {
+			//                   "description": "A boolean flag indicating if it is JSON line format",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Parquet": {
+			//               "description": "A flag indicate if the dataset format is Parquet",
+			//               "type": "boolean"
+			//             }
+			//           },
+			//           "type": "object"
+			//         },
+			//         "EndTimeOffset": {
+			//           "description": "Monitoring end time offset, e.g. PT0H",
+			//           "maxLength": 15,
+			//           "minLength": 1,
+			//           "pattern": "^.?P.*",
+			//           "type": "string"
+			//         },
+			//         "FeaturesAttribute": {
+			//           "description": "JSONpath to locate features in JSONlines dataset",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "InferenceAttribute": {
+			//           "description": "Index or JSONpath to locate predicted label(s)",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "LocalPath": {
+			//           "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//           "maxLength": 256,
+			//           "pattern": ".*",
+			//           "type": "string"
+			//         },
+			//         "ProbabilityAttribute": {
+			//           "description": "Index or JSONpath to locate probabilities",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "ProbabilityThresholdAttribute": {
+			//           "format": "double",
+			//           "type": "number"
+			//         },
+			//         "S3DataDistributionType": {
+			//           "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//           "enum": [
+			//             "FullyReplicated",
+			//             "ShardedByS3Key"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "S3InputMode": {
+			//           "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//           "enum": [
+			//             "Pipe",
+			//             "File"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "StartTimeOffset": {
+			//           "description": "Monitoring start time offset, e.g. -PT1H",
+			//           "maxLength": 15,
+			//           "minLength": 1,
+			//           "pattern": "^.?P.*",
+			//           "type": "string"
+			//         }
+			//       },
+			//       "required": [
+			//         "DataCapturedDestinationS3Uri",
+			//         "DatasetFormat",
+			//         "LocalPath"
+			//       ],
+			//       "type": "object"
+			//     },
 			//     "EndpointInput": {
 			//       "additionalProperties": false,
 			//       "description": "The endpoint for a monitoring job.",
@@ -381,7 +484,6 @@ func modelBiasJobDefinitionDataSource(ctx context.Context) (datasource.DataSourc
 			//     }
 			//   },
 			//   "required": [
-			//     "EndpointInput",
 			//     "GroundTruthS3Input"
 			//   ],
 			//   "type": "object"
@@ -389,6 +491,119 @@ func modelBiasJobDefinitionDataSource(ctx context.Context) (datasource.DataSourc
 			Description: "The inputs for a monitoring job.",
 			Attributes: tfsdk.SingleNestedAttributes(
 				map[string]tfsdk.Attribute{
+					"batch_transform_input": {
+						// Property: BatchTransformInput
+						Description: "The batch transform input for a monitoring job.",
+						Attributes: tfsdk.SingleNestedAttributes(
+							map[string]tfsdk.Attribute{
+								"data_captured_destination_s3_uri": {
+									// Property: DataCapturedDestinationS3Uri
+									Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"dataset_format": {
+									// Property: DatasetFormat
+									Description: "The dataset format of the data to monitor",
+									Attributes: tfsdk.SingleNestedAttributes(
+										map[string]tfsdk.Attribute{
+											"csv": {
+												// Property: Csv
+												Description: "The CSV format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"header": {
+															// Property: Header
+															Description: "A boolean flag indicating if given CSV has header",
+															Type:        types.BoolType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
+											"json": {
+												// Property: Json
+												Description: "The Json format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"line": {
+															// Property: Line
+															Description: "A boolean flag indicating if it is JSON line format",
+															Type:        types.BoolType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
+											"parquet": {
+												// Property: Parquet
+												Description: "A flag indicate if the dataset format is Parquet",
+												Type:        types.BoolType,
+												Computed:    true,
+											},
+										},
+									),
+									Computed: true,
+								},
+								"end_time_offset": {
+									// Property: EndTimeOffset
+									Description: "Monitoring end time offset, e.g. PT0H",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"features_attribute": {
+									// Property: FeaturesAttribute
+									Description: "JSONpath to locate features in JSONlines dataset",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"inference_attribute": {
+									// Property: InferenceAttribute
+									Description: "Index or JSONpath to locate predicted label(s)",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"local_path": {
+									// Property: LocalPath
+									Description: "Path to the filesystem where the endpoint data is available to the container.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"probability_attribute": {
+									// Property: ProbabilityAttribute
+									Description: "Index or JSONpath to locate probabilities",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"probability_threshold_attribute": {
+									// Property: ProbabilityThresholdAttribute
+									Type:     types.Float64Type,
+									Computed: true,
+								},
+								"s3_data_distribution_type": {
+									// Property: S3DataDistributionType
+									Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"s3_input_mode": {
+									// Property: S3InputMode
+									Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"start_time_offset": {
+									// Property: StartTimeOffset
+									Description: "Monitoring start time offset, e.g. -PT1H",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+							},
+						),
+						Computed: true,
+					},
 					"endpoint_input": {
 						// Property: EndpointInput
 						Description: "The endpoint for a monitoring job.",
@@ -798,11 +1013,15 @@ func modelBiasJobDefinitionDataSource(ctx context.Context) (datasource.DataSourc
 	opts = opts.WithCloudFormationTypeName("AWS::SageMaker::ModelBiasJobDefinition").WithTerraformTypeName("awscc_sagemaker_model_bias_job_definition")
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
-		"baselining_job_name":  "BaseliningJobName",
-		"cluster_config":       "ClusterConfig",
-		"config_uri":           "ConfigUri",
-		"constraints_resource": "ConstraintsResource",
-		"creation_time":        "CreationTime",
+		"baselining_job_name":              "BaseliningJobName",
+		"batch_transform_input":            "BatchTransformInput",
+		"cluster_config":                   "ClusterConfig",
+		"config_uri":                       "ConfigUri",
+		"constraints_resource":             "ConstraintsResource",
+		"creation_time":                    "CreationTime",
+		"csv":                              "Csv",
+		"data_captured_destination_s3_uri": "DataCapturedDestinationS3Uri",
+		"dataset_format":                   "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"end_time_offset":                           "EndTimeOffset",
@@ -811,6 +1030,7 @@ func modelBiasJobDefinitionDataSource(ctx context.Context) (datasource.DataSourc
 		"environment":                               "Environment",
 		"features_attribute":                        "FeaturesAttribute",
 		"ground_truth_s3_input":                     "GroundTruthS3Input",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"inference_attribute":                       "InferenceAttribute",
 		"instance_count":                            "InstanceCount",
@@ -818,8 +1038,10 @@ func modelBiasJobDefinitionDataSource(ctx context.Context) (datasource.DataSourc
 		"job_definition_arn":                        "JobDefinitionArn",
 		"job_definition_name":                       "JobDefinitionName",
 		"job_resources":                             "JobResources",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"model_bias_app_specification":              "ModelBiasAppSpecification",
@@ -828,6 +1050,7 @@ func modelBiasJobDefinitionDataSource(ctx context.Context) (datasource.DataSourc
 		"model_bias_job_output_config":              "ModelBiasJobOutputConfig",
 		"monitoring_outputs":                        "MonitoringOutputs",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"probability_attribute":                     "ProbabilityAttribute",
 		"probability_threshold_attribute":           "ProbabilityThresholdAttribute",
 		"role_arn":                                  "RoleArn",

--- a/internal/aws/sagemaker/model_explainability_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_explainability_job_definition_resource_gen.go
@@ -369,6 +369,91 @@ func modelExplainabilityJobDefinitionResource(ctx context.Context) (resource.Res
 			//   "additionalProperties": false,
 			//   "description": "The inputs for a monitoring job.",
 			//   "properties": {
+			//     "BatchTransformInput": {
+			//       "additionalProperties": false,
+			//       "description": "The batch transform input for a monitoring job.",
+			//       "properties": {
+			//         "DataCapturedDestinationS3Uri": {
+			//           "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//           "maxLength": 512,
+			//           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//           "type": "string"
+			//         },
+			//         "DatasetFormat": {
+			//           "description": "The dataset format of the data to monitor",
+			//           "properties": {
+			//             "Csv": {
+			//               "description": "The CSV format",
+			//               "properties": {
+			//                 "Header": {
+			//                   "description": "A boolean flag indicating if given CSV has header",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Json": {
+			//               "description": "The Json format",
+			//               "properties": {
+			//                 "Line": {
+			//                   "description": "A boolean flag indicating if it is JSON line format",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Parquet": {
+			//               "description": "A flag indicating if the dataset format is Parquet",
+			//               "type": "boolean"
+			//             }
+			//           },
+			//           "type": "object"
+			//         },
+			//         "FeaturesAttribute": {
+			//           "description": "JSONpath to locate features in JSONlines dataset",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "InferenceAttribute": {
+			//           "description": "Index or JSONpath to locate predicted label(s)",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "LocalPath": {
+			//           "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//           "maxLength": 256,
+			//           "pattern": ".*",
+			//           "type": "string"
+			//         },
+			//         "ProbabilityAttribute": {
+			//           "description": "Index or JSONpath to locate probabilities",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "S3DataDistributionType": {
+			//           "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//           "enum": [
+			//             "FullyReplicated",
+			//             "ShardedByS3Key"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "S3InputMode": {
+			//           "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//           "enum": [
+			//             "Pipe",
+			//             "File"
+			//           ],
+			//           "type": "string"
+			//         }
+			//       },
+			//       "required": [
+			//         "DataCapturedDestinationS3Uri",
+			//         "DatasetFormat",
+			//         "LocalPath"
+			//       ],
+			//       "type": "object"
+			//     },
 			//     "EndpointInput": {
 			//       "additionalProperties": false,
 			//       "description": "The endpoint for a monitoring job.",
@@ -424,14 +509,180 @@ func modelExplainabilityJobDefinitionResource(ctx context.Context) (resource.Res
 			//       "type": "object"
 			//     }
 			//   },
-			//   "required": [
-			//     "EndpointInput"
-			//   ],
 			//   "type": "object"
 			// }
 			Description: "The inputs for a monitoring job.",
 			Attributes: tfsdk.SingleNestedAttributes(
 				map[string]tfsdk.Attribute{
+					"batch_transform_input": {
+						// Property: BatchTransformInput
+						Description: "The batch transform input for a monitoring job.",
+						Attributes: tfsdk.SingleNestedAttributes(
+							map[string]tfsdk.Attribute{
+								"data_captured_destination_s3_uri": {
+									// Property: DataCapturedDestinationS3Uri
+									Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+									Type:        types.StringType,
+									Required:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(512),
+										validate.StringMatch(regexp.MustCompile("^(https|s3)://([^/]+)/?(.*)$"), ""),
+									},
+								},
+								"dataset_format": {
+									// Property: DatasetFormat
+									Description: "The dataset format of the data to monitor",
+									Attributes: tfsdk.SingleNestedAttributes(
+										map[string]tfsdk.Attribute{
+											"csv": {
+												// Property: Csv
+												Description: "The CSV format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"header": {
+															// Property: Header
+															Description: "A boolean flag indicating if given CSV has header",
+															Type:        types.BoolType,
+															Optional:    true,
+															Computed:    true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+											"json": {
+												// Property: Json
+												Description: "The Json format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"line": {
+															// Property: Line
+															Description: "A boolean flag indicating if it is JSON line format",
+															Type:        types.BoolType,
+															Optional:    true,
+															Computed:    true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+											"parquet": {
+												// Property: Parquet
+												Description: "A flag indicating if the dataset format is Parquet",
+												Type:        types.BoolType,
+												Optional:    true,
+												Computed:    true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+										},
+									),
+									Required: true,
+								},
+								"features_attribute": {
+									// Property: FeaturesAttribute
+									Description: "JSONpath to locate features in JSONlines dataset",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"inference_attribute": {
+									// Property: InferenceAttribute
+									Description: "Index or JSONpath to locate predicted label(s)",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"local_path": {
+									// Property: LocalPath
+									Description: "Path to the filesystem where the endpoint data is available to the container.",
+									Type:        types.StringType,
+									Required:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+										validate.StringMatch(regexp.MustCompile(".*"), ""),
+									},
+								},
+								"probability_attribute": {
+									// Property: ProbabilityAttribute
+									Description: "Index or JSONpath to locate probabilities",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"s3_data_distribution_type": {
+									// Property: S3DataDistributionType
+									Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringInSlice([]string{
+											"FullyReplicated",
+											"ShardedByS3Key",
+										}),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"s3_input_mode": {
+									// Property: S3InputMode
+									Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringInSlice([]string{
+											"Pipe",
+											"File",
+										}),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+							},
+						),
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
+					},
 					"endpoint_input": {
 						// Property: EndpointInput
 						Description: "The endpoint for a monitoring job.",
@@ -530,7 +781,11 @@ func modelExplainabilityJobDefinitionResource(ctx context.Context) (resource.Res
 								},
 							},
 						),
-						Required: true,
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
 					},
 				},
 			),
@@ -952,17 +1207,22 @@ func modelExplainabilityJobDefinitionResource(ctx context.Context) (resource.Res
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithSyntheticIDAttribute(true)
 	opts = opts.WithAttributeNameMap(map[string]string{
-		"baselining_job_name":  "BaseliningJobName",
-		"cluster_config":       "ClusterConfig",
-		"config_uri":           "ConfigUri",
-		"constraints_resource": "ConstraintsResource",
-		"creation_time":        "CreationTime",
+		"baselining_job_name":              "BaseliningJobName",
+		"batch_transform_input":            "BatchTransformInput",
+		"cluster_config":                   "ClusterConfig",
+		"config_uri":                       "ConfigUri",
+		"constraints_resource":             "ConstraintsResource",
+		"creation_time":                    "CreationTime",
+		"csv":                              "Csv",
+		"data_captured_destination_s3_uri": "DataCapturedDestinationS3Uri",
+		"dataset_format":                   "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"endpoint_input":                            "EndpointInput",
 		"endpoint_name":                             "EndpointName",
 		"environment":                               "Environment",
 		"features_attribute":                        "FeaturesAttribute",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"inference_attribute":                       "InferenceAttribute",
 		"instance_count":                            "InstanceCount",
@@ -970,8 +1230,10 @@ func modelExplainabilityJobDefinitionResource(ctx context.Context) (resource.Res
 		"job_definition_arn":                        "JobDefinitionArn",
 		"job_definition_name":                       "JobDefinitionName",
 		"job_resources":                             "JobResources",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"model_explainability_app_specification":    "ModelExplainabilityAppSpecification",
@@ -980,6 +1242,7 @@ func modelExplainabilityJobDefinitionResource(ctx context.Context) (resource.Res
 		"model_explainability_job_output_config":    "ModelExplainabilityJobOutputConfig",
 		"monitoring_outputs":                        "MonitoringOutputs",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"probability_attribute":                     "ProbabilityAttribute",
 		"role_arn":                                  "RoleArn",
 		"s3_data_distribution_type":                 "S3DataDistributionType",

--- a/internal/aws/sagemaker/model_explainability_job_definition_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/model_explainability_job_definition_singular_data_source_gen.go
@@ -291,6 +291,91 @@ func modelExplainabilityJobDefinitionDataSource(ctx context.Context) (datasource
 			//   "additionalProperties": false,
 			//   "description": "The inputs for a monitoring job.",
 			//   "properties": {
+			//     "BatchTransformInput": {
+			//       "additionalProperties": false,
+			//       "description": "The batch transform input for a monitoring job.",
+			//       "properties": {
+			//         "DataCapturedDestinationS3Uri": {
+			//           "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//           "maxLength": 512,
+			//           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//           "type": "string"
+			//         },
+			//         "DatasetFormat": {
+			//           "description": "The dataset format of the data to monitor",
+			//           "properties": {
+			//             "Csv": {
+			//               "description": "The CSV format",
+			//               "properties": {
+			//                 "Header": {
+			//                   "description": "A boolean flag indicating if given CSV has header",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Json": {
+			//               "description": "The Json format",
+			//               "properties": {
+			//                 "Line": {
+			//                   "description": "A boolean flag indicating if it is JSON line format",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Parquet": {
+			//               "description": "A flag indicating if the dataset format is Parquet",
+			//               "type": "boolean"
+			//             }
+			//           },
+			//           "type": "object"
+			//         },
+			//         "FeaturesAttribute": {
+			//           "description": "JSONpath to locate features in JSONlines dataset",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "InferenceAttribute": {
+			//           "description": "Index or JSONpath to locate predicted label(s)",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "LocalPath": {
+			//           "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//           "maxLength": 256,
+			//           "pattern": ".*",
+			//           "type": "string"
+			//         },
+			//         "ProbabilityAttribute": {
+			//           "description": "Index or JSONpath to locate probabilities",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "S3DataDistributionType": {
+			//           "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//           "enum": [
+			//             "FullyReplicated",
+			//             "ShardedByS3Key"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "S3InputMode": {
+			//           "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//           "enum": [
+			//             "Pipe",
+			//             "File"
+			//           ],
+			//           "type": "string"
+			//         }
+			//       },
+			//       "required": [
+			//         "DataCapturedDestinationS3Uri",
+			//         "DatasetFormat",
+			//         "LocalPath"
+			//       ],
+			//       "type": "object"
+			//     },
 			//     "EndpointInput": {
 			//       "additionalProperties": false,
 			//       "description": "The endpoint for a monitoring job.",
@@ -346,14 +431,107 @@ func modelExplainabilityJobDefinitionDataSource(ctx context.Context) (datasource
 			//       "type": "object"
 			//     }
 			//   },
-			//   "required": [
-			//     "EndpointInput"
-			//   ],
 			//   "type": "object"
 			// }
 			Description: "The inputs for a monitoring job.",
 			Attributes: tfsdk.SingleNestedAttributes(
 				map[string]tfsdk.Attribute{
+					"batch_transform_input": {
+						// Property: BatchTransformInput
+						Description: "The batch transform input for a monitoring job.",
+						Attributes: tfsdk.SingleNestedAttributes(
+							map[string]tfsdk.Attribute{
+								"data_captured_destination_s3_uri": {
+									// Property: DataCapturedDestinationS3Uri
+									Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"dataset_format": {
+									// Property: DatasetFormat
+									Description: "The dataset format of the data to monitor",
+									Attributes: tfsdk.SingleNestedAttributes(
+										map[string]tfsdk.Attribute{
+											"csv": {
+												// Property: Csv
+												Description: "The CSV format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"header": {
+															// Property: Header
+															Description: "A boolean flag indicating if given CSV has header",
+															Type:        types.BoolType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
+											"json": {
+												// Property: Json
+												Description: "The Json format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"line": {
+															// Property: Line
+															Description: "A boolean flag indicating if it is JSON line format",
+															Type:        types.BoolType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
+											"parquet": {
+												// Property: Parquet
+												Description: "A flag indicating if the dataset format is Parquet",
+												Type:        types.BoolType,
+												Computed:    true,
+											},
+										},
+									),
+									Computed: true,
+								},
+								"features_attribute": {
+									// Property: FeaturesAttribute
+									Description: "JSONpath to locate features in JSONlines dataset",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"inference_attribute": {
+									// Property: InferenceAttribute
+									Description: "Index or JSONpath to locate predicted label(s)",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"local_path": {
+									// Property: LocalPath
+									Description: "Path to the filesystem where the endpoint data is available to the container.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"probability_attribute": {
+									// Property: ProbabilityAttribute
+									Description: "Index or JSONpath to locate probabilities",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"s3_data_distribution_type": {
+									// Property: S3DataDistributionType
+									Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"s3_input_mode": {
+									// Property: S3InputMode
+									Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+							},
+						),
+						Computed: true,
+					},
 					"endpoint_input": {
 						// Property: EndpointInput
 						Description: "The endpoint for a monitoring job.",
@@ -731,17 +909,22 @@ func modelExplainabilityJobDefinitionDataSource(ctx context.Context) (datasource
 	opts = opts.WithCloudFormationTypeName("AWS::SageMaker::ModelExplainabilityJobDefinition").WithTerraformTypeName("awscc_sagemaker_model_explainability_job_definition")
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
-		"baselining_job_name":  "BaseliningJobName",
-		"cluster_config":       "ClusterConfig",
-		"config_uri":           "ConfigUri",
-		"constraints_resource": "ConstraintsResource",
-		"creation_time":        "CreationTime",
+		"baselining_job_name":              "BaseliningJobName",
+		"batch_transform_input":            "BatchTransformInput",
+		"cluster_config":                   "ClusterConfig",
+		"config_uri":                       "ConfigUri",
+		"constraints_resource":             "ConstraintsResource",
+		"creation_time":                    "CreationTime",
+		"csv":                              "Csv",
+		"data_captured_destination_s3_uri": "DataCapturedDestinationS3Uri",
+		"dataset_format":                   "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"endpoint_input":                            "EndpointInput",
 		"endpoint_name":                             "EndpointName",
 		"environment":                               "Environment",
 		"features_attribute":                        "FeaturesAttribute",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"inference_attribute":                       "InferenceAttribute",
 		"instance_count":                            "InstanceCount",
@@ -749,8 +932,10 @@ func modelExplainabilityJobDefinitionDataSource(ctx context.Context) (datasource
 		"job_definition_arn":                        "JobDefinitionArn",
 		"job_definition_name":                       "JobDefinitionName",
 		"job_resources":                             "JobResources",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"model_explainability_app_specification":    "ModelExplainabilityAppSpecification",
@@ -759,6 +944,7 @@ func modelExplainabilityJobDefinitionDataSource(ctx context.Context) (datasource
 		"model_explainability_job_output_config":    "ModelExplainabilityJobOutputConfig",
 		"monitoring_outputs":                        "MonitoringOutputs",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"probability_attribute":                     "ProbabilityAttribute",
 		"role_arn":                                  "RoleArn",
 		"s3_data_distribution_type":                 "S3DataDistributionType",

--- a/internal/aws/sagemaker/model_quality_job_definition_resource_gen.go
+++ b/internal/aws/sagemaker/model_quality_job_definition_resource_gen.go
@@ -463,6 +463,104 @@ func modelQualityJobDefinitionResource(ctx context.Context) (resource.Resource, 
 			//   "additionalProperties": false,
 			//   "description": "The inputs for a monitoring job.",
 			//   "properties": {
+			//     "BatchTransformInput": {
+			//       "additionalProperties": false,
+			//       "description": "The batch transform input for a monitoring job.",
+			//       "properties": {
+			//         "DataCapturedDestinationS3Uri": {
+			//           "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//           "maxLength": 512,
+			//           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//           "type": "string"
+			//         },
+			//         "DatasetFormat": {
+			//           "description": "The dataset format of the data to monitor",
+			//           "properties": {
+			//             "Csv": {
+			//               "description": "The CSV format",
+			//               "properties": {
+			//                 "Header": {
+			//                   "description": "A boolean flag indicating if given CSV has header",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Json": {
+			//               "description": "The Json format",
+			//               "properties": {
+			//                 "Line": {
+			//                   "description": "A boolean flag indicating if it is JSON line format",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Parquet": {
+			//               "description": "A flag indicating if the dataset format is Parquet",
+			//               "type": "boolean"
+			//             }
+			//           },
+			//           "type": "object"
+			//         },
+			//         "EndTimeOffset": {
+			//           "description": "Monitoring end time offset, e.g. PT0H",
+			//           "maxLength": 15,
+			//           "minLength": 1,
+			//           "pattern": "^.?P.*",
+			//           "type": "string"
+			//         },
+			//         "InferenceAttribute": {
+			//           "description": "Index or JSONpath to locate predicted label(s)",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "LocalPath": {
+			//           "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//           "maxLength": 256,
+			//           "pattern": ".*",
+			//           "type": "string"
+			//         },
+			//         "ProbabilityAttribute": {
+			//           "description": "Index or JSONpath to locate probabilities",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "ProbabilityThresholdAttribute": {
+			//           "format": "double",
+			//           "type": "number"
+			//         },
+			//         "S3DataDistributionType": {
+			//           "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//           "enum": [
+			//             "FullyReplicated",
+			//             "ShardedByS3Key"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "S3InputMode": {
+			//           "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//           "enum": [
+			//             "Pipe",
+			//             "File"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "StartTimeOffset": {
+			//           "description": "Monitoring start time offset, e.g. -PT1H",
+			//           "maxLength": 15,
+			//           "minLength": 1,
+			//           "pattern": "^.?P.*",
+			//           "type": "string"
+			//         }
+			//       },
+			//       "required": [
+			//         "DataCapturedDestinationS3Uri",
+			//         "DatasetFormat",
+			//         "LocalPath"
+			//       ],
+			//       "type": "object"
+			//     },
 			//     "EndpointInput": {
 			//       "additionalProperties": false,
 			//       "description": "The endpoint for a monitoring job.",
@@ -548,7 +646,6 @@ func modelQualityJobDefinitionResource(ctx context.Context) (resource.Resource, 
 			//     }
 			//   },
 			//   "required": [
-			//     "EndpointInput",
 			//     "GroundTruthS3Input"
 			//   ],
 			//   "type": "object"
@@ -556,6 +653,199 @@ func modelQualityJobDefinitionResource(ctx context.Context) (resource.Resource, 
 			Description: "The inputs for a monitoring job.",
 			Attributes: tfsdk.SingleNestedAttributes(
 				map[string]tfsdk.Attribute{
+					"batch_transform_input": {
+						// Property: BatchTransformInput
+						Description: "The batch transform input for a monitoring job.",
+						Attributes: tfsdk.SingleNestedAttributes(
+							map[string]tfsdk.Attribute{
+								"data_captured_destination_s3_uri": {
+									// Property: DataCapturedDestinationS3Uri
+									Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+									Type:        types.StringType,
+									Required:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(512),
+										validate.StringMatch(regexp.MustCompile("^(https|s3)://([^/]+)/?(.*)$"), ""),
+									},
+								},
+								"dataset_format": {
+									// Property: DatasetFormat
+									Description: "The dataset format of the data to monitor",
+									Attributes: tfsdk.SingleNestedAttributes(
+										map[string]tfsdk.Attribute{
+											"csv": {
+												// Property: Csv
+												Description: "The CSV format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"header": {
+															// Property: Header
+															Description: "A boolean flag indicating if given CSV has header",
+															Type:        types.BoolType,
+															Optional:    true,
+															Computed:    true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+											"json": {
+												// Property: Json
+												Description: "The Json format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"line": {
+															// Property: Line
+															Description: "A boolean flag indicating if it is JSON line format",
+															Type:        types.BoolType,
+															Optional:    true,
+															Computed:    true,
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+											"parquet": {
+												// Property: Parquet
+												Description: "A flag indicating if the dataset format is Parquet",
+												Type:        types.BoolType,
+												Optional:    true,
+												Computed:    true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
+										},
+									),
+									Required: true,
+								},
+								"end_time_offset": {
+									// Property: EndTimeOffset
+									Description: "Monitoring end time offset, e.g. PT0H",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenBetween(1, 15),
+										validate.StringMatch(regexp.MustCompile("^.?P.*"), ""),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"inference_attribute": {
+									// Property: InferenceAttribute
+									Description: "Index or JSONpath to locate predicted label(s)",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"local_path": {
+									// Property: LocalPath
+									Description: "Path to the filesystem where the endpoint data is available to the container.",
+									Type:        types.StringType,
+									Required:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+										validate.StringMatch(regexp.MustCompile(".*"), ""),
+									},
+								},
+								"probability_attribute": {
+									// Property: ProbabilityAttribute
+									Description: "Index or JSONpath to locate probabilities",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenAtMost(256),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"probability_threshold_attribute": {
+									// Property: ProbabilityThresholdAttribute
+									Type:     types.Float64Type,
+									Optional: true,
+									Computed: true,
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"s3_data_distribution_type": {
+									// Property: S3DataDistributionType
+									Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringInSlice([]string{
+											"FullyReplicated",
+											"ShardedByS3Key",
+										}),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"s3_input_mode": {
+									// Property: S3InputMode
+									Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringInSlice([]string{
+											"Pipe",
+											"File",
+										}),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+								"start_time_offset": {
+									// Property: StartTimeOffset
+									Description: "Monitoring start time offset, e.g. -PT1H",
+									Type:        types.StringType,
+									Optional:    true,
+									Computed:    true,
+									Validators: []tfsdk.AttributeValidator{
+										validate.StringLenBetween(1, 15),
+										validate.StringMatch(regexp.MustCompile("^.?P.*"), ""),
+									},
+									PlanModifiers: []tfsdk.AttributePlanModifier{
+										resource.UseStateForUnknown(),
+									},
+								},
+							},
+						),
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
+					},
 					"endpoint_input": {
 						// Property: EndpointInput
 						Description: "The endpoint for a monitoring job.",
@@ -678,7 +968,11 @@ func modelQualityJobDefinitionResource(ctx context.Context) (resource.Resource, 
 								},
 							},
 						),
-						Required: true,
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []tfsdk.AttributePlanModifier{
+							resource.UseStateForUnknown(),
+						},
 					},
 					"ground_truth_s3_input": {
 						// Property: GroundTruthS3Input
@@ -1120,11 +1414,15 @@ func modelQualityJobDefinitionResource(ctx context.Context) (resource.Resource, 
 	opts = opts.WithSyntheticIDAttribute(true)
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"baselining_job_name":                       "BaseliningJobName",
+		"batch_transform_input":                     "BatchTransformInput",
 		"cluster_config":                            "ClusterConfig",
 		"constraints_resource":                      "ConstraintsResource",
 		"container_arguments":                       "ContainerArguments",
 		"container_entrypoint":                      "ContainerEntrypoint",
 		"creation_time":                             "CreationTime",
+		"csv":                                       "Csv",
+		"data_captured_destination_s3_uri":          "DataCapturedDestinationS3Uri",
+		"dataset_format":                            "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"end_time_offset":                           "EndTimeOffset",
@@ -1132,6 +1430,7 @@ func modelQualityJobDefinitionResource(ctx context.Context) (resource.Resource, 
 		"endpoint_name":                             "EndpointName",
 		"environment":                               "Environment",
 		"ground_truth_s3_input":                     "GroundTruthS3Input",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"inference_attribute":                       "InferenceAttribute",
 		"instance_count":                            "InstanceCount",
@@ -1139,8 +1438,10 @@ func modelQualityJobDefinitionResource(ctx context.Context) (resource.Resource, 
 		"job_definition_arn":                        "JobDefinitionArn",
 		"job_definition_name":                       "JobDefinitionName",
 		"job_resources":                             "JobResources",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"model_quality_app_specification":           "ModelQualityAppSpecification",
@@ -1149,6 +1450,7 @@ func modelQualityJobDefinitionResource(ctx context.Context) (resource.Resource, 
 		"model_quality_job_output_config":           "ModelQualityJobOutputConfig",
 		"monitoring_outputs":                        "MonitoringOutputs",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"post_analytics_processor_source_uri":       "PostAnalyticsProcessorSourceUri",
 		"probability_attribute":                     "ProbabilityAttribute",
 		"probability_threshold_attribute":           "ProbabilityThresholdAttribute",

--- a/internal/aws/sagemaker/model_quality_job_definition_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/model_quality_job_definition_singular_data_source_gen.go
@@ -350,6 +350,104 @@ func modelQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSo
 			//   "additionalProperties": false,
 			//   "description": "The inputs for a monitoring job.",
 			//   "properties": {
+			//     "BatchTransformInput": {
+			//       "additionalProperties": false,
+			//       "description": "The batch transform input for a monitoring job.",
+			//       "properties": {
+			//         "DataCapturedDestinationS3Uri": {
+			//           "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//           "maxLength": 512,
+			//           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//           "type": "string"
+			//         },
+			//         "DatasetFormat": {
+			//           "description": "The dataset format of the data to monitor",
+			//           "properties": {
+			//             "Csv": {
+			//               "description": "The CSV format",
+			//               "properties": {
+			//                 "Header": {
+			//                   "description": "A boolean flag indicating if given CSV has header",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Json": {
+			//               "description": "The Json format",
+			//               "properties": {
+			//                 "Line": {
+			//                   "description": "A boolean flag indicating if it is JSON line format",
+			//                   "type": "boolean"
+			//                 }
+			//               },
+			//               "type": "object"
+			//             },
+			//             "Parquet": {
+			//               "description": "A flag indicating if the dataset format is Parquet",
+			//               "type": "boolean"
+			//             }
+			//           },
+			//           "type": "object"
+			//         },
+			//         "EndTimeOffset": {
+			//           "description": "Monitoring end time offset, e.g. PT0H",
+			//           "maxLength": 15,
+			//           "minLength": 1,
+			//           "pattern": "^.?P.*",
+			//           "type": "string"
+			//         },
+			//         "InferenceAttribute": {
+			//           "description": "Index or JSONpath to locate predicted label(s)",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "LocalPath": {
+			//           "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//           "maxLength": 256,
+			//           "pattern": ".*",
+			//           "type": "string"
+			//         },
+			//         "ProbabilityAttribute": {
+			//           "description": "Index or JSONpath to locate probabilities",
+			//           "maxLength": 256,
+			//           "type": "string"
+			//         },
+			//         "ProbabilityThresholdAttribute": {
+			//           "format": "double",
+			//           "type": "number"
+			//         },
+			//         "S3DataDistributionType": {
+			//           "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//           "enum": [
+			//             "FullyReplicated",
+			//             "ShardedByS3Key"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "S3InputMode": {
+			//           "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//           "enum": [
+			//             "Pipe",
+			//             "File"
+			//           ],
+			//           "type": "string"
+			//         },
+			//         "StartTimeOffset": {
+			//           "description": "Monitoring start time offset, e.g. -PT1H",
+			//           "maxLength": 15,
+			//           "minLength": 1,
+			//           "pattern": "^.?P.*",
+			//           "type": "string"
+			//         }
+			//       },
+			//       "required": [
+			//         "DataCapturedDestinationS3Uri",
+			//         "DatasetFormat",
+			//         "LocalPath"
+			//       ],
+			//       "type": "object"
+			//     },
 			//     "EndpointInput": {
 			//       "additionalProperties": false,
 			//       "description": "The endpoint for a monitoring job.",
@@ -435,7 +533,6 @@ func modelQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSo
 			//     }
 			//   },
 			//   "required": [
-			//     "EndpointInput",
 			//     "GroundTruthS3Input"
 			//   ],
 			//   "type": "object"
@@ -443,6 +540,113 @@ func modelQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSo
 			Description: "The inputs for a monitoring job.",
 			Attributes: tfsdk.SingleNestedAttributes(
 				map[string]tfsdk.Attribute{
+					"batch_transform_input": {
+						// Property: BatchTransformInput
+						Description: "The batch transform input for a monitoring job.",
+						Attributes: tfsdk.SingleNestedAttributes(
+							map[string]tfsdk.Attribute{
+								"data_captured_destination_s3_uri": {
+									// Property: DataCapturedDestinationS3Uri
+									Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"dataset_format": {
+									// Property: DatasetFormat
+									Description: "The dataset format of the data to monitor",
+									Attributes: tfsdk.SingleNestedAttributes(
+										map[string]tfsdk.Attribute{
+											"csv": {
+												// Property: Csv
+												Description: "The CSV format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"header": {
+															// Property: Header
+															Description: "A boolean flag indicating if given CSV has header",
+															Type:        types.BoolType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
+											"json": {
+												// Property: Json
+												Description: "The Json format",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"line": {
+															// Property: Line
+															Description: "A boolean flag indicating if it is JSON line format",
+															Type:        types.BoolType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
+											"parquet": {
+												// Property: Parquet
+												Description: "A flag indicating if the dataset format is Parquet",
+												Type:        types.BoolType,
+												Computed:    true,
+											},
+										},
+									),
+									Computed: true,
+								},
+								"end_time_offset": {
+									// Property: EndTimeOffset
+									Description: "Monitoring end time offset, e.g. PT0H",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"inference_attribute": {
+									// Property: InferenceAttribute
+									Description: "Index or JSONpath to locate predicted label(s)",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"local_path": {
+									// Property: LocalPath
+									Description: "Path to the filesystem where the endpoint data is available to the container.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"probability_attribute": {
+									// Property: ProbabilityAttribute
+									Description: "Index or JSONpath to locate probabilities",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"probability_threshold_attribute": {
+									// Property: ProbabilityThresholdAttribute
+									Type:     types.Float64Type,
+									Computed: true,
+								},
+								"s3_data_distribution_type": {
+									// Property: S3DataDistributionType
+									Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"s3_input_mode": {
+									// Property: S3InputMode
+									Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+								"start_time_offset": {
+									// Property: StartTimeOffset
+									Description: "Monitoring start time offset, e.g. -PT1H",
+									Type:        types.StringType,
+									Computed:    true,
+								},
+							},
+						),
+						Computed: true,
+					},
 					"endpoint_input": {
 						// Property: EndpointInput
 						Description: "The endpoint for a monitoring job.",
@@ -847,11 +1051,15 @@ func modelQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSo
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"baselining_job_name":                       "BaseliningJobName",
+		"batch_transform_input":                     "BatchTransformInput",
 		"cluster_config":                            "ClusterConfig",
 		"constraints_resource":                      "ConstraintsResource",
 		"container_arguments":                       "ContainerArguments",
 		"container_entrypoint":                      "ContainerEntrypoint",
 		"creation_time":                             "CreationTime",
+		"csv":                                       "Csv",
+		"data_captured_destination_s3_uri":          "DataCapturedDestinationS3Uri",
+		"dataset_format":                            "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"end_time_offset":                           "EndTimeOffset",
@@ -859,6 +1067,7 @@ func modelQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSo
 		"endpoint_name":                             "EndpointName",
 		"environment":                               "Environment",
 		"ground_truth_s3_input":                     "GroundTruthS3Input",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"inference_attribute":                       "InferenceAttribute",
 		"instance_count":                            "InstanceCount",
@@ -866,8 +1075,10 @@ func modelQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSo
 		"job_definition_arn":                        "JobDefinitionArn",
 		"job_definition_name":                       "JobDefinitionName",
 		"job_resources":                             "JobResources",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"model_quality_app_specification":           "ModelQualityAppSpecification",
@@ -876,6 +1087,7 @@ func modelQualityJobDefinitionDataSource(ctx context.Context) (datasource.DataSo
 		"model_quality_job_output_config":           "ModelQualityJobOutputConfig",
 		"monitoring_outputs":                        "MonitoringOutputs",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"post_analytics_processor_source_uri":       "PostAnalyticsProcessorSourceUri",
 		"probability_attribute":                     "ProbabilityAttribute",
 		"probability_threshold_attribute":           "ProbabilityThresholdAttribute",

--- a/internal/aws/sagemaker/monitoring_schedule_resource_gen.go
+++ b/internal/aws/sagemaker/monitoring_schedule_resource_gen.go
@@ -384,6 +384,76 @@ func monitoringScheduleResource(ctx context.Context) (resource.Resource, error) 
 			//             "additionalProperties": false,
 			//             "description": "The inputs for a monitoring job.",
 			//             "properties": {
+			//               "BatchTransformInput": {
+			//                 "additionalProperties": false,
+			//                 "description": "The batch transform input for a monitoring job.",
+			//                 "properties": {
+			//                   "DataCapturedDestinationS3Uri": {
+			//                     "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//                     "maxLength": 512,
+			//                     "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//                     "type": "string"
+			//                   },
+			//                   "DatasetFormat": {
+			//                     "description": "The dataset format of the data to monitor",
+			//                     "properties": {
+			//                       "Csv": {
+			//                         "description": "The CSV format",
+			//                         "properties": {
+			//                           "Header": {
+			//                             "description": "A boolean flag indicating if given CSV has header",
+			//                             "type": "boolean"
+			//                           }
+			//                         },
+			//                         "type": "object"
+			//                       },
+			//                       "Json": {
+			//                         "description": "The Json format",
+			//                         "properties": {
+			//                           "Line": {
+			//                             "description": "A boolean flag indicating if it is JSON line format",
+			//                             "type": "boolean"
+			//                           }
+			//                         },
+			//                         "type": "object"
+			//                       },
+			//                       "Parquet": {
+			//                         "description": "A flag indicating if the dataset format is Parquet",
+			//                         "type": "boolean"
+			//                       }
+			//                     },
+			//                     "type": "object"
+			//                   },
+			//                   "LocalPath": {
+			//                     "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//                     "maxLength": 256,
+			//                     "pattern": ".*",
+			//                     "type": "string"
+			//                   },
+			//                   "S3DataDistributionType": {
+			//                     "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//                     "enum": [
+			//                       "FullyReplicated",
+			//                       "ShardedByS3Key"
+			//                     ],
+			//                     "type": "string"
+			//                   },
+			//                   "S3InputMode": {
+			//                     "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//                     "enum": [
+			//                       "Pipe",
+			//                       "File"
+			//                     ],
+			//                     "type": "string"
+			//                   }
+			//                 },
+			//                 "required": [
+			//                   "DataCapturedDestinationS3Uri",
+			//                   "DatasetFormat",
+			//                   "LocalPath"
+			//                 ],
+			//                 "type": "object"
+			//               },
 			//               "EndpointInput": {
 			//                 "additionalProperties": false,
 			//                 "description": "The endpoint for a monitoring job.",
@@ -424,9 +494,6 @@ func monitoringScheduleResource(ctx context.Context) (resource.Resource, error) 
 			//                 "type": "object"
 			//               }
 			//             },
-			//             "required": [
-			//               "EndpointInput"
-			//             ],
 			//             "type": "object"
 			//           },
 			//           "maxItems": 1,
@@ -824,6 +891,136 @@ func monitoringScheduleResource(ctx context.Context) (resource.Resource, error) 
 									Description: "The array of inputs for the monitoring job.",
 									Attributes: tfsdk.ListNestedAttributes(
 										map[string]tfsdk.Attribute{
+											"batch_transform_input": {
+												// Property: BatchTransformInput
+												Description: "The batch transform input for a monitoring job.",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"data_captured_destination_s3_uri": {
+															// Property: DataCapturedDestinationS3Uri
+															Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+															Type:        types.StringType,
+															Required:    true,
+															Validators: []tfsdk.AttributeValidator{
+																validate.StringLenAtMost(512),
+																validate.StringMatch(regexp.MustCompile("^(https|s3)://([^/]+)/?(.*)$"), ""),
+															},
+														},
+														"dataset_format": {
+															// Property: DatasetFormat
+															Description: "The dataset format of the data to monitor",
+															Attributes: tfsdk.SingleNestedAttributes(
+																map[string]tfsdk.Attribute{
+																	"csv": {
+																		// Property: Csv
+																		Description: "The CSV format",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"header": {
+																					// Property: Header
+																					Description: "A boolean flag indicating if given CSV has header",
+																					Type:        types.BoolType,
+																					Optional:    true,
+																					Computed:    true,
+																					PlanModifiers: []tfsdk.AttributePlanModifier{
+																						resource.UseStateForUnknown(),
+																					},
+																				},
+																			},
+																		),
+																		Optional: true,
+																		Computed: true,
+																		PlanModifiers: []tfsdk.AttributePlanModifier{
+																			resource.UseStateForUnknown(),
+																		},
+																	},
+																	"json": {
+																		// Property: Json
+																		Description: "The Json format",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"line": {
+																					// Property: Line
+																					Description: "A boolean flag indicating if it is JSON line format",
+																					Type:        types.BoolType,
+																					Optional:    true,
+																					Computed:    true,
+																					PlanModifiers: []tfsdk.AttributePlanModifier{
+																						resource.UseStateForUnknown(),
+																					},
+																				},
+																			},
+																		),
+																		Optional: true,
+																		Computed: true,
+																		PlanModifiers: []tfsdk.AttributePlanModifier{
+																			resource.UseStateForUnknown(),
+																		},
+																	},
+																	"parquet": {
+																		// Property: Parquet
+																		Description: "A flag indicating if the dataset format is Parquet",
+																		Type:        types.BoolType,
+																		Optional:    true,
+																		Computed:    true,
+																		PlanModifiers: []tfsdk.AttributePlanModifier{
+																			resource.UseStateForUnknown(),
+																		},
+																	},
+																},
+															),
+															Required: true,
+														},
+														"local_path": {
+															// Property: LocalPath
+															Description: "Path to the filesystem where the endpoint data is available to the container.",
+															Type:        types.StringType,
+															Required:    true,
+															Validators: []tfsdk.AttributeValidator{
+																validate.StringLenAtMost(256),
+																validate.StringMatch(regexp.MustCompile(".*"), ""),
+															},
+														},
+														"s3_data_distribution_type": {
+															// Property: S3DataDistributionType
+															Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+															Type:        types.StringType,
+															Optional:    true,
+															Computed:    true,
+															Validators: []tfsdk.AttributeValidator{
+																validate.StringInSlice([]string{
+																	"FullyReplicated",
+																	"ShardedByS3Key",
+																}),
+															},
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+														"s3_input_mode": {
+															// Property: S3InputMode
+															Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+															Type:        types.StringType,
+															Optional:    true,
+															Computed:    true,
+															Validators: []tfsdk.AttributeValidator{
+																validate.StringInSlice([]string{
+																	"Pipe",
+																	"File",
+																}),
+															},
+															PlanModifiers: []tfsdk.AttributePlanModifier{
+																resource.UseStateForUnknown(),
+															},
+														},
+													},
+												),
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
+											},
 											"endpoint_input": {
 												// Property: EndpointInput
 												Description: "The endpoint for a monitoring job.",
@@ -883,7 +1080,11 @@ func monitoringScheduleResource(ctx context.Context) (resource.Resource, error) 
 														},
 													},
 												),
-												Required: true,
+												Optional: true,
+												Computed: true,
+												PlanModifiers: []tfsdk.AttributePlanModifier{
+													resource.UseStateForUnknown(),
+												},
 											},
 										},
 									),
@@ -1325,24 +1526,31 @@ func monitoringScheduleResource(ctx context.Context) (resource.Resource, error) 
 	opts = opts.WithSyntheticIDAttribute(true)
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"baseline_config":                           "BaselineConfig",
+		"batch_transform_input":                     "BatchTransformInput",
 		"cluster_config":                            "ClusterConfig",
 		"constraints_resource":                      "ConstraintsResource",
 		"container_arguments":                       "ContainerArguments",
 		"container_entrypoint":                      "ContainerEntrypoint",
 		"creation_time":                             "CreationTime",
+		"csv":                                       "Csv",
+		"data_captured_destination_s3_uri":          "DataCapturedDestinationS3Uri",
+		"dataset_format":                            "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"endpoint_input":                            "EndpointInput",
 		"endpoint_name":                             "EndpointName",
 		"environment":                               "Environment",
 		"failure_reason":                            "FailureReason",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"instance_count":                            "InstanceCount",
 		"instance_type":                             "InstanceType",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
 		"last_modified_time":                        "LastModifiedTime",
 		"last_monitoring_execution_summary":         "LastMonitoringExecutionSummary",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"monitoring_app_specification":              "MonitoringAppSpecification",
@@ -1359,6 +1567,7 @@ func monitoringScheduleResource(ctx context.Context) (resource.Resource, error) 
 		"monitoring_schedule_status":                "MonitoringScheduleStatus",
 		"monitoring_type":                           "MonitoringType",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"post_analytics_processor_source_uri":       "PostAnalyticsProcessorSourceUri",
 		"processing_job_arn":                        "ProcessingJobArn",
 		"record_preprocessor_source_uri":            "RecordPreprocessorSourceUri",

--- a/internal/aws/sagemaker/monitoring_schedule_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/monitoring_schedule_singular_data_source_gen.go
@@ -316,6 +316,76 @@ func monitoringScheduleDataSource(ctx context.Context) (datasource.DataSource, e
 			//             "additionalProperties": false,
 			//             "description": "The inputs for a monitoring job.",
 			//             "properties": {
+			//               "BatchTransformInput": {
+			//                 "additionalProperties": false,
+			//                 "description": "The batch transform input for a monitoring job.",
+			//                 "properties": {
+			//                   "DataCapturedDestinationS3Uri": {
+			//                     "description": "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+			//                     "maxLength": 512,
+			//                     "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+			//                     "type": "string"
+			//                   },
+			//                   "DatasetFormat": {
+			//                     "description": "The dataset format of the data to monitor",
+			//                     "properties": {
+			//                       "Csv": {
+			//                         "description": "The CSV format",
+			//                         "properties": {
+			//                           "Header": {
+			//                             "description": "A boolean flag indicating if given CSV has header",
+			//                             "type": "boolean"
+			//                           }
+			//                         },
+			//                         "type": "object"
+			//                       },
+			//                       "Json": {
+			//                         "description": "The Json format",
+			//                         "properties": {
+			//                           "Line": {
+			//                             "description": "A boolean flag indicating if it is JSON line format",
+			//                             "type": "boolean"
+			//                           }
+			//                         },
+			//                         "type": "object"
+			//                       },
+			//                       "Parquet": {
+			//                         "description": "A flag indicating if the dataset format is Parquet",
+			//                         "type": "boolean"
+			//                       }
+			//                     },
+			//                     "type": "object"
+			//                   },
+			//                   "LocalPath": {
+			//                     "description": "Path to the filesystem where the endpoint data is available to the container.",
+			//                     "maxLength": 256,
+			//                     "pattern": ".*",
+			//                     "type": "string"
+			//                   },
+			//                   "S3DataDistributionType": {
+			//                     "description": "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+			//                     "enum": [
+			//                       "FullyReplicated",
+			//                       "ShardedByS3Key"
+			//                     ],
+			//                     "type": "string"
+			//                   },
+			//                   "S3InputMode": {
+			//                     "description": "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+			//                     "enum": [
+			//                       "Pipe",
+			//                       "File"
+			//                     ],
+			//                     "type": "string"
+			//                   }
+			//                 },
+			//                 "required": [
+			//                   "DataCapturedDestinationS3Uri",
+			//                   "DatasetFormat",
+			//                   "LocalPath"
+			//                 ],
+			//                 "type": "object"
+			//               },
 			//               "EndpointInput": {
 			//                 "additionalProperties": false,
 			//                 "description": "The endpoint for a monitoring job.",
@@ -356,9 +426,6 @@ func monitoringScheduleDataSource(ctx context.Context) (datasource.DataSource, e
 			//                 "type": "object"
 			//               }
 			//             },
-			//             "required": [
-			//               "EndpointInput"
-			//             ],
 			//             "type": "object"
 			//           },
 			//           "maxItems": 1,
@@ -688,6 +755,84 @@ func monitoringScheduleDataSource(ctx context.Context) (datasource.DataSource, e
 									Description: "The array of inputs for the monitoring job.",
 									Attributes: tfsdk.ListNestedAttributes(
 										map[string]tfsdk.Attribute{
+											"batch_transform_input": {
+												// Property: BatchTransformInput
+												Description: "The batch transform input for a monitoring job.",
+												Attributes: tfsdk.SingleNestedAttributes(
+													map[string]tfsdk.Attribute{
+														"data_captured_destination_s3_uri": {
+															// Property: DataCapturedDestinationS3Uri
+															Description: "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+															Type:        types.StringType,
+															Computed:    true,
+														},
+														"dataset_format": {
+															// Property: DatasetFormat
+															Description: "The dataset format of the data to monitor",
+															Attributes: tfsdk.SingleNestedAttributes(
+																map[string]tfsdk.Attribute{
+																	"csv": {
+																		// Property: Csv
+																		Description: "The CSV format",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"header": {
+																					// Property: Header
+																					Description: "A boolean flag indicating if given CSV has header",
+																					Type:        types.BoolType,
+																					Computed:    true,
+																				},
+																			},
+																		),
+																		Computed: true,
+																	},
+																	"json": {
+																		// Property: Json
+																		Description: "The Json format",
+																		Attributes: tfsdk.SingleNestedAttributes(
+																			map[string]tfsdk.Attribute{
+																				"line": {
+																					// Property: Line
+																					Description: "A boolean flag indicating if it is JSON line format",
+																					Type:        types.BoolType,
+																					Computed:    true,
+																				},
+																			},
+																		),
+																		Computed: true,
+																	},
+																	"parquet": {
+																		// Property: Parquet
+																		Description: "A flag indicating if the dataset format is Parquet",
+																		Type:        types.BoolType,
+																		Computed:    true,
+																	},
+																},
+															),
+															Computed: true,
+														},
+														"local_path": {
+															// Property: LocalPath
+															Description: "Path to the filesystem where the endpoint data is available to the container.",
+															Type:        types.StringType,
+															Computed:    true,
+														},
+														"s3_data_distribution_type": {
+															// Property: S3DataDistributionType
+															Description: "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+															Type:        types.StringType,
+															Computed:    true,
+														},
+														"s3_input_mode": {
+															// Property: S3InputMode
+															Description: "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+															Type:        types.StringType,
+															Computed:    true,
+														},
+													},
+												),
+												Computed: true,
+											},
 											"endpoint_input": {
 												// Property: EndpointInput
 												Description: "The endpoint for a monitoring job.",
@@ -1016,24 +1161,31 @@ func monitoringScheduleDataSource(ctx context.Context) (datasource.DataSource, e
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"baseline_config":                           "BaselineConfig",
+		"batch_transform_input":                     "BatchTransformInput",
 		"cluster_config":                            "ClusterConfig",
 		"constraints_resource":                      "ConstraintsResource",
 		"container_arguments":                       "ContainerArguments",
 		"container_entrypoint":                      "ContainerEntrypoint",
 		"creation_time":                             "CreationTime",
+		"csv":                                       "Csv",
+		"data_captured_destination_s3_uri":          "DataCapturedDestinationS3Uri",
+		"dataset_format":                            "DatasetFormat",
 		"enable_inter_container_traffic_encryption": "EnableInterContainerTrafficEncryption",
 		"enable_network_isolation":                  "EnableNetworkIsolation",
 		"endpoint_input":                            "EndpointInput",
 		"endpoint_name":                             "EndpointName",
 		"environment":                               "Environment",
 		"failure_reason":                            "FailureReason",
+		"header":                                    "Header",
 		"image_uri":                                 "ImageUri",
 		"instance_count":                            "InstanceCount",
 		"instance_type":                             "InstanceType",
+		"json":                                      "Json",
 		"key":                                       "Key",
 		"kms_key_id":                                "KmsKeyId",
 		"last_modified_time":                        "LastModifiedTime",
 		"last_monitoring_execution_summary":         "LastMonitoringExecutionSummary",
+		"line":                                      "Line",
 		"local_path":                                "LocalPath",
 		"max_runtime_in_seconds":                    "MaxRuntimeInSeconds",
 		"monitoring_app_specification":              "MonitoringAppSpecification",
@@ -1050,6 +1202,7 @@ func monitoringScheduleDataSource(ctx context.Context) (datasource.DataSource, e
 		"monitoring_schedule_status":                "MonitoringScheduleStatus",
 		"monitoring_type":                           "MonitoringType",
 		"network_config":                            "NetworkConfig",
+		"parquet":                                   "Parquet",
 		"post_analytics_processor_source_uri":       "PostAnalyticsProcessorSourceUri",
 		"processing_job_arn":                        "ProcessingJobArn",
 		"record_preprocessor_source_uri":            "RecordPreprocessorSourceUri",

--- a/internal/aws/ses/dedicated_ip_pool_resource_gen.go
+++ b/internal/aws/ses/dedicated_ip_pool_resource_gen.go
@@ -42,6 +42,26 @@ func dedicatedIpPoolResource(ctx context.Context) (resource.Resource, error) {
 				resource.RequiresReplace(),
 			},
 		},
+		"scaling_mode": {
+			// Property: ScalingMode
+			// CloudFormation resource type schema:
+			// {
+			//   "description": "Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD.",
+			//   "pattern": "^(STANDARD|MANAGED)$",
+			//   "type": "string"
+			// }
+			Description: "Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD.",
+			Type:        types.StringType,
+			Optional:    true,
+			Computed:    true,
+			Validators: []tfsdk.AttributeValidator{
+				validate.StringMatch(regexp.MustCompile("^(STANDARD|MANAGED)$"), ""),
+			},
+			PlanModifiers: []tfsdk.AttributePlanModifier{
+				resource.UseStateForUnknown(),
+				resource.RequiresReplace(),
+			},
+		},
 	}
 
 	attributes["id"] = tfsdk.Attribute{
@@ -65,7 +85,8 @@ func dedicatedIpPoolResource(ctx context.Context) (resource.Resource, error) {
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithSyntheticIDAttribute(true)
 	opts = opts.WithAttributeNameMap(map[string]string{
-		"pool_name": "PoolName",
+		"pool_name":    "PoolName",
+		"scaling_mode": "ScalingMode",
 	})
 
 	opts = opts.IsImmutableType(true)

--- a/internal/aws/ses/dedicated_ip_pool_singular_data_source_gen.go
+++ b/internal/aws/ses/dedicated_ip_pool_singular_data_source_gen.go
@@ -32,6 +32,18 @@ func dedicatedIpPoolDataSource(ctx context.Context) (datasource.DataSource, erro
 			Type:        types.StringType,
 			Computed:    true,
 		},
+		"scaling_mode": {
+			// Property: ScalingMode
+			// CloudFormation resource type schema:
+			// {
+			//   "description": "Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD.",
+			//   "pattern": "^(STANDARD|MANAGED)$",
+			//   "type": "string"
+			// }
+			Description: "Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD.",
+			Type:        types.StringType,
+			Computed:    true,
+		},
 	}
 
 	attributes["id"] = tfsdk.Attribute{
@@ -51,7 +63,8 @@ func dedicatedIpPoolDataSource(ctx context.Context) (datasource.DataSource, erro
 	opts = opts.WithCloudFormationTypeName("AWS::SES::DedicatedIpPool").WithTerraformTypeName("awscc_ses_dedicated_ip_pool")
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
-		"pool_name": "PoolName",
+		"pool_name":    "PoolName",
+		"scaling_mode": "ScalingMode",
 	})
 
 	v, err := NewSingularDataSource(ctx, opts...)

--- a/internal/aws/ssmincidents/response_plan_resource_gen.go
+++ b/internal/aws/ssmincidents/response_plan_resource_gen.go
@@ -49,6 +49,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			//             "type": "string"
 			//           },
 			//           "DynamicParameters": {
+			//             "default": [],
 			//             "description": "The parameters with dynamic values to set when starting the SSM automation document.",
 			//             "insertionOrder": false,
 			//             "items": {
@@ -87,6 +88,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			//             "uniqueItems": true
 			//           },
 			//           "Parameters": {
+			//             "default": [],
 			//             "description": "The parameters to set when starting the SSM automation document.",
 			//             "insertionOrder": false,
 			//             "items": {
@@ -106,7 +108,6 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			//                     "type": "string"
 			//                   },
 			//                   "maxItems": 10,
-			//                   "minItems": 1,
 			//                   "type": "array",
 			//                   "uniqueItems": true
 			//                 }
@@ -118,6 +119,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			//               "type": "object"
 			//             },
 			//             "maxItems": 200,
+			//             "minItems": 1,
 			//             "type": "array",
 			//             "uniqueItems": true
 			//           },
@@ -225,6 +227,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 										validate.ArrayLenAtMost(200),
 									},
 									PlanModifiers: []tfsdk.AttributePlanModifier{
+										DefaultValue(types.Set{ElemType: types.StringType, Elems: []attr.Value{}}),
 										resource.UseStateForUnknown(),
 									},
 								},
@@ -246,7 +249,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 												Type:     types.ListType{ElemType: types.StringType},
 												Required: true,
 												Validators: []tfsdk.AttributeValidator{
-													validate.ArrayLenBetween(1, 10),
+													validate.ArrayLenAtMost(10),
 													validate.UniqueItems(),
 													validate.ArrayForEach(validate.StringLenAtMost(10000)),
 												},
@@ -256,9 +259,10 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 									Optional: true,
 									Computed: true,
 									Validators: []tfsdk.AttributeValidator{
-										validate.ArrayLenAtMost(200),
+										validate.ArrayLenBetween(1, 200),
 									},
 									PlanModifiers: []tfsdk.AttributePlanModifier{
+										DefaultValue(types.Set{ElemType: types.StringType, Elems: []attr.Value{}}),
 										resource.UseStateForUnknown(),
 									},
 								},
@@ -333,6 +337,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			//   "description": "The chat channel configuration.",
 			//   "properties": {
 			//     "ChatbotSns": {
+			//       "default": [],
 			//       "insertionOrder": true,
 			//       "items": {
 			//         "description": "The ARN of the Chatbot SNS topic.",
@@ -360,6 +365,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 							validate.ArrayForEach(validate.StringMatch(regexp.MustCompile("^arn:aws(-(cn|us-gov))?:sns:(([a-z]+-)+[0-9])?:([0-9]{12})?:[^.]+$"), "")),
 						},
 						PlanModifiers: []tfsdk.AttributePlanModifier{
+							DefaultValue(types.List{ElemType: types.StringType, Elems: []attr.Value{}}),
 							resource.UseStateForUnknown(),
 						},
 					},
@@ -405,7 +411,6 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			//     "type": "string"
 			//   },
 			//   "maxItems": 5,
-			//   "minItems": 1,
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
@@ -414,7 +419,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			Optional:    true,
 			Computed:    true,
 			Validators: []tfsdk.AttributeValidator{
-				validate.ArrayLenBetween(1, 5),
+				validate.ArrayLenAtMost(5),
 				validate.ArrayForEach(validate.StringLenAtMost(1000)),
 				validate.ArrayForEach(validate.StringMatch(regexp.MustCompile("^arn:aws(-(cn|us-gov))?:ssm-contacts:(([a-z]+-)+[0-9])?:([0-9]{12})?:[^.]+$"), "")),
 			},
@@ -473,6 +478,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			//       "uniqueItems": true
 			//     },
 			//     "NotificationTargets": {
+			//       "default": [],
 			//       "description": "The list of notification targets.",
 			//       "insertionOrder": false,
 			//       "items": {
@@ -595,6 +601,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 						},
 						PlanModifiers: []tfsdk.AttributePlanModifier{
 							Multiset(),
+							DefaultValue(types.List{ElemType: types.StringType, Elems: []attr.Value{}}),
 							resource.UseStateForUnknown(),
 						},
 					},
@@ -675,7 +682,6 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			//     "type": "object"
 			//   },
 			//   "maxItems": 50,
-			//   "minItems": 1,
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
@@ -703,7 +709,7 @@ func responsePlanResource(ctx context.Context) (resource.Resource, error) {
 			Optional: true,
 			Computed: true,
 			Validators: []tfsdk.AttributeValidator{
-				validate.ArrayLenBetween(1, 50),
+				validate.ArrayLenAtMost(50),
 			},
 			PlanModifiers: []tfsdk.AttributePlanModifier{
 				DefaultValue(types.Set{ElemType: types.StringType, Elems: []attr.Value{}}),

--- a/internal/aws/ssmincidents/response_plan_singular_data_source_gen.go
+++ b/internal/aws/ssmincidents/response_plan_singular_data_source_gen.go
@@ -46,6 +46,7 @@ func responsePlanDataSource(ctx context.Context) (datasource.DataSource, error) 
 			//             "type": "string"
 			//           },
 			//           "DynamicParameters": {
+			//             "default": [],
 			//             "description": "The parameters with dynamic values to set when starting the SSM automation document.",
 			//             "insertionOrder": false,
 			//             "items": {
@@ -84,6 +85,7 @@ func responsePlanDataSource(ctx context.Context) (datasource.DataSource, error) 
 			//             "uniqueItems": true
 			//           },
 			//           "Parameters": {
+			//             "default": [],
 			//             "description": "The parameters to set when starting the SSM automation document.",
 			//             "insertionOrder": false,
 			//             "items": {
@@ -103,7 +105,6 @@ func responsePlanDataSource(ctx context.Context) (datasource.DataSource, error) 
 			//                     "type": "string"
 			//                   },
 			//                   "maxItems": 10,
-			//                   "minItems": 1,
 			//                   "type": "array",
 			//                   "uniqueItems": true
 			//                 }
@@ -115,6 +116,7 @@ func responsePlanDataSource(ctx context.Context) (datasource.DataSource, error) 
 			//               "type": "object"
 			//             },
 			//             "maxItems": 200,
+			//             "minItems": 1,
 			//             "type": "array",
 			//             "uniqueItems": true
 			//           },
@@ -255,6 +257,7 @@ func responsePlanDataSource(ctx context.Context) (datasource.DataSource, error) 
 			//   "description": "The chat channel configuration.",
 			//   "properties": {
 			//     "ChatbotSns": {
+			//       "default": [],
 			//       "insertionOrder": true,
 			//       "items": {
 			//         "description": "The ARN of the Chatbot SNS topic.",
@@ -307,7 +310,6 @@ func responsePlanDataSource(ctx context.Context) (datasource.DataSource, error) 
 			//     "type": "string"
 			//   },
 			//   "maxItems": 5,
-			//   "minItems": 1,
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }
@@ -365,6 +367,7 @@ func responsePlanDataSource(ctx context.Context) (datasource.DataSource, error) 
 			//       "uniqueItems": true
 			//     },
 			//     "NotificationTargets": {
+			//       "default": [],
 			//       "description": "The list of notification targets.",
 			//       "insertionOrder": false,
 			//       "items": {
@@ -510,7 +513,6 @@ func responsePlanDataSource(ctx context.Context) (datasource.DataSource, error) 
 			//     "type": "object"
 			//   },
 			//   "maxItems": 50,
-			//   "minItems": 1,
 			//   "type": "array",
 			//   "uniqueItems": true
 			// }

--- a/internal/provider/generators/allschemas/available_schemas.2022-10-19.hcl
+++ b/internal/provider/generators/allschemas/available_schemas.2022-10-19.hcl
@@ -1,12 +1,3 @@
-defaults {
-  schema_cache_directory     = "../service/cloudformation/schemas"
-  terraform_type_name_prefix = "awscc"
-}
-
-meta_schema {
-  path = "../service/cloudformation/meta-schemas/provider.definition.schema.v1.json"
-}
-
 # 616 CloudFormation resource types schemas are available for use with the Cloud Control API.
 
 resource_schema "aws_acmpca_certificate" {
@@ -58,19 +49,11 @@ resource_schema "aws_amplify_domain" {
 resource_schema "aws_amplifyuibuilder_component" {
   cloudformation_type_name               = "AWS::AmplifyUIBuilder::Component"
   suppress_plural_data_source_generation = true
-
-  # Goes into infinite recursion while generating code...
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_amplifyuibuilder_theme" {
   cloudformation_type_name               = "AWS::AmplifyUIBuilder::Theme"
   suppress_plural_data_source_generation = true
-
-  # Goes into infinite recursion while generating code...
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_apigateway_account" {
@@ -88,12 +71,8 @@ resource_schema "aws_apigateway_authorizer" {
 }
 
 resource_schema "aws_apigateway_base_path_mapping" {
-  cloudformation_type_name = "AWS::ApiGateway::BasePathMapping"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
+  cloudformation_type_name               = "AWS::ApiGateway::BasePathMapping"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_apigateway_client_certificate" {
@@ -106,12 +85,8 @@ resource_schema "aws_apigateway_deployment" {
 }
 
 resource_schema "aws_apigateway_documentation_part" {
-  cloudformation_type_name = "AWS::ApiGateway::DocumentationPart"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
+  cloudformation_type_name               = "AWS::ApiGateway::DocumentationPart"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_apigateway_documentation_version" {
@@ -159,11 +134,7 @@ resource_schema "aws_apigateway_usage_plan_key" {
 
 resource_schema "aws_apigatewayv2_model" {
   cloudformation_type_name               = "AWS::ApiGatewayV2::Model"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_apigatewayv2_vpc_link" {
@@ -229,11 +200,6 @@ resource_schema "aws_appstream_entitlement" {
 
 resource_schema "aws_appstream_image_builder" {
   cloudformation_type_name = "AWS::AppStream::ImageBuilder"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_appsync_domain_name" {
@@ -283,11 +249,6 @@ resource_schema "aws_autoscaling_lifecycle_hook" {
 
 resource_schema "aws_autoscaling_scaling_policy" {
   cloudformation_type_name = "AWS::AutoScaling::ScalingPolicy"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_autoscaling_warm_pool" {
@@ -365,6 +326,10 @@ resource_schema "aws_ce_anomaly_subscription" {
 resource_schema "aws_ce_cost_category" {
   cloudformation_type_name               = "AWS::CE::CostCategory"
   suppress_plural_data_source_generation = true
+}
+
+resource_schema "aws_cur_report_definition" {
+  cloudformation_type_name = "AWS::CUR::ReportDefinition"
 }
 
 resource_schema "aws_cassandra_keyspace" {
@@ -456,11 +421,7 @@ resource_schema "aws_cloudfront_key_group" {
 
 resource_schema "aws_cloudfront_monitoring_subscription" {
   cloudformation_type_name               = "AWS::CloudFront::MonitoringSubscription"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_cloudfront_origin_access_control" {
@@ -507,13 +468,12 @@ resource_schema "aws_codeartifact_repository" {
   cloudformation_type_name = "AWS::CodeArtifact::Repository"
 }
 
+resource_schema "aws_codedeploy_application" {
+  cloudformation_type_name = "AWS::CodeDeploy::Application"
+}
+
 resource_schema "aws_codedeploy_deployment_config" {
   cloudformation_type_name = "AWS::CodeDeploy::DeploymentConfig"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_codeguruprofiler_profiling_group" {
@@ -570,11 +530,6 @@ resource_schema "aws_connect_hours_of_operation" {
 
 resource_schema "aws_connect_instance" {
   cloudformation_type_name = "AWS::Connect::Instance"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_connect_instance_storage_config" {
@@ -616,10 +571,6 @@ resource_schema "aws_controltower_enabled_control" {
   suppress_plural_data_source_generation = true
 }
 
-resource_schema "aws_cur_report_definition" {
-  cloudformation_type_name = "AWS::CUR::ReportDefinition"
-}
-
 resource_schema "aws_customerprofiles_domain" {
   cloudformation_type_name = "AWS::CustomerProfiles::Domain"
 }
@@ -648,10 +599,6 @@ resource_schema "aws_databrew_project" {
 
 resource_schema "aws_databrew_recipe" {
   cloudformation_type_name = "AWS::DataBrew::Recipe"
-
-  # Parameters property is 'anyOf', which we cannot yet handle.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_databrew_ruleset" {
@@ -664,11 +611,6 @@ resource_schema "aws_databrew_schedule" {
 
 resource_schema "aws_datapipeline_pipeline" {
   cloudformation_type_name = "AWS::DataPipeline::Pipeline"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_datasync_agent" {
@@ -742,11 +684,6 @@ resource_schema "aws_dynamodb_global_table" {
 
 resource_schema "aws_dynamodb_table" {
   cloudformation_type_name = "AWS::DynamoDB::Table"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_ec2_capacity_reservation" {
@@ -775,11 +712,6 @@ resource_schema "aws_ec2_ec2_fleet" {
 
 resource_schema "aws_ec2_eip" {
   cloudformation_type_name = "AWS::EC2::EIP"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_ec2_egress_only_internet_gateway" {
@@ -804,10 +736,6 @@ resource_schema "aws_ec2_host" {
   cloudformation_type_name = "AWS::EC2::Host"
 }
 
-resource_schema "aws_ec2_internet_gateway" {
-  cloudformation_type_name = "AWS::EC2::InternetGateway"
-}
-
 resource_schema "aws_ec2_ipam" {
   cloudformation_type_name = "AWS::EC2::IPAM"
 }
@@ -823,6 +751,14 @@ resource_schema "aws_ec2_ipam_pool" {
 
 resource_schema "aws_ec2_ipam_scope" {
   cloudformation_type_name = "AWS::EC2::IPAMScope"
+}
+
+resource_schema "aws_ec2_internet_gateway" {
+  cloudformation_type_name = "AWS::EC2::InternetGateway"
+}
+
+resource_schema "aws_ec2_key_pair" {
+  cloudformation_type_name = "AWS::EC2::KeyPair"
 }
 
 resource_schema "aws_ec2_local_gateway_route" {
@@ -878,8 +814,7 @@ resource_schema "aws_ec2_spot_fleet" {
 }
 
 resource_schema "aws_ec2_subnet" {
-  cloudformation_type_name               = "AWS::EC2::Subnet"
-  suppress_plural_data_source_generation = true
+  cloudformation_type_name = "AWS::EC2::Subnet"
 }
 
 resource_schema "aws_ec2_subnet_network_acl_association" {
@@ -935,15 +870,6 @@ resource_schema "aws_ec2_vpc" {
 
 resource_schema "aws_ec2_vpcdhcp_options_association" {
   cloudformation_type_name = "AWS::EC2::VPCDHCPOptionsAssociation"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
-}
-
-resource_schema "aws_ec2_vpc_endpoint" {
-  cloudformation_type_name = "AWS::EC2::VPCEndpoint"
 }
 
 resource_schema "aws_ec2_vpc_peering_connection" {
@@ -952,15 +878,14 @@ resource_schema "aws_ec2_vpc_peering_connection" {
 
 resource_schema "aws_ec2_vpn_connection" {
   cloudformation_type_name = "AWS::EC2::VPNConnection"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_ec2_vpn_gateway" {
   cloudformation_type_name = "AWS::EC2::VPNGateway"
+}
+
+resource_schema "aws_ecr_public_repository" {
+  cloudformation_type_name = "AWS::ECR::PublicRepository"
 }
 
 resource_schema "aws_ecr_pull_through_cache_rule" {
@@ -973,10 +898,6 @@ resource_schema "aws_ecr_registry_policy" {
 
 resource_schema "aws_ecr_replication_configuration" {
   cloudformation_type_name = "AWS::ECR::ReplicationConfiguration"
-}
-
-resource_schema "aws_ecr_public_repository" {
-  cloudformation_type_name = "AWS::ECR::PublicRepository"
 }
 
 resource_schema "aws_ecr_repository" {
@@ -1052,11 +973,6 @@ resource_schema "aws_eks_nodegroup" {
 
 resource_schema "aws_emr_security_configuration" {
   cloudformation_type_name = "AWS::EMR::SecurityConfiguration"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_emr_studio" {
@@ -1071,17 +987,16 @@ resource_schema "aws_emrcontainers_virtual_cluster" {
   cloudformation_type_name = "AWS::EMRContainers::VirtualCluster"
 }
 
+resource_schema "aws_emrserverless_application" {
+  cloudformation_type_name = "AWS::EMRServerless::Application"
+}
+
 resource_schema "aws_elasticache_global_replication_group" {
   cloudformation_type_name = "AWS::ElastiCache::GlobalReplicationGroup"
 }
 
 resource_schema "aws_elasticache_subnet_group" {
   cloudformation_type_name = "AWS::ElastiCache::SubnetGroup"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_elasticache_user" {
@@ -1094,42 +1009,20 @@ resource_schema "aws_elasticache_user_group" {
 
 resource_schema "aws_elasticbeanstalk_application" {
   cloudformation_type_name = "AWS::ElasticBeanstalk::Application"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_elasticbeanstalk_application_version" {
   cloudformation_type_name = "AWS::ElasticBeanstalk::ApplicationVersion"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_elasticloadbalancingv2_listener" {
   cloudformation_type_name               = "AWS::ElasticLoadBalancingV2::Listener"
   suppress_plural_data_source_generation = true
-
-  # error creating write-only attribute path (/properties/DefaultActions/*/AuthenticateOidcConfig/ClientSecret): invalid property path segment: "*"
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_elasticloadbalancingv2_listener_rule" {
   cloudformation_type_name               = "AWS::ElasticLoadBalancingV2::ListenerRule"
   suppress_plural_data_source_generation = true
-
-  # error creating write-only attribute path (/properties/Actions/*/AuthenticateOidcConfig/ClientSecret): invalid property path segment: "*"
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-}
-
-resource_schema "aws_emrserverless_application" {
-  cloudformation_type_name = "AWS::EMRServerless::Application"
 }
 
 resource_schema "aws_eventschemas_registry_policy" {
@@ -1147,10 +1040,6 @@ resource_schema "aws_events_archive" {
 
 resource_schema "aws_events_connection" {
   cloudformation_type_name = "AWS::Events::Connection"
-
-  # error creating write-only attribute path (/definitions/BasicAuthParameters/Password): expected "properties" for the second property path segment, got: "definitions"
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_events_endpoint" {
@@ -1186,14 +1075,6 @@ resource_schema "aws_fis_experiment_template" {
   cloudformation_type_name = "AWS::FIS::ExperimentTemplate"
 }
 
-resource_schema "aws_forecast_dataset" {
-  cloudformation_type_name = "AWS::Forecast::Dataset"
-}
-
-resource_schema "aws_forecast_dataset_group" {
-  cloudformation_type_name = "AWS::Forecast::DatasetGroup"
-}
-
 resource_schema "aws_fms_notification_channel" {
   cloudformation_type_name               = "AWS::FMS::NotificationChannel"
   suppress_plural_data_source_generation = true
@@ -1206,6 +1087,14 @@ resource_schema "aws_fms_policy" {
 
 resource_schema "aws_finspace_environment" {
   cloudformation_type_name = "AWS::FinSpace::Environment"
+}
+
+resource_schema "aws_forecast_dataset" {
+  cloudformation_type_name = "AWS::Forecast::Dataset"
+}
+
+resource_schema "aws_forecast_dataset_group" {
+  cloudformation_type_name = "AWS::Forecast::DatasetGroup"
 }
 
 resource_schema "aws_frauddetector_detector" {
@@ -1286,11 +1175,6 @@ resource_schema "aws_greengrassv2_deployment" {
 
 resource_schema "aws_groundstation_config" {
   cloudformation_type_name = "AWS::GroundStation::Config"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_groundstation_dataflow_endpoint_group" {
@@ -1303,6 +1187,10 @@ resource_schema "aws_groundstation_mission_profile" {
 
 resource_schema "aws_healthlake_fhir_datastore" {
   cloudformation_type_name = "AWS::HealthLake::FHIRDatastore"
+}
+
+resource_schema "aws_iam_instance_profile" {
+  cloudformation_type_name = "AWS::IAM::InstanceProfile"
 }
 
 resource_schema "aws_iam_oidc_provider" {
@@ -1351,19 +1239,6 @@ resource_schema "aws_identitystore_group_membership" {
   suppress_plural_data_source_generation = true
 }
 
-resource_schema "aws_inspector_assessment_target" {
-  cloudformation_type_name = "AWS::Inspector::AssessmentTarget"
-}
-
-resource_schema "aws_inspector_assessment_template" {
-  cloudformation_type_name = "AWS::Inspector::AssessmentTemplate"
-}
-
-resource_schema "aws_inspector_resource_group" {
-  cloudformation_type_name               = "AWS::Inspector::ResourceGroup"
-  suppress_plural_data_source_generation = true
-}
-
 resource_schema "aws_imagebuilder_component" {
   cloudformation_type_name               = "AWS::ImageBuilder::Component"
   suppress_plural_data_source_generation = true
@@ -1378,7 +1253,8 @@ resource_schema "aws_imagebuilder_distribution_configuration" {
 }
 
 resource_schema "aws_imagebuilder_image" {
-  cloudformation_type_name = "AWS::ImageBuilder::Image"
+  cloudformation_type_name               = "AWS::ImageBuilder::Image"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_imagebuilder_image_pipeline" {
@@ -1391,6 +1267,19 @@ resource_schema "aws_imagebuilder_image_recipe" {
 
 resource_schema "aws_imagebuilder_infrastructure_configuration" {
   cloudformation_type_name = "AWS::ImageBuilder::InfrastructureConfiguration"
+}
+
+resource_schema "aws_inspector_assessment_target" {
+  cloudformation_type_name = "AWS::Inspector::AssessmentTarget"
+}
+
+resource_schema "aws_inspector_assessment_template" {
+  cloudformation_type_name = "AWS::Inspector::AssessmentTemplate"
+}
+
+resource_schema "aws_inspector_resource_group" {
+  cloudformation_type_name               = "AWS::Inspector::ResourceGroup"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_inspectorv2_filter" {
@@ -1443,11 +1332,6 @@ resource_schema "aws_iot_mitigation_action" {
 
 resource_schema "aws_iot_policy" {
   cloudformation_type_name = "AWS::IoT::Policy"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_iot_provisioning_template" {
@@ -1480,38 +1364,18 @@ resource_schema "aws_iot_topic_rule_destination" {
 
 resource_schema "aws_iotanalytics_channel" {
   cloudformation_type_name = "AWS::IoTAnalytics::Channel"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_iotanalytics_dataset" {
   cloudformation_type_name = "AWS::IoTAnalytics::Dataset"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_iotanalytics_datastore" {
   cloudformation_type_name = "AWS::IoTAnalytics::Datastore"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_iotanalytics_pipeline" {
   cloudformation_type_name = "AWS::IoTAnalytics::Pipeline"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_iotcoredeviceadvisor_suite_definition" {
@@ -1540,11 +1404,6 @@ resource_schema "aws_iotfleetwise_campaign" {
 
 resource_schema "aws_iotfleetwise_decoder_manifest" {
   cloudformation_type_name = "AWS::IoTFleetWise::DecoderManifest"
-
-  # NetworkInterfaces is of unsupported type: list of .
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_iotfleetwise_fleet" {
@@ -1597,19 +1456,11 @@ resource_schema "aws_iotsitewise_project" {
 resource_schema "aws_iottwinmaker_component_type" {
   cloudformation_type_name               = "AWS::IoTTwinMaker::ComponentType"
   suppress_plural_data_source_generation = true
-
-  # Goes into infinite recursion while generating code...
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_iottwinmaker_entity" {
   cloudformation_type_name               = "AWS::IoTTwinMaker::Entity"
   suppress_plural_data_source_generation = true
-
-  # Goes into infinite recursion while generating code...
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_iottwinmaker_scene" {
@@ -1848,11 +1699,6 @@ resource_schema "aws_location_tracker_consumer" {
 
 resource_schema "aws_logs_destination" {
   cloudformation_type_name = "AWS::Logs::Destination"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_logs_log_group" {
@@ -1860,21 +1706,12 @@ resource_schema "aws_logs_log_group" {
 }
 
 resource_schema "aws_logs_log_stream" {
-  cloudformation_type_name = "AWS::Logs::LogStream"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
+  cloudformation_type_name               = "AWS::Logs::LogStream"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_logs_metric_filter" {
   cloudformation_type_name = "AWS::Logs::MetricFilter"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_logs_query_definition" {
@@ -1883,6 +1720,11 @@ resource_schema "aws_logs_query_definition" {
 
 resource_schema "aws_logs_resource_policy" {
   cloudformation_type_name = "AWS::Logs::ResourcePolicy"
+}
+
+resource_schema "aws_logs_subscription_filter" {
+  cloudformation_type_name               = "AWS::Logs::SubscriptionFilter"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_lookoutequipment_inference_scheduler" {
@@ -1996,12 +1838,8 @@ resource_schema "aws_mediapackage_packaging_group" {
 }
 
 resource_schema "aws_mediatailor_playback_configuration" {
-  cloudformation_type_name = "AWS::MediaTailor::PlaybackConfiguration"
-
-  # "ConfigurationAliases is of unsupported type: ".
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
+  cloudformation_type_name               = "AWS::MediaTailor::PlaybackConfiguration"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_memorydb_acl" {
@@ -2068,12 +1906,8 @@ resource_schema "aws_networkmanager_global_network" {
 }
 
 resource_schema "aws_networkmanager_link" {
-  cloudformation_type_name = "AWS::NetworkManager::Link"
-
-  # Top-level "Provider" property conflicts with Terraform meta-argument.
-  suppress_plural_data_source_generation   = true
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
+  cloudformation_type_name               = "AWS::NetworkManager::Link"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_networkmanager_link_association" {
@@ -2119,21 +1953,12 @@ resource_schema "aws_nimblestudio_studio_component" {
 }
 
 resource_schema "aws_opensearchservice_domain" {
-  cloudformation_type_name = "AWS::OpenSearchService::Domain"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
+  cloudformation_type_name               = "AWS::OpenSearchService::Domain"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_opsworkscm_server" {
   cloudformation_type_name = "AWS::OpsWorksCM::Server"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_panorama_application_instance" {
@@ -2206,29 +2031,14 @@ resource_schema "aws_quicksight_theme" {
 
 resource_schema "aws_rds_db_cluster" {
   cloudformation_type_name = "AWS::RDS::DBCluster"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_rds_db_cluster_parameter_group" {
   cloudformation_type_name = "AWS::RDS::DBClusterParameterGroup"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_rds_db_instance" {
   cloudformation_type_name = "AWS::RDS::DBInstance"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_rds_db_parameter_group" {
@@ -2262,11 +2072,6 @@ resource_schema "aws_rds_global_cluster" {
 
 resource_schema "aws_rds_option_group" {
   cloudformation_type_name = "AWS::RDS::OptionGroup"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_rum_app_monitor" {
@@ -2275,29 +2080,14 @@ resource_schema "aws_rum_app_monitor" {
 
 resource_schema "aws_redshift_cluster" {
   cloudformation_type_name = "AWS::Redshift::Cluster"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_redshift_cluster_parameter_group" {
   cloudformation_type_name = "AWS::Redshift::ClusterParameterGroup"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_redshift_cluster_subnet_group" {
   cloudformation_type_name = "AWS::Redshift::ClusterSubnetGroup"
-
-  # Suppress until given green light by AWS.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_redshift_endpoint_access" {
@@ -2353,11 +2143,6 @@ resource_schema "aws_rekognition_project" {
 
 resource_schema "aws_rekognition_stream_processor" {
   cloudformation_type_name = "AWS::Rekognition::StreamProcessor"
-
-  # PolygonRegionsOfInterest is of unsupported type: set of array.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_resiliencehub_app" {
@@ -2373,11 +2158,13 @@ resource_schema "aws_resourcegroups_group" {
 }
 
 resource_schema "aws_robomaker_fleet" {
-  cloudformation_type_name = "AWS::RoboMaker::Fleet"
+  cloudformation_type_name               = "AWS::RoboMaker::Fleet"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_robomaker_robot" {
-  cloudformation_type_name = "AWS::RoboMaker::Robot"
+  cloudformation_type_name               = "AWS::RoboMaker::Robot"
+  suppress_plural_data_source_generation = true
 }
 
 resource_schema "aws_robomaker_robot_application" {
@@ -2488,10 +2275,6 @@ resource_schema "aws_route53resolver_resolver_dnssec_config" {
   cloudformation_type_name = "AWS::Route53Resolver::ResolverDNSSECConfig"
 }
 
-resource_schema "aws_route53resolver_resolver_rule_association" {
-  cloudformation_type_name = "AWS::Route53Resolver::ResolverRuleAssociation"
-}
-
 resource_schema "aws_route53resolver_resolver_query_logging_config" {
   cloudformation_type_name = "AWS::Route53Resolver::ResolverQueryLoggingConfig"
 }
@@ -2502,6 +2285,10 @@ resource_schema "aws_route53resolver_resolver_query_logging_config_association" 
 
 resource_schema "aws_route53resolver_resolver_rule" {
   cloudformation_type_name = "AWS::Route53Resolver::ResolverRule"
+}
+
+resource_schema "aws_route53resolver_resolver_rule_association" {
+  cloudformation_type_name = "AWS::Route53Resolver::ResolverRuleAssociation"
 }
 
 resource_schema "aws_s3_access_point" {
@@ -2551,11 +2338,6 @@ resource_schema "aws_s3outposts_bucket_policy" {
 
 resource_schema "aws_s3outposts_endpoint" {
   cloudformation_type_name = "AWS::S3Outposts::Endpoint"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_ses_configuration_set" {
@@ -2585,11 +2367,10 @@ resource_schema "aws_ses_template" {
 
 resource_schema "aws_sns_topic" {
   cloudformation_type_name = "AWS::SNS::Topic"
+}
 
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
+resource_schema "aws_sqs_queue" {
+  cloudformation_type_name = "AWS::SQS::Queue"
 }
 
 resource_schema "aws_ssm_association" {
@@ -2636,10 +2417,6 @@ resource_schema "aws_sso_instance_access_control_attribute_configuration" {
 resource_schema "aws_sso_permission_set" {
   cloudformation_type_name               = "AWS::SSO::PermissionSet"
   suppress_plural_data_source_generation = true
-}
-
-resource_schema "aws_sqs_queue" {
-  cloudformation_type_name = "AWS::SQS::Queue"
 }
 
 resource_schema "aws_sagemaker_app" {
@@ -2782,20 +2559,10 @@ resource_schema "aws_supportapp_slack_channel_configuration" {
 
 resource_schema "aws_synthetics_canary" {
   cloudformation_type_name = "AWS::Synthetics::Canary"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_synthetics_group" {
   cloudformation_type_name = "AWS::Synthetics::Group"
-
-  # Top-level "Id" property is not a primary identifier.
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
-  suppress_plural_data_source_generation   = true
 }
 
 resource_schema "aws_timestream_database" {
@@ -2852,19 +2619,11 @@ resource_schema "aws_wafv2_regex_pattern_set" {
 resource_schema "aws_wafv2_rule_group" {
   cloudformation_type_name               = "AWS::WAFv2::RuleGroup"
   suppress_plural_data_source_generation = true
-
-  # Goes into infinite recursion while generating code...
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_wafv2_web_acl" {
   cloudformation_type_name               = "AWS::WAFv2::WebACL"
   suppress_plural_data_source_generation = true
-
-  # Goes into infinite recursion while generating code...
-  suppress_resource_generation             = true
-  suppress_singular_data_source_generation = true
 }
 
 resource_schema "aws_wafv2_web_acl_association" {

--- a/internal/service/cloudformation/schemas/AWS_ApiGatewayV2_Model.json
+++ b/internal/service/cloudformation/schemas/AWS_ApiGatewayV2_Model.json
@@ -32,28 +32,30 @@
     "handlers": {
         "create": {
             "permissions": [
-                "apigatewayv2:createModel"
+                "apigateway:POST"
             ]
         },
         "update": {
             "permissions": [
-                "apigatewayv2:updateModel"
+                "apigateway:PATCH",
+                "apigateway:GET",
+                "apigateway:PUT"
             ]
         },
         "read": {
             "permissions": [
-                "apigatewayv2:getModel"
+                "apigateway:GET"
             ]
         },
         "delete": {
             "permissions": [
-                "apigatewayv2:getModel",
-                "apigatewayv2:deleteModel"
+                "apigateway:GET",
+                "apigateway:DELETE"
             ]
         },
         "list": {
             "permissions": [
-                "apigatewayv2:getModels"
+                "apigateway:GET"
             ]
         }
     }

--- a/internal/service/cloudformation/schemas/AWS_ApiGatewayV2_VpcLink.json
+++ b/internal/service/cloudformation/schemas/AWS_ApiGatewayV2_VpcLink.json
@@ -48,8 +48,7 @@
     "handlers": {
         "create": {
             "permissions": [
-                "apigateway:createVpcLink",
-                "apigateway:getVpcLink",
+                "apigateway:POST",
                 "iam:CreateServiceLinkedRole",
                 "iam:DeleteServiceLinkedRole",
                 "iam:GetServiceLinkedRoleDeletionStatus"
@@ -57,8 +56,8 @@
         },
         "update": {
             "permissions": [
-                "apigateway:updateVpcLink",
-                "apigateway:getVpcLink",
+                "apigateway:PATCH",
+                "apigateway:GET",
                 "iam:CreateServiceLinkedRole",
                 "iam:DeleteServiceLinkedRole",
                 "iam:GetServiceLinkedRoleDeletionStatus"
@@ -66,7 +65,7 @@
         },
         "read": {
             "permissions": [
-                "apigateway:getVpcLink",
+                "apigateway:GET",
                 "iam:CreateServiceLinkedRole",
                 "iam:DeleteServiceLinkedRole",
                 "iam:GetServiceLinkedRoleDeletionStatus"
@@ -74,8 +73,8 @@
         },
         "delete": {
             "permissions": [
-                "apigateway:deleteVpcLink",
-                "apigateway:getVpcLink",
+                "apigateway:GET",
+                "apigateway:DELETE",
                 "iam:CreateServiceLinkedRole",
                 "iam:DeleteServiceLinkedRole",
                 "iam:GetServiceLinkedRoleDeletionStatus"
@@ -83,7 +82,7 @@
         },
         "list": {
             "permissions": [
-                "apigateway:getVpcLinks",
+                "apigateway:GET",
                 "iam:CreateServiceLinkedRole",
                 "iam:DeleteServiceLinkedRole",
                 "iam:GetServiceLinkedRoleDeletionStatus"

--- a/internal/service/cloudformation/schemas/AWS_AppFlow_Flow.json
+++ b/internal/service/cloudformation/schemas/AWS_AppFlow_Flow.json
@@ -766,6 +766,9 @@
                 },
                 "IncludeDeletedRecords": {
                     "$ref": "#/definitions/IncludeDeletedRecords"
+                },
+                "DataTransferApi" : {
+                    "$ref": "#/definitions/DataTransferApi"
                 }
             },
             "required": [
@@ -1011,6 +1014,9 @@
                 },
                 "WriteOperationType": {
                     "$ref": "#/definitions/WriteOperationType"
+                },
+                "DataTransferApi" : {
+                    "$ref": "#/definitions/DataTransferApi"
                 }
             },
             "required": [
@@ -1134,7 +1140,8 @@
                 "MATH_OPERATION_FIELDS_ORDER",
                 "CONCAT_FORMAT",
                 "SUBFIELD_CATEGORY_MAP",
-                "EXCLUDE_SOURCE_FIELDS_LIST"
+                "EXCLUDE_SOURCE_FIELDS_LIST",
+                "INCLUDE_NEW_FIELDS"
             ]
         },
         "TaskPropertiesObject": {
@@ -1488,6 +1495,14 @@
                 "Draft",
                 "Errored",
                 "Suspended"
+            ]
+        },
+        "DataTransferApi": {
+            "type": "string",
+            "enum": [
+                "AUTOMATIC",
+                "BULKV2",
+                "REST_SYNC"
             ]
         }
     },

--- a/internal/service/cloudformation/schemas/AWS_CodeStarNotifications_NotificationRule.json
+++ b/internal/service/cloudformation/schemas/AWS_CodeStarNotifications_NotificationRule.json
@@ -93,8 +93,7 @@
         "Name"
     ],
     "createOnlyProperties": [
-        "/properties/Resource",
-        "/properties/Tags"
+        "/properties/Resource"
     ],
     "primaryIdentifier": [
         "/properties/Arn"
@@ -130,7 +129,10 @@
         },
         "update": {
             "permissions": [
-                "codestar-notifications:updateNotificationRule"
+                "codestar-notifications:updateNotificationRule",
+                "codestar-notifications:TagResource",
+                "codestar-notifications:UntagResource"
+
             ]
         }
     }

--- a/internal/service/cloudformation/schemas/AWS_Connect_User.json
+++ b/internal/service/cloudformation/schemas/AWS_Connect_User.json
@@ -3,10 +3,6 @@
   "description": "Resource Type definition for AWS::Connect::User",
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-connect",
   "definitions": {
-    "Email": {
-      "description": "The email address. If you are using SAML for identity management and include this parameter, an error is returned.",
-      "type": "string"
-    },
     "FirstName": {
       "description": "The first name. This is required if you are using Amazon Connect or SAML for identity management.",
       "type": "string"
@@ -14,6 +10,21 @@
     "LastName": {
       "description": "The last name. This is required if you are using Amazon Connect or SAML for identity management.",
       "type": "string"
+    },
+    "Email": {
+      "description": "The email address. If you are using SAML for identity management and include this parameter, an error is returned.",
+      "type": "string"
+    },
+    "SecondaryEmail": {
+      "description": "The secondary email address. If you provide a secondary email, the user receives email notifications -- other than password reset notifications -- to this email address instead of to their primary email address.",
+      "type": "string",
+      "pattern": ""
+    },
+    "Mobile": {
+      "description": "The mobile phone number.",
+      "type": "string",
+      "pattern": "^\\+[1-9]\\d{1,14}$"
+
     },
     "SecurityProfileArn": {
       "description": "The identifier of the security profile for the user.",
@@ -46,14 +57,20 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "Email": {
-          "$ref": "#/definitions/Email"
-        },
         "FirstName": {
           "$ref": "#/definitions/FirstName"
         },
         "LastName": {
           "$ref": "#/definitions/LastName"
+        },
+        "Email": {
+          "$ref": "#/definitions/Email"
+        },
+        "SecondaryEmail": {
+          "$ref": "#/definitions/SecondaryEmail"
+        },
+        "Mobile": {
+          "$ref": "#/definitions/Mobile"
         }
       }
     },

--- a/internal/service/cloudformation/schemas/AWS_DataPipeline_Pipeline.json
+++ b/internal/service/cloudformation/schemas/AWS_DataPipeline_Pipeline.json
@@ -1,0 +1,252 @@
+{
+  "typeName": "AWS::DataPipeline::Pipeline",
+  "description": "An example resource schema demonstrating some basic constructs and validation rules.",
+  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-datapipeline",
+  "properties": {
+    "Activate": {
+      "description": "Indicates whether to validate and start the pipeline or stop an active pipeline. By default, the value is set to true.",
+      "type": "boolean"
+    },
+    "Description": {
+      "description": "A description of the pipeline.",
+      "type": "string"
+    },
+    "Name": {
+      "description": "The name of the pipeline.",
+      "type": "string"
+    },
+    "ParameterObjects": {
+      "description": "The parameter objects used with the pipeline.",
+      "uniqueItems": false,
+      "insertionOrder": false,
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ParameterObject"
+      }
+    },
+    "ParameterValues": {
+      "description": "The parameter values used with the pipeline.",
+      "uniqueItems": false,
+      "insertionOrder": false,
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ParameterValue"
+      }
+    },
+    "PipelineObjects": {
+      "description": "The objects that define the pipeline. These objects overwrite the existing pipeline definition. Not all objects, fields, and values can be updated. For information about restrictions, see Editing Your Pipeline in the AWS Data Pipeline Developer Guide.",
+      "uniqueItems": false,
+      "insertionOrder": false,
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PipelineObject"
+      }
+    },
+    "PipelineTags": {
+      "description": "A list of arbitrary tags (key-value pairs) to associate with the pipeline, which you can use to control permissions. For more information, see Controlling Access to Pipelines and Resources in the AWS Data Pipeline Developer Guide.",
+      "uniqueItems": false,
+      "insertionOrder": false,
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PipelineTag"
+      }
+    },
+    "PipelineId": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "ParameterObject": {
+      "type": "object",
+      "properties": {
+        "Attributes": {
+          "description": "The attributes of the parameter object.",
+          "uniqueItems": false,
+          "insertionOrder": false,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ParameterAttribute"
+          }
+        },
+        "Id": {
+          "description": "The ID of the parameter object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Attributes",
+        "Id"
+      ],
+      "additionalProperties": false
+    },
+    "ParameterAttribute": {
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "The field identifier.",
+          "type": "string"
+        },
+        "StringValue": {
+          "description": "The field value, expressed as a String.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Key",
+        "StringValue"
+      ],
+      "additionalProperties": false
+    },
+    "ParameterValue": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "description": "The ID of the parameter value.",
+          "type": "string"
+        },
+        "StringValue": {
+          "description": "The field value, expressed as a String.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Id",
+        "StringValue"
+      ],
+      "additionalProperties": false
+    },
+    "Field": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Key": {
+          "description": "Specifies the name of a field for a particular object. To view valid values for a particular field, see Pipeline Object Reference in the AWS Data Pipeline Developer Guide.",
+          "type": "string"
+        },
+        "RefValue": {
+          "description": "A field value that you specify as an identifier of another object in the same pipeline definition.",
+          "type": "string"
+        },
+        "StringValue": {
+          "description": "A field value that you specify as a string. To view valid values for a particular field, see Pipeline Object Reference in the AWS Data Pipeline Developer Guide.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Key"
+      ]
+    },
+    "PipelineObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Fields": {
+          "description": "Key-value pairs that define the properties of the object.",
+          "type": "array",
+          "uniqueItems": false,
+          "insertionOrder": false,
+          "items": {
+            "$ref": "#/definitions/Field"
+          }
+        },
+        "Id": {
+          "description": "The ID of the object.",
+          "type": "string"
+        },
+        "Name": {
+          "description": "The name of the object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Fields",
+        "Id",
+        "Name"
+      ]
+    },
+    "PipelineTag": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Key": {
+          "description": "The key name of a tag.",
+          "type": "string"
+        },
+        "Value": {
+          "description": "The value to associate with the key name.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Key",
+        "Value"
+      ]
+    }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "cloudFormationSystemTags": false,
+    "tagProperty": "/properties/PipelineTags"
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name"
+  ],
+  "readOnlyProperties": [
+    "/properties/PipelineId"
+  ],
+  "createOnlyProperties": [
+    "/properties/Description",
+    "/properties/Name"
+  ],
+  "primaryIdentifier": [
+    "/properties/PipelineId"
+  ],
+  "handlers": {
+    "create": {
+      "permissions": [
+        "datapipeline:CreatePipeline",
+        "datapipeline:PutPipelineDefinition",
+        "datapipeline:GetPipelineDefinition",
+        "datapipeline:DescribePipelines",
+        "datapipeline:ValidatePipelineDefinition",
+        "datapipeline:ActivatePipeline",
+        "datapipeline:AddTags"
+      ]
+    },
+    "read": {
+      "permissions": [
+        "datapipeline:GetPipelineDefinition",
+        "datapipeline:DescribePipelines"
+      ]
+    },
+    "update": {
+      "permissions": [
+        "datapipeline:PutPipelineDefinition",
+        "datapipeline:AddTags",
+        "datapipeline:RemoveTags",
+        "datapipeline:DeactivatePipeline",
+        "datapipeline:GetPipelineDefinition",
+        "datapipeline:ActivatePipeline",
+        "datapipeline:ValidatePipelineDefinition",
+        "datapipeline:DescribePipelines",
+        "datapipeline:AddTags",
+        "datapipeline:RemoveTags"
+      ]
+    },
+    "delete": {
+      "permissions": [
+        "datapipeline:DeletePipeline",
+        "datapipeline:DescribePipelines",
+        "datapipeline:RemoveTags"
+      ]
+    },
+    "list": {
+      "permissions": [
+        "datapipeline:ListPipelines"
+      ]
+    }
+  }
+}

--- a/internal/service/cloudformation/schemas/AWS_EC2_VPCEndpoint.json
+++ b/internal/service/cloudformation/schemas/AWS_EC2_VPCEndpoint.json
@@ -1,131 +1,67 @@
 {
-  "typeName": "AWS::EC2::VPCEndpoint",
-  "description": "Resource Type definition for AWS::EC2::VPCEndpoint",
-  "additionalProperties": false,
-  "properties": {
-    "Id": {
-      "type": "string"
+  "typeName" : "AWS::EC2::VPCEndpoint",
+  "description" : "Resource Type definition for AWS::EC2::VPCEndpoint",
+  "additionalProperties" : false,
+  "properties" : {
+    "Id" : {
+      "type" : "string"
     },
-    "CreationTimestamp": {
-      "type": "string"
+    "CreationTimestamp" : {
+      "type" : "string"
     },
-    "DnsEntries": {
-      "type": "array",
-      "uniqueItems": false,
-      "insertionOrder": false,
-      "items": {
-        "type": "string"
+    "DnsEntries" : {
+      "type" : "array",
+      "uniqueItems" : false,
+      "items" : {
+        "type" : "string"
       }
     },
-    "NetworkInterfaceIds": {
-      "type": "array",
-      "uniqueItems": false,
-      "insertionOrder": false,
-      "items": {
-        "type": "string"
+    "NetworkInterfaceIds" : {
+      "type" : "array",
+      "uniqueItems" : false,
+      "items" : {
+        "type" : "string"
       }
     },
-    "PolicyDocument": {
-      "type": [
-        "string",
-        "object"
-      ],
-      "description": "A policy to attach to the endpoint that controls access to the service."
+    "PolicyDocument" : {
+      "type" : "object"
     },
-    "PrivateDnsEnabled": {
-      "type": "boolean",
-      "description": "Indicate whether to associate a private hosted zone with the specified VPC."
+    "PrivateDnsEnabled" : {
+      "type" : "boolean"
     },
-    "RouteTableIds": {
-      "type": "array",
-      "description": "One or more route table IDs.",
-      "uniqueItems": true,
-      "insertionOrder": false,
-      "items": {
-        "type": "string"
+    "RouteTableIds" : {
+      "type" : "array",
+      "uniqueItems" : true,
+      "items" : {
+        "type" : "string"
       }
     },
-    "SecurityGroupIds": {
-      "type": "array",
-      "description": "The ID of one or more security groups to associate with the endpoint network interface.",
-      "uniqueItems": true,
-      "insertionOrder": false,
-      "items": {
-        "type": "string"
+    "SecurityGroupIds" : {
+      "type" : "array",
+      "uniqueItems" : true,
+      "items" : {
+        "type" : "string"
       }
     },
-    "ServiceName": {
-      "type": "string",
-      "description": "The service name."
+    "ServiceName" : {
+      "type" : "string"
     },
-    "SubnetIds": {
-      "type": "array",
-      "description": "The ID of one or more subnets in which to create an endpoint network interface.",
-      "uniqueItems": true,
-      "insertionOrder": false,
-      "items": {
-        "type": "string"
+    "SubnetIds" : {
+      "type" : "array",
+      "uniqueItems" : true,
+      "items" : {
+        "type" : "string"
       }
     },
-    "VpcEndpointType": {
-      "type": "string",
-      "enum": [
-        "Interface",
-        "Gateway",
-        "GatewayLoadBalancer"
-      ]
+    "VpcEndpointType" : {
+      "type" : "string"
     },
-    "VpcId": {
-      "type": "string",
-      "description": "The ID of the VPC in which the endpoint will be used."
+    "VpcId" : {
+      "type" : "string"
     }
   },
-  "required": [
-    "VpcId",
-    "ServiceName"
-  ],
-  "readOnlyProperties": [
-    "/properties/NetworkInterfaceIds",
-    "/properties/CreationTimestamp",
-    "/properties/DnsEntries",
-    "/properties/Id"
-  ],
-  "createOnlyProperties": [
-    "/properties/ServiceName",
-    "/properties/VpcEndpointType",
-    "/properties/VpcId"
-  ],
-  "primaryIdentifier": [
-    "/properties/Id"
-  ],
-  "taggable": false,
-  "handlers": {
-    "create": {
-      "permissions": [
-        "ec2:CreateVpcEndpoint",
-        "ec2:DescribeVpcEndpoints"
-      ]
-    },
-    "read": {
-      "permissions": [
-        "ec2:DescribeVpcEndpoints"
-      ]
-    },
-    "update": {
-      "permissions": [
-        "ec2:ModifyVpcEndpoint",
-        "ec2:DescribeVpcEndpoints"
-      ]
-    },
-    "delete": {
-      "permissions": [
-        "ec2:DeleteVpcEndpoints"
-      ]
-    },
-    "list": {
-      "permissions": [
-        "ec2:DescribeVpcEndpoints"
-      ]
-    }
-  }
+  "required" : [ "VpcId", "ServiceName" ],
+  "readOnlyProperties" : [ "/properties/NetworkInterfaceIds", "/properties/CreationTimestamp", "/properties/DnsEntries", "/properties/Id" ],
+  "createOnlyProperties" : [ "/properties/ServiceName", "/properties/VpcEndpointType", "/properties/VpcId" ],
+  "primaryIdentifier" : [ "/properties/Id" ]
 }

--- a/internal/service/cloudformation/schemas/AWS_IdentityStore_GroupMembership.json
+++ b/internal/service/cloudformation/schemas/AWS_IdentityStore_GroupMembership.json
@@ -3,26 +3,22 @@
     "description": "Resource Type Definition for AWS:IdentityStore::GroupMembership",
     "definitions": {
         "MemberId": {
-            "oneOf": [
-                {
-                    "description": "An object containing the identifier of a group member.",
-                    "type": "object",
-                    "title": "UserId",
-                    "properties": {
-                        "UserId": {
-                            "description": "The identifier for a user in the identity store.",
-                            "type": "string",
-                            "maxLength": 47,
-                            "minLength": 1,
-                            "pattern": "^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
-                        }
-                    },
-                    "required": [
-                        "UserId"
-                    ],
-                    "additionalProperties": false
+            "description": "An object containing the identifier of a group member.",
+            "type": "object",
+            "title": "UserId",
+            "properties": {
+                "UserId": {
+                    "description": "The identifier for a user in the identity store.",
+                    "type": "string",
+                    "maxLength": 47,
+                    "minLength": 1,
+                    "pattern": "^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
                 }
-            ]
+            },
+            "required": [
+                "UserId"
+            ],
+            "additionalProperties": false
         }
     },
     "properties": {

--- a/internal/service/cloudformation/schemas/AWS_Lex_Bot.json
+++ b/internal/service/cloudformation/schemas/AWS_Lex_Bot.json
@@ -701,6 +701,139 @@
         "Ordered"
       ]
     },
+    "AllowedInputTypes": {
+      "description": "Specifies the allowed input types.",
+      "type": "object",
+      "properties": {
+        "AllowAudioInput": {
+          "description": "Indicates whether audio input is allowed.",
+          "type": "boolean"
+        },
+        "AllowDTMFInput": {
+          "description": "Indicates whether DTMF input is allowed.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "AllowAudioInput",
+        "AllowDTMFInput"
+      ],
+      "additionalProperties": false
+    },
+    "DTMFSpecification": {
+      "description": "Specifies the settings on DTMF input.",
+      "type": "object",
+      "properties": {
+        "DeletionCharacter": {
+          "description": "The DTMF character that clears the accumulated DTMF digits and immediately ends the input.",
+          "type": "string",
+          "pattern": "^[A-D0-9#*]{1}$"
+        },
+        "EndCharacter": {
+          "description": "The DTMF character that immediately ends input. If the user does not press this character, the input ends after the end timeout.",
+          "type": "string",
+          "pattern": "^[A-D0-9#*]{1}$"
+        },
+        "EndTimeoutMs": {
+          "description": "How long the bot should wait after the last DTMF character input before assuming that the input has concluded.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "MaxLength": {
+          "description": "The maximum number of DTMF digits allowed in an utterance.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1024
+        }
+      },
+      "required": [
+        "DeletionCharacter",
+        "EndCharacter",
+        "EndTimeoutMs",
+        "MaxLength"
+      ],
+      "additionalProperties": false
+    },
+    "AudioSpecification": {
+      "description": "Specifies the audio input specifications.",
+      "type": "object",
+      "properties": {
+        "EndTimeoutMs": {
+          "description": "Time for which a bot waits after the customer stops speaking to assume the utterance is finished.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "MaxLengthMs": {
+          "description": "Time for how long Amazon Lex waits before speech input is truncated and the speech is returned to application.",
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "EndTimeoutMs",
+        "MaxLengthMs"
+      ],
+      "additionalProperties": false
+    },
+    "AudioAndDTMFInputSpecification": {
+      "description": "Specifies the audio and DTMF input specification.",
+      "type": "object",
+      "properties": {
+        "StartTimeoutMs": {
+          "description": "Time for which a bot waits before assuming that the customer isn't going to speak or press a key. This timeout is shared between Audio and DTMF inputs.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "DTMFSpecification": {
+          "$ref": "#/definitions/DTMFSpecification"
+        },
+        "AudioSpecification": {
+          "$ref": "#/definitions/AudioSpecification"
+        }
+      },
+      "required": [
+        "StartTimeoutMs"
+      ],
+      "additionalProperties": false
+    },
+    "TextInputSpecification": {
+      "description": "Specifies the text input specifications.",
+      "type": "object",
+      "properties": {
+        "StartTimeoutMs": {
+          "description": "Time for which a bot waits before re-prompting a customer for text input.",
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "StartTimeoutMs"
+      ],
+      "additionalProperties": false
+    },
+    "PromptAttemptSpecification": {
+      "description": "Specifies the settings on a prompt attempt.",
+      "type": "object",
+      "properties": {
+        "AllowedInputTypes": {
+          "$ref": "#/definitions/AllowedInputTypes"
+        },
+        "AllowInterrupt": {
+          "description": "Indicates whether the user can interrupt a speech prompt attempt from the bot.",
+          "type": "boolean"
+        },
+        "AudioAndDTMFInputSpecification": {
+          "$ref": "#/definitions/AudioAndDTMFInputSpecification"
+        },
+        "TextInputSpecification": {
+          "$ref": "#/definitions/TextInputSpecification"
+        }
+      },
+      "required": [
+        "AllowedInputTypes"
+      ],
+      "additionalProperties": false
+    },
     "PromptSpecification": {
       "description": "Prompts the user to confirm the intent.",
       "type": "object",
@@ -717,6 +850,16 @@
         },
         "MessageSelectionStrategy": {
           "$ref": "#/definitions/MessageSelectionStrategy"
+        },
+        "PromptAttemptsSpecification": {
+          "description": "Specifies the advanced settings on each attempt of the prompt.",
+          "type": "object",
+          "patternProperties": {
+            "": {
+              "$ref": "#/definitions/PromptAttemptSpecification"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": [

--- a/internal/service/cloudformation/schemas/AWS_MSK_Cluster.json
+++ b/internal/service/cloudformation/schemas/AWS_MSK_Cluster.json
@@ -61,6 +61,15 @@
     },
     "ConfigurationInfo": {
       "$ref": "#/definitions/ConfigurationInfo"
+    },
+    "StorageMode": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 6,
+      "enum": [
+        "LOCAL",
+        "TIERED"
+      ]
     }
   },
   "definitions": {
@@ -484,6 +493,7 @@
         "kafka:UpdateBrokerType",
         "kafka:UpdateBrokerCount",
         "kafka:UpdateBrokerStorage",
+        "kafka:UpdateStorage",
         "kafka:UpdateSecurity",
         "kafka:UpdateConnectivity",
         "kafka:DescribeClusterOperation",

--- a/internal/service/cloudformation/schemas/AWS_Redshift_EndpointAccess.json
+++ b/internal/service/cloudformation/schemas/AWS_Redshift_EndpointAccess.json
@@ -142,8 +142,14 @@
         "/properties/EndpointStatus",
         "/properties/EndpointCreateTime",
         "/properties/Port",
-        "/properties/VpcSecurityGroups",
-        "/properties/VpcEndpoint"
+        "/properties/VpcSecurityGroups/*/VpcSecurityGroupId",
+        "/properties/VpcSecurityGroups/*/Status",
+        "/properties/VpcEndpoint/VpcEndpointId",
+        "/properties/VpcEndpoint/VpcId",
+        "/properties/VpcEndpoint/NetworkInterfaces/*/NetworkInterfaceId",
+        "/properties/VpcEndpoint/NetworkInterfaces/*/PrivateIpAddress",
+        "/properties/VpcEndpoint/NetworkInterfaces/*/SubnetId",
+        "/properties/VpcEndpoint/NetworkInterfaces/*/AvailabilityZone"
     ],
     "handlers": {
         "create": {

--- a/internal/service/cloudformation/schemas/AWS_SES_DedicatedIpPool.json
+++ b/internal/service/cloudformation/schemas/AWS_SES_DedicatedIpPool.json
@@ -7,11 +7,17 @@
             "type": "string",
             "description": "The name of the dedicated IP pool.",
             "pattern": "^[a-z0-9_-]{0,64}$"
+        },
+        "ScalingMode": {
+            "type": "string",
+            "description": "Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD.",
+            "pattern": "^(STANDARD|MANAGED)$"
         }
     },
     "additionalProperties": false,
     "createOnlyProperties": [
-        "/properties/PoolName"
+        "/properties/PoolName",
+        "/properties/ScalingMode"
     ],
     "primaryIdentifier": [
         "/properties/PoolName"
@@ -20,11 +26,13 @@
         "create": {
             "permissions": [
                 "ses:CreateDedicatedIpPool",
+                "ses:GetDedicatedIpPool",
                 "ses:GetDedicatedIps"
             ]
         },
         "read": {
             "permissions": [
+                "ses:GetDedicatedIpPool",
                 "ses:GetDedicatedIps"
             ]
         },

--- a/internal/service/cloudformation/schemas/AWS_SNS_Topic.json
+++ b/internal/service/cloudformation/schemas/AWS_SNS_Topic.json
@@ -47,6 +47,10 @@
         },
         "TopicArn": {
             "type": "string"
+        },
+        "SignatureVersion": {
+            "description": "Version of the Amazon SNS signature used. If the SignatureVersion is 1, Signature is a Base64-encoded SHA1withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values. If the SignatureVersion is 2, Signature is a Base64-encoded SHA256withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values.",
+            "type": "string"
         }
     },
     "definitions": {

--- a/internal/service/cloudformation/schemas/AWS_SSMIncidents_ResponsePlan.json
+++ b/internal/service/cloudformation/schemas/AWS_SSMIncidents_ResponsePlan.json
@@ -76,7 +76,9 @@
           "items": {
             "$ref": "#/definitions/SsmParameter"
           },
-          "maxItems": 200
+          "minItems": 1,
+          "maxItems": 200,
+          "default": []
         },
         "DynamicParameters": {
           "description": "The parameters with dynamic values to set when starting the SSM automation document.",
@@ -86,7 +88,8 @@
           "items": {
             "$ref": "#/definitions/DynamicSsmParameter"
           },
-          "maxItems": 200
+          "maxItems": 200,
+          "default": []
         }
       }
     },
@@ -104,7 +107,6 @@
           "uniqueItems": true,
           "insertionOrder": true,
           "maxItems": 10,
-          "minItems": 1,
           "items": {
             "$ref": "#/definitions/SsmParameterValue"
           }
@@ -204,6 +206,7 @@
         "NotificationTargets": {
           "description": "The list of notification targets.",
           "type": "array",
+          "default": [],
           "maxItems": 10,
           "items": {
             "$ref": "#/definitions/NotificationTargetItem"
@@ -224,9 +227,9 @@
         "IncidentTags": {
           "description": "Tags that get applied to incidents created by the StartIncident API action.",
           "type": "array",
-          "default": [],
           "uniqueItems": true,
           "insertionOrder": false,
+          "default": [],
           "maxItems": 50,
           "items": {
             "$ref": "#/definitions/Tag"
@@ -238,6 +241,7 @@
       "type": "array",
       "uniqueItems": true,
       "insertionOrder": true,
+      "default": [],
       "items": {
         "$ref": "#/definitions/SnsArn"
       }
@@ -281,7 +285,6 @@
       "type": "array",
       "default": [],
       "maxItems": 5,
-      "minItems": 1,
       "uniqueItems": true,
       "insertionOrder": false,
       "items": {
@@ -305,7 +308,6 @@
       "default": [],
       "uniqueItems": true,
       "insertionOrder": false,
-      "minItems": 1,
       "maxItems": 50,
       "items": {
         "$ref": "#/definitions/Tag"

--- a/internal/service/cloudformation/schemas/AWS_SageMaker_DataQualityJobDefinition.json
+++ b/internal/service/cloudformation/schemas/AWS_SageMaker_DataQualityJobDefinition.json
@@ -166,9 +166,11 @@
       "properties" : {
         "EndpointInput": {
           "$ref" : "#/definitions/EndpointInput"
+        },
+        "BatchTransformInput": {
+          "$ref" : "#/definitions/BatchTransformInput"
         }
-      },
-      "required": [ "EndpointInput" ]
+      }
     },
     "EndpointInput" : {
       "type" : "object",
@@ -202,6 +204,45 @@
         }
       },
       "required" : [ "EndpointName", "LocalPath" ]
+    },
+    "BatchTransformInput": {
+      "type" : "object",
+      "additionalProperties" : false,
+      "description": "The batch transform input for a monitoring job.",
+      "properties" : {
+        "DataCapturedDestinationS3Uri": {
+          "type" : "string",
+          "description" : "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+          "maxLength" : 512
+        },
+        "DatasetFormat": {
+          "$ref" : "#/definitions/DatasetFormat"
+        },
+        "LocalPath": {
+          "type" : "string",
+          "description" : "Path to the filesystem where the endpoint data is available to the container.",
+          "pattern": ".*",
+          "maxLength" : 256
+        },
+        "S3DataDistributionType": {
+          "type" : "string",
+          "description" : "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+          "enum":[
+            "FullyReplicated",
+            "ShardedByS3Key"
+          ]
+        },
+        "S3InputMode": {
+          "type" : "string",
+          "description" : "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+          "enum":[
+            "Pipe",
+            "File"
+          ]
+        }
+      },
+      "required" : [ "DataCapturedDestinationS3Uri", "DatasetFormat", "LocalPath" ]
     },
     "MonitoringOutputConfig" : {
       "type" : "object",
@@ -407,6 +448,45 @@
       "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$",
       "minLength" : 1,
       "maxLength" : 63
+    },
+    "DatasetFormat": {
+      "description": "The dataset format of the data to monitor",
+      "type": "object",
+      "properties": {
+        "Csv": {
+          "$ref" : "#/definitions/Csv"
+        },
+        "Json": {
+          "$ref" : "#/definitions/Json"
+        },
+        "Parquet" : {
+          "$ref" : "#/definitions/Parquet"
+        }
+      }
+    },
+    "Csv": {
+      "description": "The CSV format",
+      "type": "object",
+      "properties": {
+        "Header": {
+          "description": "A boolean flag indicating if given CSV has header",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Json": {
+      "description": "The Json format",
+      "type": "object",
+      "properties": {
+        "Line": {
+          "description": "A boolean flag indicating if it is JSON line format",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parquet": {
+      "description": "A flag indicate if the dataset format is Parquet",
+      "type": "boolean"
     }
   },
   "required" : [ "DataQualityAppSpecification", "DataQualityJobInput", "DataQualityJobOutputConfig", "JobResources", "RoleArn"],

--- a/internal/service/cloudformation/schemas/AWS_SageMaker_ModelBiasJobDefinition.json
+++ b/internal/service/cloudformation/schemas/AWS_SageMaker_ModelBiasJobDefinition.json
@@ -129,11 +129,14 @@
         "EndpointInput": {
           "$ref" : "#/definitions/EndpointInput"
         },
+        "BatchTransformInput": {
+          "$ref": "#/definitions/BatchTransformInput"
+        },
         "GroundTruthS3Input": {
           "$ref" : "#/definitions/MonitoringGroundTruthS3Input"
         }
       },
-      "required": [ "EndpointInput", "GroundTruthS3Input" ]
+      "required": [ "GroundTruthS3Input" ]
     },
     "EndpointInput" : {
       "type" : "object",
@@ -194,6 +197,72 @@
         }
       },
       "required" : [ "EndpointName", "LocalPath" ]
+    },
+    "BatchTransformInput": {
+      "type" : "object",
+      "additionalProperties" : false,
+      "description": "The batch transform input for a monitoring job.",
+      "properties" : {
+        "DataCapturedDestinationS3Uri": {
+          "type" : "string",
+          "description" : "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+          "maxLength" : 512
+        },
+        "DatasetFormat": {
+          "$ref" : "#/definitions/DatasetFormat"
+        },
+        "LocalPath": {
+          "type" : "string",
+          "description" : "Path to the filesystem where the endpoint data is available to the container.",
+          "pattern": ".*",
+          "maxLength" : 256
+        },
+        "S3DataDistributionType": {
+          "type" : "string",
+          "description" : "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+          "enum":[
+            "FullyReplicated",
+            "ShardedByS3Key"
+          ]
+        },
+        "S3InputMode": {
+          "type" : "string",
+          "description" : "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+          "enum":[
+            "Pipe",
+            "File"
+          ]
+        },
+        "StartTimeOffset": {
+          "description" : "Monitoring start time offset, e.g. -PT1H",
+          "$ref": "#/definitions/MonitoringTimeOffsetString"
+        },
+        "EndTimeOffset": {
+          "description" : "Monitoring end time offset, e.g. PT0H",
+          "$ref": "#/definitions/MonitoringTimeOffsetString"
+        },
+        "FeaturesAttribute": {
+          "type" : "string",
+          "description" : "JSONpath to locate features in JSONlines dataset",
+          "maxLength" : 256
+        },
+        "InferenceAttribute": {
+          "type" : "string",
+          "description" : "Index or JSONpath to locate predicted label(s)",
+          "maxLength" : 256
+        },
+        "ProbabilityAttribute": {
+          "type" : "string",
+          "description" : "Index or JSONpath to locate probabilities",
+          "maxLength" : 256
+        },
+        "ProbabilityThresholdAttribute": {
+          "type" : "number",
+          "format": "double"
+        }
+      },
+      "required" : [ "DataCapturedDestinationS3Uri", "DatasetFormat", "LocalPath" ]
     },
     "MonitoringOutputConfig" : {
       "type" : "object",
@@ -420,6 +489,45 @@
         }
       },
       "required" : [ "S3Uri" ]
+    },
+    "DatasetFormat": {
+      "description": "The dataset format of the data to monitor",
+      "type": "object",
+      "properties": {
+        "Csv": {
+          "$ref" : "#/definitions/Csv"
+        },
+        "Json": {
+          "$ref" : "#/definitions/Json"
+        },
+        "Parquet" : {
+          "$ref" : "#/definitions/Parquet"
+        }
+      }
+    },
+    "Csv": {
+      "description": "The CSV format",
+      "type": "object",
+      "properties": {
+        "Header": {
+          "description": "A boolean flag indicating if given CSV has header",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Json": {
+      "description": "The Json format",
+      "type": "object",
+      "properties": {
+        "Line": {
+          "description": "A boolean flag indicating if it is JSON line format",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parquet": {
+      "description": "A flag indicate if the dataset format is Parquet",
+      "type": "boolean"
     }
   },
   "required" : [ "ModelBiasAppSpecification", "ModelBiasJobInput", "ModelBiasJobOutputConfig", "JobResources", "RoleArn"],

--- a/internal/service/cloudformation/schemas/AWS_SageMaker_ModelExplainabilityJobDefinition.json
+++ b/internal/service/cloudformation/schemas/AWS_SageMaker_ModelExplainabilityJobDefinition.json
@@ -128,9 +128,11 @@
       "properties" : {
         "EndpointInput": {
           "$ref" : "#/definitions/EndpointInput"
+        },
+        "BatchTransformInput": {
+          "$ref": "#/definitions/BatchTransformInput"
         }
-      },
-      "required": [ "EndpointInput" ]
+      }
     },
     "EndpointInput" : {
       "type" : "object",
@@ -179,6 +181,60 @@
         }
       },
       "required" : [ "EndpointName", "LocalPath" ]
+    },
+    "BatchTransformInput": {
+      "type" : "object",
+      "additionalProperties" : false,
+      "description": "The batch transform input for a monitoring job.",
+      "properties" : {
+        "DataCapturedDestinationS3Uri": {
+          "type" : "string",
+          "description" : "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+          "maxLength" : 512
+        },
+        "DatasetFormat": {
+          "$ref" : "#/definitions/DatasetFormat"
+        },
+        "LocalPath": {
+          "type" : "string",
+          "description" : "Path to the filesystem where the endpoint data is available to the container.",
+          "pattern": ".*",
+          "maxLength" : 256
+        },
+        "S3DataDistributionType": {
+          "type" : "string",
+          "description" : "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+          "enum":[
+            "FullyReplicated",
+            "ShardedByS3Key"
+          ]
+        },
+        "S3InputMode": {
+          "type" : "string",
+          "description" : "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+          "enum":[
+            "Pipe",
+            "File"
+          ]
+        },
+        "FeaturesAttribute": {
+          "type" : "string",
+          "description" : "JSONpath to locate features in JSONlines dataset",
+          "maxLength" : 256
+        },
+        "InferenceAttribute": {
+          "type" : "string",
+          "description" : "Index or JSONpath to locate predicted label(s)",
+          "maxLength" : 256
+        },
+        "ProbabilityAttribute": {
+          "type" : "string",
+          "description" : "Index or JSONpath to locate probabilities",
+          "maxLength" : 256
+        }
+      },
+      "required" : [ "DataCapturedDestinationS3Uri", "DatasetFormat", "LocalPath" ]
     },
     "MonitoringOutputConfig" : {
       "type" : "object",
@@ -391,6 +447,45 @@
       "pattern": "^.?P.*",
       "minLength" : 1,
       "maxLength" : 15
+    },
+    "DatasetFormat": {
+      "description": "The dataset format of the data to monitor",
+      "type": "object",
+      "properties": {
+        "Csv": {
+          "$ref" : "#/definitions/Csv"
+        },
+        "Json": {
+          "$ref" : "#/definitions/Json"
+        },
+        "Parquet" : {
+          "$ref" : "#/definitions/Parquet"
+        }
+      }
+    },
+    "Csv": {
+      "description": "The CSV format",
+      "type": "object",
+      "properties": {
+        "Header": {
+          "description": "A boolean flag indicating if given CSV has header",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Json": {
+      "description": "The Json format",
+      "type": "object",
+      "properties": {
+        "Line": {
+          "description": "A boolean flag indicating if it is JSON line format",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parquet": {
+      "description": "A flag indicating if the dataset format is Parquet",
+      "type": "boolean"
     }
   },
   "required" : [ "ModelExplainabilityAppSpecification", "ModelExplainabilityJobInput", "ModelExplainabilityJobOutputConfig", "JobResources", "RoleArn"],

--- a/internal/service/cloudformation/schemas/AWS_SageMaker_ModelQualityJobDefinition.json
+++ b/internal/service/cloudformation/schemas/AWS_SageMaker_ModelQualityJobDefinition.json
@@ -156,11 +156,14 @@
         "EndpointInput": {
           "$ref" : "#/definitions/EndpointInput"
         },
+        "BatchTransformInput": {
+          "$ref" : "#/definitions/BatchTransformInput"
+        },
         "GroundTruthS3Input": {
           "$ref" : "#/definitions/MonitoringGroundTruthS3Input"
         }
       },
-      "required": [ "EndpointInput", "GroundTruthS3Input" ]
+      "required": [ "GroundTruthS3Input" ]
     },
     "EndpointInput" : {
       "type" : "object",
@@ -216,6 +219,67 @@
         }
       },
       "required" : [ "EndpointName", "LocalPath" ]
+    },
+    "BatchTransformInput": {
+      "type" : "object",
+      "additionalProperties" : false,
+      "description": "The batch transform input for a monitoring job.",
+      "properties" : {
+        "DataCapturedDestinationS3Uri": {
+          "type" : "string",
+          "description" : "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+          "maxLength" : 512
+        },
+        "DatasetFormat": {
+          "$ref" : "#/definitions/DatasetFormat"
+        },
+        "LocalPath": {
+          "type" : "string",
+          "description" : "Path to the filesystem where the endpoint data is available to the container.",
+          "pattern": ".*",
+          "maxLength" : 256
+        },
+        "S3DataDistributionType": {
+          "type" : "string",
+          "description" : "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+          "enum":[
+            "FullyReplicated",
+            "ShardedByS3Key"
+          ]
+        },
+        "S3InputMode": {
+          "type" : "string",
+          "description" : "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+          "enum":[
+            "Pipe",
+            "File"
+          ]
+        },
+        "StartTimeOffset": {
+          "description" : "Monitoring start time offset, e.g. -PT1H",
+          "$ref": "#/definitions/MonitoringTimeOffsetString"
+        },
+        "EndTimeOffset": {
+          "description" : "Monitoring end time offset, e.g. PT0H",
+          "$ref": "#/definitions/MonitoringTimeOffsetString"
+        },
+        "InferenceAttribute": {
+          "type" : "string",
+          "description" : "Index or JSONpath to locate predicted label(s)",
+          "maxLength" : 256
+        },
+        "ProbabilityAttribute": {
+          "type" : "string",
+          "description" : "Index or JSONpath to locate probabilities",
+          "maxLength" : 256
+        },
+        "ProbabilityThresholdAttribute": {
+          "type" : "number",
+          "format": "double"
+        }
+      },
+      "required" : [ "DataCapturedDestinationS3Uri", "DatasetFormat", "LocalPath" ]
     },
     "MonitoringOutputConfig" : {
       "type" : "object",
@@ -451,6 +515,45 @@
         }
       },
       "required" : [ "S3Uri" ]
+    },
+    "DatasetFormat": {
+      "description": "The dataset format of the data to monitor",
+      "type": "object",
+      "properties": {
+        "Csv": {
+          "$ref" : "#/definitions/Csv"
+        },
+        "Json": {
+          "$ref" : "#/definitions/Json"
+        },
+        "Parquet" : {
+          "$ref" : "#/definitions/Parquet"
+        }
+      }
+    },
+    "Csv": {
+      "description": "The CSV format",
+      "type": "object",
+      "properties": {
+        "Header": {
+          "description": "A boolean flag indicating if given CSV has header",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Json": {
+      "description": "The Json format",
+      "type": "object",
+      "properties": {
+        "Line": {
+          "description": "A boolean flag indicating if it is JSON line format",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parquet": {
+      "description": "A flag indicating if the dataset format is Parquet",
+      "type": "boolean"
     }
   },
   "required" : [ "ModelQualityAppSpecification", "ModelQualityJobInput", "ModelQualityJobOutputConfig", "JobResources", "RoleArn"],

--- a/internal/service/cloudformation/schemas/AWS_SageMaker_MonitoringSchedule.json
+++ b/internal/service/cloudformation/schemas/AWS_SageMaker_MonitoringSchedule.json
@@ -245,9 +245,11 @@
       "properties" : {
         "EndpointInput": {
           "$ref" : "#/definitions/EndpointInput"
+        },
+        "BatchTransformInput": {
+          "$ref" : "#/definitions/BatchTransformInput"
         }
-      },
-      "required": [ "EndpointInput" ]
+      }
     },
     "EndpointInput" : {
       "type" : "object",
@@ -281,6 +283,45 @@
         }
       },
       "required" : [ "EndpointName", "LocalPath" ]
+    },
+    "BatchTransformInput": {
+      "type" : "object",
+      "additionalProperties" : false,
+      "description": "The batch transform input for a monitoring job.",
+      "properties" : {
+        "DataCapturedDestinationS3Uri": {
+          "type" : "string",
+          "description" : "A URI that identifies the Amazon S3 storage location where Batch Transform Job captures data.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$",
+          "maxLength" : 512
+        },
+        "DatasetFormat": {
+          "$ref" : "#/definitions/DatasetFormat"
+        },
+        "LocalPath": {
+          "type" : "string",
+          "description" : "Path to the filesystem where the endpoint data is available to the container.",
+          "pattern": ".*",
+          "maxLength" : 256
+        },
+        "S3DataDistributionType": {
+          "type" : "string",
+          "description" : "Whether input data distributed in Amazon S3 is fully replicated or sharded by an S3 key. Defauts to FullyReplicated",
+          "enum":[
+            "FullyReplicated",
+            "ShardedByS3Key"
+          ]
+        },
+        "S3InputMode": {
+          "type" : "string",
+          "description" : "Whether the Pipe or File is used as the input mode for transfering data for the monitoring job. Pipe mode is recommended for large datasets. File mode is useful for small files that fit in memory. Defaults to File.",
+          "enum":[
+            "Pipe",
+            "File"
+          ]
+        }
+      },
+      "required" : [ "DataCapturedDestinationS3Uri", "DatasetFormat", "LocalPath" ]
     },
     "MonitoringOutputConfig" : {
       "type" : "object",
@@ -541,6 +582,45 @@
       "description" : "The name of the monitoring schedule.",
       "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$",
       "maxLength" : 63
+    },
+    "DatasetFormat": {
+      "description": "The dataset format of the data to monitor",
+      "type": "object",
+      "properties": {
+        "Csv": {
+          "$ref" : "#/definitions/Csv"
+        },
+        "Json": {
+          "$ref" : "#/definitions/Json"
+        },
+        "Parquet" : {
+          "$ref" : "#/definitions/Parquet"
+        }
+      }
+    },
+    "Csv": {
+      "description": "The CSV format",
+      "type": "object",
+      "properties": {
+        "Header": {
+          "description": "A boolean flag indicating if given CSV has header",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Json": {
+      "description": "The Json format",
+      "type": "object",
+      "properties": {
+        "Line": {
+          "description": "A boolean flag indicating if it is JSON line format",
+          "type" : "boolean"
+        }
+      }
+    },
+    "Parquet": {
+      "description": "A flag indicating if the dataset format is Parquet",
+      "type": "boolean"
     }
   },
   "required" : [ "MonitoringScheduleConfig", "MonitoringScheduleName" ],


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

```console
% TF_LOG=ERROR make testacc PKG_NAME=internal/aws/logs TESTARGS='-run=TestAccAWSLogsLogGroup_\|TestAccAWSLogsLogGroupDataSource_' ACCTEST_PARALLELISM=3 
TF_ACC=1 go test ./internal/aws/logs -v -count 1 -parallel 3 -run=TestAccAWSLogsLogGroup_\|TestAccAWSLogsLogGroupDataSource_ -timeout 180m
=== RUN   TestAccAWSLogsLogGroup_basic
=== PAUSE TestAccAWSLogsLogGroup_basic
=== RUN   TestAccAWSLogsLogGroup_disappears
=== PAUSE TestAccAWSLogsLogGroup_disappears
=== RUN   TestAccAWSLogsLogGroup_update
=== PAUSE TestAccAWSLogsLogGroup_update
=== RUN   TestAccAWSLogsLogGroupDataSource_basic
=== PAUSE TestAccAWSLogsLogGroupDataSource_basic
=== RUN   TestAccAWSLogsLogGroupDataSource_NonExistent
=== PAUSE TestAccAWSLogsLogGroupDataSource_NonExistent
=== CONT  TestAccAWSLogsLogGroup_basic
=== CONT  TestAccAWSLogsLogGroup_update
=== CONT  TestAccAWSLogsLogGroupDataSource_basic
--- PASS: TestAccAWSLogsLogGroupDataSource_basic (25.34s)
=== CONT  TestAccAWSLogsLogGroupDataSource_NonExistent
--- PASS: TestAccAWSLogsLogGroup_basic (26.28s)
=== CONT  TestAccAWSLogsLogGroup_disappears
2022-10-20T10:58:08.291-0400 [ERROR] sdk.proto: Response contains error diagnostic: diagnostic_detail="After attempting to read the data source, the API returned a resource not found error for the id provided. Original Error: couldn't find resource" diagnostic_severity=ERROR diagnostic_summary="AWS Data Source Not Found" tf_req_id=011d5543-578f-62b0-0a54-ec37d87c482c tf_provider_addr=registry.terraform.io/hashicorp/awscc tf_proto_version=6.3 tf_rpc=ReadDataSource tf_data_source_type=awscc_logs_log_group
--- PASS: TestAccAWSLogsLogGroupDataSource_NonExistent (1.90s)
--- PASS: TestAccAWSLogsLogGroup_update (40.53s)
--- PASS: TestAccAWSLogsLogGroup_disappears (18.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-awscc/internal/aws/logs	45.379s
```
