### PR TITLE
docs: added example for ec2_vpc ipv6

### DIFF
--- a/docs/resources/ec2_vpc.md
+++ b/docs/resources/ec2_vpc.md
@@ -47,7 +47,7 @@ resource "awscc_ec2_ipam" "main" {
 
 resource "awscc_ec2_ipam_pool" "main" {
   address_family = "ipv4"
-  ipam_scope_id  = awscc_ec2_ipam.main.private_default_scope_id 
+  ipam_scope_id  = awscc_ec2_ipam.main.private_default_scope_id
   locale         = "us-east-1"
 }
 
@@ -62,6 +62,18 @@ resource "awscc_ec2_vpc" "main" {
   depends_on = [
     awscc_ec2_ipam_pool_cidr.main
   ]
+}
+```
+
+Create a VPC with Amazon provided IPV6 pool
+```terraform
+resource "awscc_ec2_vpc_cidr_block" "main" {
+  amazon_provided_ipv_6_cidr_block = true
+  vpc_id                           = awscc_ec2_vpc.selected.id
+}
+
+resource "awscc_ec2_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
 }
 ```
 

--- a/examples/resources/awscc_ec2_vpc/ec2_vpc_ipam.tf
+++ b/examples/resources/awscc_ec2_vpc/ec2_vpc_ipam.tf
@@ -6,7 +6,7 @@ resource "awscc_ec2_ipam" "main" {
 
 resource "awscc_ec2_ipam_pool" "main" {
   address_family = "ipv4"
-  ipam_scope_id  = awscc_ec2_ipam.main.private_default_scope_id 
+  ipam_scope_id  = awscc_ec2_ipam.main.private_default_scope_id
   locale         = "us-east-1"
 }
 

--- a/examples/resources/awscc_ec2_vpc/ec2_vpc_ipv6.tf
+++ b/examples/resources/awscc_ec2_vpc/ec2_vpc_ipv6.tf
@@ -1,0 +1,8 @@
+resource "awscc_ec2_vpc_cidr_block" "main" {
+  amazon_provided_ipv_6_cidr_block = true
+  vpc_id                           = awscc_ec2_vpc.selected.id
+}
+
+resource "awscc_ec2_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}

--- a/templates/resources/ec2_vpc.md.tmpl
+++ b/templates/resources/ec2_vpc.md.tmpl
@@ -23,6 +23,9 @@ To create a VPC with tags
 To create a VPC with CIDR from AWS IPAM
 {{ tffile (printf "examples/resources/%s/ec2_vpc_ipam.tf" .Name)}}
 
+Create a VPC with Amazon provided IPV6 pool
+{{ tffile (printf "examples/resources/%s/ec2_vpc_ipv6.tf" .Name)}}
+
 {{ .SchemaMarkdown | trimspace }}
 {{- if .HasImport }}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Adding example for the ipv6 pool enabled vpc. Format updated the ipam example.
