### PR TITLE
Introduce workflow to automate GitHub Projects

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -19,7 +19,6 @@ env:
 jobs:
   team_board:
     name: Provider Team Project
-    needs: community_check
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -32,18 +32,12 @@ jobs:
       VIEW_WORKING_BOARD: ${{ vars.team_project_view_working_board }}
 
     steps:
-      - name: Generate GitHub Authentication Token
+      - name: Generate GitHub App Token
         id: token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@c8f55efbd427e7465d6da1106e7979bc8aaee856 # v1.10.1
         with:
-          app_id: ${{ secrets.APP_ID }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ secrets.INSTALLATION_ID }}
-          private_key: ${{ secrets.APP_PEM }}
-          permissions: >-
-            {
-              "organization_projects": "write"
-            }
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
 
       - name: Check if Author is Maintainer
         id: author

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,4 +1,5 @@
 name: GitHub Projects Automations
+permissions: {}
 
 on:
   issues:
@@ -14,10 +15,6 @@ on:
 
 env:
   ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
-
-# Any automation with Projects will need a token from the GitHub App,
-# so restrict the permissions of the automated token.
-permissions: {}
 
 jobs:
   community_check:
@@ -37,7 +34,6 @@ jobs:
         run: |
           echo "author_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
 
-          # If the environment variable is unset, passing it as a jq arg throws an error
           if [ -n "$ASSIGNEE_LOGIN" ]; then
             echo "assignee_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
           fi
@@ -68,12 +64,16 @@ jobs:
           installation_retrieval_mode: id
           installation_retrieval_payload: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PEM }}
+          permissions: >-
+            {
+              "organization_projects": "write"
+            }
 
       - name: Maintainer Pull Requests
         if: |
           github.event.name == 'pull_request_target'
           && github.event.action == 'opened'
-          $$ fromJSON(env.AUTHOR_IS_MAINTAINER)
+          && fromJSON(env.AUTHOR_IS_MAINTAINER)
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,4 +1,5 @@
 name: GitHub Projects Automations
+permissions: {}
 
 on:
   issues:
@@ -15,32 +16,13 @@ on:
 env:
   ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
 
-# Any automation with Projects will need a token from the GitHub App,
-# so restrict the permissions of the automated token.
-permissions: {}
-
 jobs:
   community_check:
     name: Community Check
-    runs-on: ubuntu-latest
-
-    outputs:
-      author_is_maintainer: ${{ steps.check.outputs.author_is_maintainer }}
-      assignee_is_maintainer: ${{ steps.check.outputs.assignee_is_maintainer }}
-
-    steps:
-      - name: Compare Logins to Lists
-        id: check
-        env:
-          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
-          AUTHOR_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
-        run: |
-          echo "author_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
-
-          # If the environment variable is unset, passing it as a jq arg throws an error
-          if [ -n "$ASSIGNEE_LOGIN" ]; then
-            echo "assignee_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
-          fi
+    uses: hashicorp/terraform-provider-aws/.github/workflows/community-check.yml@008c8a10089c5730f6244a0acc95b22447bcfac4
+    secrets: inherit
+    with:
+      username: ${{ github.event.action == 'assigned' && github.event.assignee.login || (github.event.issue.user.login || github.event.pull_request.user.login) }}
 
   team_board:
     name: Provider Team Project
@@ -48,8 +30,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      AUTHOR_IS_MAINTAINER: ${{ needs.community_check.outputs.author_is_maintainer }}
-      ASSIGNEE_IS_MAINTAINER: ${{ needs.community_check.outputs.assignee_is_maintainer }}
       PROJECT_ID: PVT_kwDOAAuecM4AF-7h
       PROJECT_NUMBER: 196
       STATUS_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgDcsQA
@@ -68,12 +48,16 @@ jobs:
           installation_retrieval_mode: id
           installation_retrieval_payload: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PEM }}
+          permissions: >-
+            {
+              "organization_projects": "write"
+            }
 
       - name: Maintainer Pull Requests
         if: |
           github.event.name == 'pull_request_target'
           && github.event.action == 'opened'
