### PR TITLE
Cleanup after go1.19 upgrade

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,14 +5,13 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
+    - asciicheck
     - errcheck
-    - errorlint
-    - goconst
+    - exportloopref
+    - gocritic
     - gofmt
     - gomnd
     - gosimple
-    - govet
     - ineffassign
     - makezero
     - misspell
@@ -20,11 +19,14 @@ linters:
     - nilerr
     - nolintlint
     - staticcheck
-    - structcheck
+    - stylecheck
+    - typecheck
     - unconvert
-    - unused
     - unparam
-    - varcheck
+    - unused
+    - vet
+    - vetshadow
+    - whitespace
 
 linters-settings:
   errcheck:
@@ -32,6 +34,14 @@ linters-settings:
     ignore: fmt:.*,github.com/hashicorp/terraform-plugin-framework/tfsdk:SetAttribute,fprintf
     # exclude-functions:
     #   - (*github.com/hashicorp/terraform-plugin-framework/tfsdk.State).SetAttribute
+  gocritic:
+    enabled-tags:
+      - diagnostic
+    disabled-tags:
+      - style
+      - performance
+      - experimental
+      - opinionated
   gomnd:
     settings:
       mnd:
@@ -47,7 +57,9 @@ linters-settings:
           - validate.StringLenAtMost
           - validate.StringLenBetween
   nolintlint:
-    allow-unused: true # Because of the disabled rules with Go 1.18
+    allow-unused: false
+  stylecheck:
+    checks: ["all", "-ST1003"]
   unparam:
     check-exported: true
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,9 +41,11 @@ testacc:
 lint: golangci-lint importlint
 
 golangci-lint:
+	@echo "==> Checking source code with golangci-lint..."
 	@golangci-lint run ./internal/...
 
 importlint:
+	@echo "==> Checking source code with importlint..."
 	@impi --local . --scheme stdThirdPartyLocal --ignore-generated=true ./...
 
 tools:

