### PR TITLE
fix: updated example for awscc_amplify_domain

### DIFF
--- a/docs/resources/amplify_domain.md
+++ b/docs/resources/amplify_domain.md
@@ -13,6 +13,24 @@ The AWS::Amplify::Domain resource allows you to connect a custom domain to your 
 
 ### Basic Domain and Subdomains
 ```terraform
+resource "awscc_amplify_domain" "example" {
+  app_id      = awscc_amplify_app.example.app_id
+  domain_name = "example.com"
+
+  sub_domain_settings = [
+    {
+      # https://example.com
+      branch_name = awscc_amplify_branch.main.branch_name
+      prefix      = ""
+    },
+    {
+      # https://www.example.com
+      branch_name = awscc_amplify_branch.main.branch_name
+      prefix      = "www"
+    },
+  ]
+}
+
 resource "awscc_amplify_app" "example" {
   name = "app"
 
@@ -29,24 +47,6 @@ resource "awscc_amplify_app" "example" {
 resource "awscc_amplify_branch" "main" {
   app_id      = awscc_amplify_app.example.app_id
   branch_name = "main"
-}
-
-resource "awscc_amplify_domain" "example" {
-  app_id      = awscc_amplify_app.example.app_id
-  domain_name = "example.com"
-
-  sub_domain_settings = [
-    {
-      # https://example.com
-      branch_name = aws_amplify_branch.main.branch_name
-      prefix      = ""
-    },
-    {
-      # https://www.example.com
-      branch_name = aws_amplify_branch.main.branch_name
-      prefix      = "www"
-    },
-  ]
 }
 ```
 

--- a/examples/resources/awscc_amplify_domain/amplify_domain.tf
+++ b/examples/resources/awscc_amplify_domain/amplify_domain.tf
@@ -1,3 +1,21 @@
+resource "awscc_amplify_domain" "example" {
+  app_id      = awscc_amplify_app.example.app_id
+  domain_name = "example.com"
+
+  sub_domain_settings = [
+    {
+      # https://example.com
+      branch_name = awscc_amplify_branch.main.branch_name
+      prefix      = ""
+    },
+    {
+      # https://www.example.com
+      branch_name = awscc_amplify_branch.main.branch_name
+      prefix      = "www"
+    },
+  ]
+}
+
 resource "awscc_amplify_app" "example" {
   name = "app"
 
@@ -16,20 +34,4 @@ resource "awscc_amplify_branch" "main" {
   branch_name = "main"
 }
 
-resource "awscc_amplify_domain" "example" {
-  app_id      = awscc_amplify_app.example.app_id
-  domain_name = "example.com"
 
-  sub_domain_settings = [
-    {
-      # https://example.com
-      branch_name = aws_amplify_branch.main.branch_name
-      prefix      = ""
-    },
-    {
-      # https://www.example.com
-      branch_name = aws_amplify_branch.main.branch_name
-      prefix      = "www"
-    },
-  ]
-}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
* updated branch_name reference to `awscc_amplify_branch` than the non-existing `aws_amplify_branch` 
* There does seem to be an issue on the resource around it not stabilizing.

