### PR TITLE
Rename reference to **AWS CloudFormation** in the resource schema

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,6 +37,7 @@ resources:
 
 schemas:
 	$(GO_VER) generate internal/provider/schemas.go
+	$(GO_VER) run internal/provider/generators/schema_rename/main.go
 
 test:
 	$(GO_VER) test $(TEST) $(TESTARGS) -timeout=5m

--- a/internal/provider/generators/schema_rename/README.md
+++ b/internal/provider/generators/schema_rename/README.md
@@ -1,0 +1,13 @@
+# AWS CloudFormation Resource Schema Renamer
+
+Find any reference to the **AWS CloudFormation** in the resource schema attributes / descriptions.
+
+This tool
+
+* Reads the schema files under `./internal/service/cloudformation/schemas/`
+* Checks whether any reference to **AWS CloudFormation** exists in the schema attributes or description.
+* Replace reference of **AWS CloudFormation** with **Terraform**
+
+## Allowlist
+
+This tool will skips any CloudFormation schema file with prefix `AWS_CloudFormation_` which denotes all AWS CloudFormation resources (stack, hooks, etc).

--- a/internal/provider/generators/schema_rename/main.go
+++ b/internal/provider/generators/schema_rename/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+    "fmt"
+    "path/filepath"
+	"os"
+    "strings"
+    "github.com/hashicorp/terraform-provider-awscc/internal/provider/generators/schema_rename/rename"
+)
+
+func main() {
+    baseDir := "./internal/service/cloudformation/schemas/"
+    err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+        if err != nil {
+            return err
+        }
+
+        if !info.IsDir() && filepath.Ext(path) == ".json" {
+            // Skip files that start with "AWS_CloudFormation_"
+            if !strings.HasPrefix(info.Name(), "AWS_CloudFormation_") {
+                err = rename.RenameCfnSchemaFile(path)
+                if err != nil {
+                    return err
+                }
+            }
+        }
+
+        return nil
+    })
+
+    if err != nil {
+        fmt.Println("Error:", err)
+    }
+}

--- a/internal/provider/generators/schema_rename/rename/rename.go
+++ b/internal/provider/generators/schema_rename/rename/rename.go
@@ -1,0 +1,103 @@
+package rename
+
+import (
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "strings"
+    "reflect"
+)
+
+func RenameCfnSchemaFile (filePath string) error {
+    // Open JSON schema file from base directory 
+    file, err := os.Open(filePath)
+    if err != nil {
+        fmt.Println("Error opening file:", err)
+        return err
+    }
+    defer file.Close()
+
+    // Read the JSON data
+    data, err := ioutil.ReadAll(file)
+    if err != nil {
+        fmt.Println("Error reading file:", err)
+        return err
+    }
+
+    // Unmarshal the JSON data into a map while preserving the order
+    var jsonData map[string]interface{}
+    err = json.Unmarshal(data, &jsonData)
+    if err != nil {
+        fmt.Println("Error unmarshaling JSON:", err)
+        return err
+    }
+
+    // Create a copy of the original JSON data
+    originalData := make(map[string]interface{})
+    for k, v := range jsonData {
+        originalData[k] = v
+    }
+
+    // Replace "CloudFormation" with "Terraform" in the description
+    err = updateDescription(jsonData)
+    if err != nil {
+        fmt.Println("Error updating description:", err)
+        return err
+    }
+
+    // Check if the JSON data has changed
+    if reflect.DeepEqual(jsonData, originalData) {
+        // No changes detected, skip writing the file
+        return nil
+    }
+
+    // Marshal the updated JSON data while preserving the order
+    updatedDataBytes, err := json.MarshalIndent(jsonData, "", "  ")
+    if err != nil {
+        fmt.Println("Error marshaling JSON:", err)
+        return err
+    }
+
+    // Write the updated JSON data back to the file
+    err = ioutil.WriteFile(filePath, updatedDataBytes, 0644)
+    if err != nil {
+        fmt.Println("Error writing file:", err)
+        return err
+    }
+
+    fmt.Printf("File %s updated successfully\n", filePath)
+    return nil
+}
+
+func updateDescription(data map[string]interface{}) error {
+    for key, value := range data {
+        if key == "description" {
+            description, ok := value.(string)
+            if ok {
+                updatedDescription := strings.ReplaceAll(description, "AWS CloudFormation", "Terraform")
+                data[key] = updatedDescription
+            }
+        } else {
+            switch v := value.(type) {
+            case map[string]interface{}:
+                err := updateDescription(v)
+                if err != nil {
+                    return err
+                }
+            case []interface{}:
+                for i, item := range v {
+                    switch item.(type) {
+                    case map[string]interface{}:
+                        err := updateDescription(item.(map[string]interface{}))
+                        if err != nil {
+                            return err
+                        }
+                        v[i] = item
+                    }
+                }
+            }
+        }
+    }
+    return nil
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1783

This new function will run after schemas is downloaded and will check for any reference to **AWS CloudFormation** within the schema. 