--- a/internal/generic/translate.go
+++ b/internal/generic/translate.go
@@ -54,7 +54,7 @@ func (t toCloudControl) AsString(ctx context.Context, schema *tfsdk.Schema, val 
 
 // rawFromValue returns the raw value (suitable for JSON marshaling) of the specified Terraform value.
 // Terraform attribute names are mapped to Cloud Control property names.
-func (t toCloudControl) rawFromValue(ctx context.Context, schema *tfsdk.Schema, path *tftypes.AttributePath, val tftypes.Value) (interface{}, error) { //nolint:unparam
+func (t toCloudControl) rawFromValue(ctx context.Context, schema *tfsdk.Schema, path *tftypes.AttributePath, val tftypes.Value) (interface{}, error) {
 	if val.IsNull() || !val.IsKnown() {
 		return nil, nil
 	}

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -77,8 +77,8 @@ func CloudFormationPropertyToTerraformAttribute(propertyName string) string {
 // Pluralize converts a name to its plural form.
 // The inflection package is used as a first attempt to pluralize names,
 // but exceptions to the rule are handled as follows:
-//  - '_plural' is appended to a name ending in 's' e.g. 'windows'
-//  - 's' is appended to a name ending in a number
+//   - '_plural' is appended to a name ending in 's' e.g. 'windows'
+//   - 's' is appended to a name ending in a number
 func Pluralize(name string) string {
 	if name == "" {
 		return name

--- a/internal/provider/generators/import-examples/main.go
+++ b/internal/provider/generators/import-examples/main.go
@@ -73,7 +73,6 @@ func GenerateExample(resourceName string, ui *cli.BasicUi) {
 	if err != nil {
 		ui.Error(fmt.Sprintf("error writing to file (%s): %s", filename, err))
 	}
-
 }
 
 type TemplateData struct {

--- a/internal/provider/generators/plural-data-source/main.go
+++ b/internal/provider/generators/plural-data-source/main.go
@@ -128,9 +128,11 @@ func (p *PluralDataSourceGenerator) Generate(packageName, schemaFilename, acctes
 }
 
 // Terraform resource schema definition.
+//
 //go:embed schema.tmpl
 var dataSourceSchemaTemplateBody string
 
 // Terraform acceptance tests.
+//
 //go:embed tests.tmpl
 var acceptanceTestsTemplateBody string

--- a/internal/provider/generators/resource/main.go
+++ b/internal/provider/generators/resource/main.go
@@ -108,9 +108,11 @@ func (r *ResourceGenerator) Generate(packageName, schemaFilename, acctestsFilena
 }
 
 // Terraform resource schema definition.
+//
 //go:embed schema.tmpl
 var resourceSchemaTemplateBody string
 
 // Terraform acceptance tests.
+//
 //go:embed tests.tmpl
 var acceptanceTestsTemplateBody string

--- a/internal/provider/generators/schema/main.go
+++ b/internal/provider/generators/schema/main.go
@@ -88,30 +88,34 @@ func main() {
 		generatedCodeRootDirectoryName = *generatedCodeRoot
 	}
 
+	os.Exit(run(destinationPackage, generatedCodeRootDirectoryName, resourcesFilename, singularDatasourcesFilename, pluralDatasourcesFilename))
+}
+
+func run(destinationPackage, generatedCodeRootDirectoryName, resourcesFilename, singularDatasourcesFilename, pluralDatasourcesFilename string) int {
 	ui := &cli.BasicUi{
 		Reader:      os.Stdin,
 		Writer:      os.Stdout,
 		ErrorWriter: os.Stderr,
 	}
 
-	tempDirectory, err := os.MkdirTemp("", "*")
-
-	if err != nil {
-		ui.Error(fmt.Sprintf("error creating temporary directory: %s", err))
-		os.Exit(1)
-	}
-
-	defer os.RemoveAll(tempDirectory)
-
 	ctx := context.TODO()
 	cfg, err := config.LoadDefaultConfig(ctx)
 
 	if err != nil {
 		ui.Error(fmt.Sprintf("error loading AWS SDK config: %s", err))
-		os.Exit(1)
+		return 1
 	}
 
 	client := cloudformation.NewFromConfig(cfg)
+
+	tempDirectory, err := os.MkdirTemp("", "*")
+
+	if err != nil {
+		ui.Error(fmt.Sprintf("error creating temporary directory: %s", err))
+		return 1
+	}
+
+	defer os.RemoveAll(tempDirectory)
 
 	downloader := &Downloader{
 		client:        client,
@@ -122,19 +126,19 @@ func main() {
 	err = hclsimple.DecodeFile(*configFile, nil, &downloader.config)
 	if err != nil {
 		ui.Error(fmt.Sprintf("error loading configuration: %s", err))
-		os.Exit(1)
+		return 1
 	}
 
 	if err := downloader.MetaSchema(); err != nil {
 		ui.Error(fmt.Sprintf("error loading CloudFormation Resource Provider Definition Schema: %s", err))
-		os.Exit(1)
+		return 1
 	}
 
 	resources, dataSources, err := downloader.Schemas()
 
 	if err != nil {
 		ui.Error(fmt.Sprintf("error processing CloudFormation Resource Provider Schemas: %s", err))
-		os.Exit(1)
+		return 1
 	}
 
 	generator := &Generator{
@@ -143,18 +147,20 @@ func main() {
 
 	if err := generator.GenerateResources(destinationPackage, resourcesFilename, generatedCodeRootDirectoryName, *importPathRoot, resources); err != nil {
 		ui.Error(fmt.Sprintf("error generating Terraform resource generation instructions: %s", err))
-		os.Exit(1)
+		return 1
 	}
 
 	if err := generator.GenerateDataSources(destinationPackage, singularDatasourcesFilename, generatedCodeRootDirectoryName, *importPathRoot, dataSources.Singular); err != nil {
 		ui.Error(fmt.Sprintf("error generating Terraform singular data-source generation instructions: %s", err))
-		os.Exit(1)
+		return 1
 	}
 
 	if err := generator.GenerateDataSources(destinationPackage, pluralDatasourcesFilename, generatedCodeRootDirectoryName, *importPathRoot, dataSources.Plural); err != nil {
 		ui.Error(fmt.Sprintf("error generating Terraform plural data-source generation instructions: %s", err))
-		os.Exit(1)
+		return 1
 	}
+
+	return 0
 }
 
 var errCopyFileWithDir = errors.New("dir argument to CopyFile")

--- a/internal/provider/generators/schema/main.go
+++ b/internal/provider/generators/schema/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"go/format"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -95,7 +94,7 @@ func main() {
 		ErrorWriter: os.Stderr,
 	}
 
-	tempDirectory, err := ioutil.TempDir("", "*")
+	tempDirectory, err := os.MkdirTemp("", "*")
 
 	if err != nil {
 		ui.Error(fmt.Sprintf("error creating temporary directory: %s", err))
@@ -337,7 +336,7 @@ func (d *Downloader) ResourceSchema(schema ResourceSchema) (string, string, erro
 			return "", "", fmt.Errorf("sanitizing schema: %w", err)
 		}
 
-		err = ioutil.WriteFile(dst, []byte(schema), 0644) //nolint:gomnd
+		err = os.WriteFile(dst, []byte(schema), 0644) //nolint:gomnd
 
 		if err != nil {
 			return "", "", fmt.Errorf("writing schema to %q: %w", dst, err)

--- a/internal/provider/generators/singular-data-source/main.go
+++ b/internal/provider/generators/singular-data-source/main.go
@@ -108,9 +108,11 @@ func (s *SingularDataSourceGenerator) Generate(packageName, schemaFilename, acct
 }
 
 // Terraform data source schema definition.
+//
 //go:embed schema.tmpl
 var dataSourceSchemaTemplateBody string
 
 // Terraform acceptance tests.
+//
 //go:embed tests.tmpl
 var acceptanceTestsTemplateBody string

--- a/internal/validate/int.go
+++ b/internal/validate/int.go
@@ -166,7 +166,6 @@ func (validator intInSliceValidator) Validate(ctx context.Context, request tfsdk
 		validator.valid,
 		i,
 	))
-
 }
 
 func newIntNotInSliceError(p path.Path, valid []int, value int64) diag.Diagnostic {

--- a/internal/validate/required.go
+++ b/internal/validate/required.go
@@ -303,7 +303,6 @@ func evaluateRequiredAttributesFuncs(names []string, fs ...RequiredAttributesFun
 	}
 
 	return diags
-
 }
 
 // specifiedAttributes returns the names of the attributes that are set in an object.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-awscc/tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates https://github.com/hashicorp/terraform-provider-awscc/pull/790.

Fixes

```
level=warning msg="[runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
level=warning msg="[runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
level=warning msg="[runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
level=warning msg="[linters_context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649."
internal/naming/naming.go:[8](https://github.com/hashicorp/terraform-provider-awscc/actions/runs/3737661759/jobs/6343064674#step:10:9)0: File is not `gofmt`-ed with `-s` (gofmt)
//  - '_plural' is appended to a name ending in 's' e.g. 'windows'
//  - 's' is appended to a name ending in a number
Error: internal/provider/generators/schema/main.go:11:2: SA101[9](https://github.com/hashicorp/terraform-provider-awscc/actions/runs/3737661759/jobs/6343064674#step:10:10): "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
Error: Process completed with exit code 1.
```
