### PR TITLE
Handle `null` current value when planning JSON strings

### DIFF
--- a/internal/generic/jsonstring.go
+++ b/internal/generic/jsonstring.go
@@ -245,7 +245,7 @@ func (attributePlanModifier jsonStringAttributePlanModifier) Modify(ctx context.
 
 	if err != nil {
 		response.Diagnostics.AddError(
-			"Invalid JSON string",
+			"Invalid JSON string (planned)",
 			fmt.Sprintf("unable to unmarshal JSON: %s", err.Error()),
 		)
 
@@ -261,21 +261,25 @@ func (attributePlanModifier jsonStringAttributePlanModifier) Modify(ctx context.
 		return
 	}
 
-	currentMap, err := expandJSONFromString(current.Value)
-
-	if err != nil {
-		response.Diagnostics.AddError(
-			"Invalid JSON string",
-			fmt.Sprintf("unable to unmarshal JSON: %s", err.Error()),
-		)
-
-		return
-	}
-
-	if reflect.DeepEqual(plannedMap, currentMap) {
-		response.AttributePlan = request.AttributeState
-	} else {
+	if current.IsNull() {
 		response.AttributePlan = request.AttributePlan
+	} else {
+		currentMap, err := expandJSONFromString(current.Value)
+
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Invalid JSON string (current)",
+				fmt.Sprintf("unable to unmarshal JSON: %s", err.Error()),
+			)
+
+			return
+		}
+
+		if reflect.DeepEqual(plannedMap, currentMap) {
+			response.AttributePlan = request.AttributeState
+		} else {
+			response.AttributePlan = request.AttributePlan
+		}
 	}
 }
 

--- a/internal/generic/jsonstring.go
+++ b/internal/generic/jsonstring.go
@@ -78,7 +78,7 @@ func (t jsonStringType) Validate(ctx context.Context, v tftypes.Value, p path.Pa
 	if !v.Type().Is(tftypes.String) {
 		diags.AddAttributeError(
 			p,
-			"Duration Type Validation Error",
+			"JSONString Type Validation Error",
 			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 				fmt.Sprintf("Expected String value, received %T with value: %v", v, v),
 		)
@@ -96,7 +96,7 @@ func (t jsonStringType) Validate(ctx context.Context, v tftypes.Value, p path.Pa
 	if err != nil {
 		diags.AddAttributeError(
 			p,
-			"Duration Type Validation Error",
+			"JSONString Type Validation Error",
 			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 				fmt.Sprintf("Cannot convert value to String: %s", err),
 		)

--- a/internal/generic/jsonstring_test.go
+++ b/internal/generic/jsonstring_test.go
@@ -132,6 +132,11 @@ func TestJSONStringTypeAttributePlanModifier(t *testing.T) {
 			currentValue: types.Int64{Value: 1},
 			expectError:  true,
 		},
+		"current null": {
+			plannedValue:  JSONString{Value: `{"k1": 42}`},
+			currentValue:  JSONString{Null: true},
+			expectedValue: JSONString{Value: `{"k1": 42}`},
+		},
 		"exactly equal": {
 			plannedValue:  JSONString{Value: `{}`},
 			currentValue:  JSONString{Value: `{}`},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-awscc/issues/695.
