### PR TITLE
Fix labeler workflow by specifying GitHub token

### DIFF
--- a/.github/workflows/labelers.yml
+++ b/.github/workflows/labelers.yml
@@ -29,6 +29,7 @@ jobs:
 
     env:
       GH_CLI_SUBCOMMAND: ${{ (github.event.issue.pull_request || github.event.pull_request) && 'pr' || 'issue' }}
+      GH_TOKEN: ${{ github.token }}
       ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
       LABELS: ${{ toJSON(github.event.issue.labels.*.name || github.event.pull_request.labels.*.name) }}
       MAINTAINERS: ${{ secrets.MAINTAINERS }}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

### About

Fixes the labeler workflow by specifying the `GH_TOKEN` environment variables

### References

- [Using GitHub CLI in workflows](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows)
- [This failing run](https://github.com/hashicorp/terraform-provider-awscc/actions/runs/9409652041/job/25919980265?pr=1802)