-          $$ fromJSON(env.AUTHOR_IS_MAINTAINER)
+          && fromJSON(needs.community_check.outputs.maintainer)
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
@@ -94,7 +78,7 @@ jobs:
       - name: Maintainer Assignments
         if: |
           github.event.action == 'assigned'
-          && fromJSON(env.ASSIGNEE_IS_MAINTAINER)
+          && fromJSON(needs.community_check.outputs.maintainer)
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -13,16 +13,41 @@ on:
       - opened
 
 env:
-  ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
-  AUTHOR_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
   ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
 
 jobs:
+  community_check:
+    name: Community Check
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    outputs:
+      author_is_maintainer: ${{ steps.check.outputs.author_is_maintainer }}
+      assignee_is_maintainer: ${{ steps.check.outputs.assignee_is_maintainer }}
+
+    steps:
+      - name: Compare Logins to Lists
+        id: check
+        env:
+          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
+          AUTHOR_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
+        run: |
+          echo "author_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+
+          # If the environment variable is unset, passing it as a jq arg throws an error
+          if [ -n "$ASSIGNEE_LOGIN" ]; then
+            echo "assignee_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+          fi
+
   team_board:
     name: Provider Team Project
+    needs: community_check
     runs-on: ubuntu-latest
+    permissions: {}
 
     env:
+      AUTHOR_IS_MAINTAINER: ${{ needs.community_check.outputs.author_is_maintainer }}
+      ASSIGNEE_IS_MAINTAINER: ${{ needs.community_check.outputs.assignee_is_maintainer }}
       PROJECT_ID: PVT_kwDOAAuecM4AF-7h
       PROJECT_NUMBER: 196
       STATUS_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgDcsQA
@@ -42,19 +67,11 @@ jobs:
           installation_retrieval_payload: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PEM }}
 
-      - name: Set Up Environment
-        run: |
-          echo "AUTHOR_IS_MAINTAINER=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> $GITHUB_ENV
-
-          if [ -n "$ASSIGNEE_LOGIN" ]; then
-            echo "ASSIGNEE_IS_MAINTAINER=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> $GITHUB_ENV
-          fi
-
       - name: Maintainer Pull Requests
         if: |
           github.event.name == 'pull_request_target'
           && github.event.action == 'opened'
-          fromJSON(env.AUTHOR_IS_MAINTAINER)
+          $$ fromJSON(env.AUTHOR_IS_MAINTAINER)
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -15,11 +15,14 @@ on:
 env:
   ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
 
+# Any automation with Projects will need a token from the GitHub App,
+# so restrict the permissions of the automated token.
+permissions: {}
+
 jobs:
   community_check:
     name: Community Check
     runs-on: ubuntu-latest
-    permissions: {}
 
     outputs:
       author_is_maintainer: ${{ steps.check.outputs.author_is_maintainer }}
@@ -43,7 +46,6 @@ jobs:
     name: Provider Team Project
     needs: community_check
     runs-on: ubuntu-latest
-    permissions: {}
 
     env:
       AUTHOR_IS_MAINTAINER: ${{ needs.community_check.outputs.author_is_maintainer }}
@@ -131,7 +133,7 @@ jobs:
           PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
 
           gh project item-edit \
-          --id "$PROJECT_ITEM_ID" \
-          --project-id "$PROJECT_ID" \
-          --field-id "$VIEW_FIELD_ID" \
-          --single-select-option-id "$VIEW_ENGINEERING_INITIATIVE"
+            --id "$PROJECT_ITEM_ID" \
+            --project-id "$PROJECT_ID" \
+            --field-id "$VIEW_FIELD_ID" \
+            --single-select-option-id "$VIEW_ENGINEERING_INITIATIVE"

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -13,9 +13,6 @@ on:
       - labeled
       - opened
 
-env:
-  ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
-
 jobs:
   community_check:
     name: Community Check
