### PR TITLE
docs: awscc_s3_bucket - default encryption

### DIFF
--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -11,7 +11,9 @@ Resource Type definition for AWS::S3::Bucket
 ## Example Usage
 
 ### Create a s3 bucket 
+
 To create a s3 bucket
+
 ```terraform
 resource "awscc_s3_bucket" "example" {
   bucket_name = "example-bucket"
@@ -25,7 +27,9 @@ resource "awscc_s3_bucket" "example" {
 ```
 
 ### Create a s3 bucket with public access restricted 
+
 To create a s3 bucket with public access restricted
+
 ```terraform
 resource "awscc_s3_bucket" "example" {
   bucket_name = "example-bucket"
@@ -42,6 +46,24 @@ resource "awscc_s3_bucket" "example" {
     restrict_public_buckets = true
   }
 
+}
+```
+
+### S3 bucket with default encryption AES256
+
+To create a s3 bucket with server side default encryption AES256
+
+```terraform
+resource "awscc_s3_bucket" "example" {
+  bucket_name = "wellsiau-example-bucket-2"
+
+  bucket_encryption = {
+    server_side_encryption_configuration = [{
+      server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }]
+  }
 }
 ```
 

--- a/examples/resources/awscc_s3_bucket/s3_bucket_encryption.tf
+++ b/examples/resources/awscc_s3_bucket/s3_bucket_encryption.tf
@@ -1,0 +1,11 @@
+resource "awscc_s3_bucket" "example" {
+  bucket_name = "wellsiau-example-bucket-2"
+
+  bucket_encryption = {
+    server_side_encryption_configuration = [{
+      server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }]
+  }
+}

--- a/templates/resources/s3_bucket.md.tmpl
+++ b/templates/resources/s3_bucket.md.tmpl
@@ -11,12 +11,22 @@ description: |-
 ## Example Usage
 
 ### Create a s3 bucket 
+
 To create a s3 bucket
+
 {{ tffile (printf "examples/resources/%s/s3_bucket.tf" .Name)}}
 
 ### Create a s3 bucket with public access restricted 
+
 To create a s3 bucket with public access restricted
+
 {{ tffile (printf "examples/resources/%s/s3_block_public.tf" .Name)}}
+
+### S3 bucket with default encryption AES256
+
+To create a s3 bucket with server side default encryption AES256
+
+{{ tffile (printf "examples/resources/%s/s3_bucket_encryption.tf" .Name)}}
 
 {{ .SchemaMarkdown | trimspace }}
 {{- if .HasImport }}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Added new example for using s3 default encryption (AES256), generated via Bedrock
