### PR TITLE
Release: Set provider version in HTTP User-Agent strings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
       - goos: freebsd
         goarch: arm64
     ldflags:
-      - -s -w -X internal/provider.Version={{.Version}}
+      - -s -w -X 'github.com/hashicorp/terraform-provider-awscc/internal/provider.Version={{.Version}}'
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   extra_files:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/28240.

##### Before

```
User-Agent: APN/1.0 HashiCorp/1.0 Terraform/1.0.9 (+https://www.terraform.io) terraform-provider-awscc/dev (+https://registry.terraform.io/providers/hashicorp/awscc) aws-sdk-go-v2/1.17.2 os/macos lang/go/1.19.3 md/GOOS/darwin md/GOARCH/amd64 api/sts/1.17.6
```

##### After

```
User-Agent: APN/1.0 HashiCorp/1.0 Terraform/1.0.9 (+https://www.terraform.io) terraform-provider-awscc/0.41.0 (+https://registry.terraform.io/providers/hashicorp/awscc) aws-sdk-go-v2/1.17.2 os/macos lang/go/1.19.3 md/GOOS/darwin md/GOARCH/amd64 api/sts/1.17.6
```