@@ -46,6 +43,7 @@ jobs:
     env:
       AUTHOR_IS_MAINTAINER: ${{ needs.community_check.outputs.author_is_maintainer }}
       ASSIGNEE_IS_MAINTAINER: ${{ needs.community_check.outputs.assignee_is_maintainer }}
+      ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
       PROJECT_ID: PVT_kwDOAAuecM4AF-7h
       PROJECT_NUMBER: 196
       STATUS_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgDcsQA

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -49,8 +49,8 @@ jobs:
         id: author
         if: github.event.action == 'opened'
         env:
-          MAINTAINERS: ${{ secrets.MAINTAINERS }}
           AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          MAINTAINERS: ${{ secrets.MAINTAINERS }}
         run: |
           echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
 
@@ -79,8 +79,8 @@ jobs:
         id: assignee
         if: github.event.action == 'assigned'
         env:
-          MAINTAINERS: ${{ secrets.MAINTAINERS }}
           ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
+          MAINTAINERS: ${{ secrets.MAINTAINERS }}
         run: |
           echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -13,37 +13,16 @@ on:
       - labeled
       - opened
 
+env:
+  ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+
 jobs:
-  community_check:
-    name: Community Check
-    runs-on: ubuntu-latest
-
-    outputs:
-      author_is_maintainer: ${{ steps.check.outputs.author_is_maintainer }}
-      assignee_is_maintainer: ${{ steps.check.outputs.assignee_is_maintainer }}
-
-    steps:
-      - name: Compare Logins to Lists
-        id: check
-        env:
-          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
-          AUTHOR_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
-        run: |
-          echo "author_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
-
-          if [ -n "$ASSIGNEE_LOGIN" ]; then
-            echo "assignee_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
-          fi
-
   team_board:
     name: Provider Team Project
     needs: community_check
     runs-on: ubuntu-latest
 
     env:
-      AUTHOR_IS_MAINTAINER: ${{ needs.community_check.outputs.author_is_maintainer }}
-      ASSIGNEE_IS_MAINTAINER: ${{ needs.community_check.outputs.assignee_is_maintainer }}
-      ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
       PROJECT_ID: PVT_kwDOAAuecM4AF-7h
       PROJECT_NUMBER: 196
       STATUS_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgDcsQA
@@ -54,7 +33,7 @@ jobs:
       VIEW_WORKING_BOARD: ${{ vars.team_project_view_working_board }}
 
     steps:
-      - name: Generate GitHub Auth Token
+      - name: Generate GitHub Authentication Token
         id: token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
@@ -67,11 +46,19 @@ jobs:
               "organization_projects": "write"
             }
 
+      - name: Check if Author is Maintainer
+        id: author
+        if: github.event.action == 'opened'
+        env:
+          MAINTAINERS: ${{ secrets.MAINTAINERS }}
+          AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+        run: |
+          echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+
       - name: Maintainer Pull Requests
         if: |
-          github.event.name == 'pull_request_target'
-          && github.event.action == 'opened'
-          && fromJSON(env.AUTHOR_IS_MAINTAINER)
+          steps.author.conclusion != 'skipped'
+          && fromJSON(steps.author.outputs.is_maintainer)
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
@@ -89,10 +76,19 @@ jobs:
             --field-id "$VIEW_FIELD_ID" \
             --single-select-option-id "$VIEW_WORKING_BOARD"
 
+      - name: Check if Assignee is Maintainer
+        id: assignee
+        if: github.event.action == 'assigned'
+        env:
+          MAINTAINERS: ${{ secrets.MAINTAINERS }}
+          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
+        run: |
+          echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+
       - name: Maintainer Assignments
         if: |
