### PR TITLE
Add description attribute to policy store in Amazon Verified Permissions

### DIFF
--- a/internal/aws/verifiedpermissions/policy_store_plural_data_source_gen.go
+++ b/internal/aws/verifiedpermissions/policy_store_plural_data_source_gen.go
@@ -32,6 +32,11 @@ func policyStoresDataSource(ctx context.Context) (datasource.DataSource, error) 
 			ElementType: types.StringType,
 			Computed:    true,
 		},
+		"descriptions": schema.MapAttribute{
+				Description: "Map of policy store IDs to their descriptions.",
+				ElementType: types.StringType,
+				Computed:    true,
+		},
 	}
 
 	schema := schema.Schema{

--- a/internal/aws/verifiedpermissions/policy_store_resource_gen.go
+++ b/internal/aws/verifiedpermissions/policy_store_resource_gen.go
@@ -121,6 +121,24 @@ func policyStoreResource(ctx context.Context) (resource.Resource, error) {
 			}, /*END SCHEMA*/
 			Required: true,
 		}, /*END ATTRIBUTE*/
+		// Property: Description
+		// CloudFormation resource type description:
+		//
+		//	{
+		//	  "maxLength": 150,
+		//	  "minLength": 0,
+		//	  "type": "string"
+		//	}
+		"description": schema.StringAttribute{ /*START ATTRIBUTE*/
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{ /*START VALIDATORS*/
+						stringvalidator.LengthBetween(0, 150),
+				}, /*END VALIDATORS*/
+				PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+						stringplanmodifier.UseStateForUnknown(),
+				}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
 	} /*END SCHEMA*/
 
 	attributes["id"] = schema.StringAttribute{

--- a/internal/aws/verifiedpermissions/policy_store_singular_data_source_gen.go
+++ b/internal/aws/verifiedpermissions/policy_store_singular_data_source_gen.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/hashicorp/terraform-provider-awscc/internal/generic"
 	"github.com/hashicorp/terraform-provider-awscc/internal/registry"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 func init() {
@@ -96,6 +98,21 @@ func policyStoreDataSource(ctx context.Context) (datasource.DataSource, error) {
 			}, /*END SCHEMA*/
 			Computed: true,
 		}, /*END ATTRIBUTE*/
+		// Property: Description
+		// CloudFormation resource type description:
+		//
+		//	{
+		//	  "maxLength": 150,
+		//	  "minLength": 0,
+		//	  "type": "string"
+		//	}
+		"description": schema.StringAttribute{ /*START ATTRIBUTE*/
+				Optional: true, // Include if users can set the description
+				Computed: true,
+				Validators: []validator.String{ /*START VALIDATORS*/
+						stringvalidator.LengthBetween(0, 150), // Example validator
+				}, /*END VALIDATORS*/
+		}, /*END ATTRIBUTE*/
 	} /*END SCHEMA*/
 
 	attributes["id"] = schema.StringAttribute{
@@ -114,6 +131,7 @@ func policyStoreDataSource(ctx context.Context) (datasource.DataSource, error) {
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"arn":                 "Arn",
+		"description":        "Description",
 		"cedar_json":          "CedarJson",
 		"mode":                "Mode",
 		"policy_store_id":     "PolicyStoreId",

--- a/internal/service/cloudformation/schemas/AWS_VerifiedPermissions_PolicyStore.json
+++ b/internal/service/cloudformation/schemas/AWS_VerifiedPermissions_PolicyStore.json
@@ -47,6 +47,11 @@
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$"
     },
+    "Description": {
+      "type": "string",
+      "maxLength": 150,
+      "minLength": 0
+    },
     "ValidationSettings": {
       "$ref": "#/definitions/ValidationSettings"
     },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

## What
Add description attribute to policy store in Amazon Verified Permissions.

## Why
Recently, the support for adding a description for the policy store has been added. Previously it was not possible, so we can just recognize it via policy store id or the creation date.

## How
Added optional parameter description.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
