### PR TITLE
Fix `markdown-link-check` errors

### DIFF
--- a/contributing/pullrequest-submission-and-lifecycle.md
+++ b/contributing/pullrequest-submission-and-lifecycle.md
@@ -4,8 +4,6 @@
 - [Branch Prefixes](#branch-prefixes)
 - [Common Review Items](#common-review-items)
     - [Go Coding Style](#go-coding-style)
-    - [Resource Contribution Guidelines](#resource-contribution-guidelines)
-- [Changelog Process](#changelog-process)
 
 We appreciate direct contributions to the provider codebase. Here's what to
 expect:
@@ -29,16 +27,14 @@ expect:
 1. Once you believe your pull request is ready to be reviewed, ensure the
    pull request is not a draft pull request by [marking it ready for review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request)
    or removing `[WIP]` from the pull request title if necessary, and a
-   maintainer will review it. Follow [the checklists below](#checklists-for-contribution)
-   to help ensure that your contribution can be easily reviewed and potentially
-   merged.
+   maintainer will review it.
 
 1. One of Terraform's provider team members will look over your contribution and
    either approve it or provide comments letting you know if there is anything
    left to do. We'll try give you the opportunity to make the required changes yourself, but in some cases we may perform the changes ourselves if it makes sense to (minor changes, or for urgent issues).  We do our best to keep up with the volume of PRs waiting for
    review, but it may take some time depending on the complexity of the work.
 
-1. Once all outstanding comments and checklist items have been addressed, your
+1. Once all outstanding comments have been addressed, your
    contribution will be merged! Merged PRs will be included in the next
    Terraform release.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Fixes `markdown-link-check` [errors](https://github.com/hashicorp/terraform-provider-awscc/actions/runs/4820288904/jobs/8584568962):

```
FILE: contributing/pullrequest-submission-and-lifecycle.md
  [✖] #resource-contribution-guidelines → Status: 404
  [✖] #changelog-process → Status: 404
  [✖] #checklists-for-contribution → Status: 404

  13 links checked.

  ERROR: 3 dead links found!
  [✖] #resource-contribution-guidelines → Status: 404
  [✖] #changelog-process → Status: 404
  [✖] #checklists-for-contribution → Status: 404
```