-          github.event.action == 'assigned'
-          && fromJSON(env.ASSIGNEE_IS_MAINTAINER)
+          steps.assignee.conclusion != 'skipped'
+          && fromJSON(steps.assignee.outputs.is_maintainer)
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,0 +1,120 @@
+name: GitHub Projects Automations
+
+on:
+  issues:
+    types:
+      - assigned
+      - labeled
+
+  pull_request_target:
+    types:
+      - assigned
+      - labeled
+      - opened
+
+env:
+  ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
+  AUTHOR_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
+  ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+
+jobs:
+  team_board:
+    name: Provider Team Project
+    runs-on: ubuntu-latest
+
+    env:
+      PROJECT_ID: PVT_kwDOAAuecM4AF-7h
+      PROJECT_NUMBER: 196
+      STATUS_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgDcsQA
+      STATUS_IN_PROGRESS: ${{ vars.team_project_status_in_progress }}
+      VIEW_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgMRB34
+      VIEW_ENGINEERING_INITIATIVE: ${{ vars.team_project_view_engineering_initiative }}
+      VIEW_MAINTAINER_PR: ${{ vars.team_project_status_maintainer_pr }}
+      VIEW_WORKING_BOARD: ${{ vars.team_project_view_working_board }}
+
+    steps:
+      - name: Generate GitHub Auth Token
+        id: token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ secrets.INSTALLATION_ID }}
+          private_key: ${{ secrets.APP_PEM }}
+
+      - name: Set Up Environment
+        run: |
+          echo "AUTHOR_IS_MAINTAINER=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> $GITHUB_ENV
+
+          if [ -n "$ASSIGNEE_LOGIN" ]; then
+            echo "ASSIGNEE_IS_MAINTAINER=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> $GITHUB_ENV
+          fi
+
+      - name: Maintainer Pull Requests
+        if: |
+          github.event.name == 'pull_request_target'
+          && github.event.action == 'opened'
+          fromJSON(env.AUTHOR_IS_MAINTAINER)
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
+
+          gh project item-edit \
+            --id "$PROJECT_ITEM_ID" \
+            --project-id "$PROJECT_ID" \
+            --field-id "$STATUS_FIELD_ID" \
+            --single-select-option-id "$VIEW_MAINTAINER_PR"
+
+          gh project item-edit \
+            --id "$PROJECT_ITEM_ID" \
+            --project-id "$PROJECT_ID" \
+            --field-id "$VIEW_FIELD_ID" \
+            --single-select-option-id "$VIEW_WORKING_BOARD"
+
+      - name: Maintainer Assignments
+        if: |
+          github.event.action == 'assigned'
+          && fromJSON(env.ASSIGNEE_IS_MAINTAINER)
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
+
+          gh project item-edit \
+            --id "$PROJECT_ITEM_ID" \
+            --project-id "$PROJECT_ID" \
+            --field-id "$STATUS_FIELD_ID" \
+            --single-select-option-id "$STATUS_IN_PROGRESS"
+
+          gh project item-edit \
+            --id "$PROJECT_ITEM_ID" \
+            --project-id "$PROJECT_ID" \
+            --field-id "$VIEW_FIELD_ID" \
+            --single-select-option-id "$VIEW_WORKING_BOARD"
+
+      - name: Prioritized to Working Board
+        if: github.event.label.name == 'prioritized'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
+
+          gh project item-edit \
+            --id "$PROJECT_ITEM_ID" \
+            --project-id "$PROJECT_ID" \
+            --field-id "$VIEW_FIELD_ID" \
+            --single-select-option-id "$VIEW_WORKING_BOARD"
+
+      - name: Engineering Initiatives to View
+        if: github.event.label.name == 'engineering-initiative'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
+
+          gh project item-edit \
+          --id "$PROJECT_ITEM_ID" \
+          --project-id "$PROJECT_ID" \
+          --field-id "$VIEW_FIELD_ID" \
+          --single-select-option-id "$VIEW_ENGINEERING_INITIATIVE"

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,5 +1,4 @@
 name: GitHub Projects Automations
-permissions: {}
 
 on:
   issues:
@@ -16,13 +15,32 @@ on:
 env:
   ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
 
+# Any automation with Projects will need a token from the GitHub App,
+# so restrict the permissions of the automated token.
+permissions: {}
+
 jobs:
   community_check:
     name: Community Check
-    uses: hashicorp/terraform-provider-aws/.github/workflows/community-check.yml@008c8a10089c5730f6244a0acc95b22447bcfac4
-    secrets: inherit
-    with:
-      username: ${{ github.event.action == 'assigned' && github.event.assignee.login || (github.event.issue.user.login || github.event.pull_request.user.login) }}
+    runs-on: ubuntu-latest
+
+    outputs:
+      author_is_maintainer: ${{ steps.check.outputs.author_is_maintainer }}
+      assignee_is_maintainer: ${{ steps.check.outputs.assignee_is_maintainer }}
+
+    steps:
+      - name: Compare Logins to Lists
+        id: check
+        env:
+          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
+          AUTHOR_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
+        run: |
+          echo "author_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+
+          # If the environment variable is unset, passing it as a jq arg throws an error
+          if [ -n "$ASSIGNEE_LOGIN" ]; then
+            echo "assignee_is_maintainer=$(echo ${{ secrets.MAINTAINERS }} | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+          fi
 
   team_board:
     name: Provider Team Project
@@ -30,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      AUTHOR_IS_MAINTAINER: ${{ needs.community_check.outputs.author_is_maintainer }}
+      ASSIGNEE_IS_MAINTAINER: ${{ needs.community_check.outputs.assignee_is_maintainer }}
       PROJECT_ID: PVT_kwDOAAuecM4AF-7h
       PROJECT_NUMBER: 196
       STATUS_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgDcsQA
@@ -48,16 +68,12 @@ jobs:
           installation_retrieval_mode: id
           installation_retrieval_payload: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PEM }}
-          permissions: >-
-            {
-              "organization_projects": "write"
-            }
 
       - name: Maintainer Pull Requests
         if: |
           github.event.name == 'pull_request_target'
           && github.event.action == 'opened'
-          && fromJSON(needs.community_check.outputs.maintainer)
+          $$ fromJSON(env.AUTHOR_IS_MAINTAINER)
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
@@ -78,7 +94,7 @@ jobs:
       - name: Maintainer Assignments
         if: |
           github.event.action == 'assigned'
-          && fromJSON(needs.community_check.outputs.maintainer)
+          && fromJSON(env.ASSIGNEE_IS_MAINTAINER)
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,4 +1,4 @@
-name: GitHub Projects Automations
+name: Provider Team Working Board
 permissions: {}
 
 on:
@@ -13,24 +13,12 @@ on:
       - labeled
       - opened
 
-env:
-  ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
-
 jobs:
   team_board:
-    name: Provider Team Project
+    name: Manage Board
     runs-on: ubuntu-latest
-
     env:
-      PROJECT_ID: PVT_kwDOAAuecM4AF-7h
-      PROJECT_NUMBER: 196
-      STATUS_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgDcsQA
-      STATUS_IN_PROGRESS: ${{ vars.team_project_status_in_progress }}
-      VIEW_FIELD_ID: PVTSSF_lADOAAuecM4AF-7hzgMRB34
-      VIEW_ENGINEERING_INITIATIVE: ${{ vars.team_project_view_engineering_initiative }}
-      VIEW_MAINTAINER_PR: ${{ vars.team_project_status_maintainer_pr }}
-      VIEW_WORKING_BOARD: ${{ vars.team_project_view_working_board }}
-
+      ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
     steps:
       - name: Generate GitHub App Token
         id: token
@@ -39,88 +27,53 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}
 
-      - name: Check if Author is Maintainer
-        id: author
-        if: github.event.action == 'opened'
-        env:
-          AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
-          MAINTAINERS: ${{ secrets.MAINTAINERS }}
-        run: |
-          echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          sparse-checkout: .github/actions/
 
-      - name: Maintainer Pull Requests
+      - name: Run Community Check
+        id: community_check
+        if: contains(fromJSON('["opened", "assigned"]'), github.event.action)
+        uses: ./.github/actions/community_check
+        with:
+          user_login: ${{ github.event.action == 'assigned' && github.event.assignee.login || github.event.pull_request.user.login }}
+          maintainers: ${{ secrets.MAINTAINERS }}
+
+      - name: Handle Maintainer Pull Requests
         if: |
-          steps.author.conclusion != 'skipped'
-          && fromJSON(steps.author.outputs.is_maintainer)
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
+          github.event.action == 'opened'
+          && steps.community_check.outputs.maintainer == 'true'
+        uses: ./.github/actions/team_working_board
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          item_url: ${{ env.ISSUE_URL }}
+          status: "Maintainer PR"
+          view: "working-board"
 
-          gh project item-edit \
-            --id "$PROJECT_ITEM_ID" \
-            --project-id "$PROJECT_ID" \
-            --field-id "$STATUS_FIELD_ID" \
-            --single-select-option-id "$VIEW_MAINTAINER_PR"
-
-          gh project item-edit \
-            --id "$PROJECT_ITEM_ID" \
-            --project-id "$PROJECT_ID" \
-            --field-id "$VIEW_FIELD_ID" \
-            --single-select-option-id "$VIEW_WORKING_BOARD"
-
-      - name: Check if Assignee is Maintainer
-        id: assignee
-        if: github.event.action == 'assigned'
-        env:
-          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
-          MAINTAINERS: ${{ secrets.MAINTAINERS }}
-        run: |
-          echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
-
-      - name: Maintainer Assignments
+      - name: Handle Maintainer Assignments
         if: |
-          steps.assignee.conclusion != 'skipped'
-          && fromJSON(steps.assignee.outputs.is_maintainer)
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
+          github.event.action == 'assigned'
+          && steps.community_check.outputs.maintainer == 'true'
+        uses: ./.github/actions/team_working_board
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          item_url: ${{ env.ISSUE_URL }}
+          status: "In Progress"
+          view: "working-board"
 
-          gh project item-edit \
-            --id "$PROJECT_ITEM_ID" \
-            --project-id "$PROJECT_ID" \
-            --field-id "$STATUS_FIELD_ID" \
-            --single-select-option-id "$STATUS_IN_PROGRESS"
-
-          gh project item-edit \
-            --id "$PROJECT_ITEM_ID" \
-            --project-id "$PROJECT_ID" \
-            --field-id "$VIEW_FIELD_ID" \
-            --single-select-option-id "$VIEW_WORKING_BOARD"
-
-      - name: Prioritized to Working Board
+      - name: Set View for Items Labeled prioritized
         if: github.event.label.name == 'prioritized'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
+        uses: ./.github/actions/team_working_board
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          item_url: ${{ env.ISSUE_URL }}
+          view: "working-board"
 
-          gh project item-edit \
-            --id "$PROJECT_ITEM_ID" \
-            --project-id "$PROJECT_ID" \
-            --field-id "$VIEW_FIELD_ID" \
-            --single-select-option-id "$VIEW_WORKING_BOARD"
-
-      - name: Engineering Initiatives to View
+      - name: Set View for Items Labeled engineering-initiative
         if: github.event.label.name == 'engineering-initiative'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          PROJECT_ITEM_ID=$(gh project item-add $PROJECT_NUMBER --owner "hashicorp" --url "$ISSUE_URL" --format json --jq '.id')
-
-          gh project item-edit \
-            --id "$PROJECT_ITEM_ID" \
-            --project-id "$PROJECT_ID" \
-            --field-id "$VIEW_FIELD_ID" \
-            --single-select-option-id "$VIEW_ENGINEERING_INITIATIVE"
+        uses: ./.github/actions/community_check
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          item_url: ${{ env.ISSUE_URL }}
+          view: "engineering-initiative"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

### About

Introduces a workflow to handle various tasks related to automating the team's GitHub Project. The sole job works on the AWS Provider team's GitHub Project, but the workflow is intentionally constructed so that we can easily add other projects within separate jobs (hence the use of `env` at the top level and within the `team_board` job).

Similar to #1773, this  will require the following secrets in the repository:

Slack related:
- `SLACK_BOT_TOKEN`
- `SLACK_CHANNEL`

Depends on #1743
Relates #1742
Relates #1773