### PR TITLE
Fix `panic: Go Duration ValueDuration Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.2.0 (Unreleased)
+
+BUG FIXES:
+
+* provider: Fix `panic: Go Duration ValueDuration Error` errors if `assume_role.duration` or `assume_role_with_web_identity.duration` are not configured ([#1737](https://github.com/hashicorp/terraform-provider-awscc/issues/1737))
+
 ## 1.1.0 (June  6, 2024)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* provider: Fix `panic: Go Duration ValueDuration Error` errors if `assume_role.duration` or `assume_role_with_web_identity.duration` are not configured ([#1737](https://github.com/hashicorp/terraform-provider-awscc/issues/1737))
+* provider: Fix `panic: Go Duration ValueDuration Error` errors if `assume_role.duration` or `assume_role_with_web_identity.duration` are not configured ([#1813](https://github.com/hashicorp/terraform-provider-awscc/issues/1813))
 
 ## 1.1.0 (June  6, 2024)
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -14,7 +14,6 @@ import (
 	basediag "github.com/hashicorp/aws-sdk-go-base/v2/diag"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -23,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/errs/diag"
 	"github.com/hashicorp/terraform-provider-awscc/internal/flex"
 	"github.com/hashicorp/terraform-provider-awscc/internal/registry"
 	cctypes "github.com/hashicorp/terraform-provider-awscc/internal/types"
@@ -87,7 +85,7 @@ func (p *ccProvider) Schema(ctx context.Context, request provider.SchemaRequest,
 			"assume_role": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"duration": schema.StringAttribute{
-						CustomType:  timetypes.GoDurationType{},
+						CustomType:  cctypes.DurationType,
 						Description: "The duration, between 15 minutes and 12 hours, of the role session. Valid time units are ns, us (or µs), ms, s, h, or m.",
 						Optional:    true,
 					},
@@ -131,7 +129,7 @@ func (p *ccProvider) Schema(ctx context.Context, request provider.SchemaRequest,
 			"assume_role_with_web_identity": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"duration": schema.StringAttribute{
-						CustomType:  timetypes.GoDurationType{},
+						CustomType:  cctypes.DurationType,
 						Description: "The duration, between 15 minutes and 12 hours, of the role session. Valid time units are ns, us (or µs), ms, s, h, or m.",
 						Optional:    true,
 					},
@@ -283,19 +281,19 @@ type userAgentProduct struct {
 }
 
 type assumeRoleData struct {
-	Duration          timetypes.GoDuration `tfsdk:"duration"`
-	ExternalID        types.String         `tfsdk:"external_id"`
-	Policy            jsontypes.Exact      `tfsdk:"policy"`
-	PolicyARNs        types.List           `tfsdk:"policy_arns"`
-	RoleARN           cctypes.ARN          `tfsdk:"role_arn"`
-	SessionName       types.String         `tfsdk:"session_name"`
-	Tags              types.Map            `tfsdk:"tags"`
-	TransitiveTagKeys types.Set            `tfsdk:"transitive_tag_keys"`
+	Duration          cctypes.Duration `tfsdk:"duration"`
+	ExternalID        types.String     `tfsdk:"external_id"`
+	Policy            jsontypes.Exact  `tfsdk:"policy"`
+	PolicyARNs        types.List       `tfsdk:"policy_arns"`
+	RoleARN           cctypes.ARN      `tfsdk:"role_arn"`
+	SessionName       types.String     `tfsdk:"session_name"`
+	Tags              types.Map        `tfsdk:"tags"`
+	TransitiveTagKeys types.Set        `tfsdk:"transitive_tag_keys"`
 }
 
 func (a assumeRoleData) Config() *awsbase.AssumeRole {
 	assumeRole := &awsbase.AssumeRole{
-		Duration:    ccdiag.Must(a.Duration.ValueGoDuration()),
+		Duration:    a.Duration.ValueDuration(),
 		ExternalID:  a.ExternalID.ValueString(),
 		Policy:      a.Policy.ValueString(),
 		RoleARN:     a.RoleARN.ValueString(),
@@ -327,18 +325,18 @@ func (a assumeRoleData) Config() *awsbase.AssumeRole {
 }
 
 type assumeRoleWithWebIdentityData struct {
-	Duration             timetypes.GoDuration `tfsdk:"duration"`
-	Policy               jsontypes.Exact      `tfsdk:"policy"`
-	PolicyARNs           types.List           `tfsdk:"policy_arns"`
-	RoleARN              cctypes.ARN          `tfsdk:"role_arn"`
-	SessionName          types.String         `tfsdk:"session_name"`
-	WebIdentityToken     types.String         `tfsdk:"web_identity_token"`
-	WebIdentityTokenFile types.String         `tfsdk:"web_identity_token_file"`
+	Duration             cctypes.Duration `tfsdk:"duration"`
+	Policy               jsontypes.Exact  `tfsdk:"policy"`
+	PolicyARNs           types.List       `tfsdk:"policy_arns"`
+	RoleARN              cctypes.ARN      `tfsdk:"role_arn"`
+	SessionName          types.String     `tfsdk:"session_name"`
+	WebIdentityToken     types.String     `tfsdk:"web_identity_token"`
+	WebIdentityTokenFile types.String     `tfsdk:"web_identity_token_file"`
 }
 
 func (a assumeRoleWithWebIdentityData) Config() *awsbase.AssumeRoleWithWebIdentity {
 	assumeRole := &awsbase.AssumeRoleWithWebIdentity{
-		Duration:             ccdiag.Must(a.Duration.ValueGoDuration()),
+		Duration:             a.Duration.ValueDuration(),
 		Policy:               a.Policy.ValueString(),
 		RoleARN:              a.RoleARN.ValueString(),
 		SessionName:          a.SessionName.ValueString(),

--- a/internal/types/duration.go
+++ b/internal/types/duration.go
@@ -1,0 +1,158 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.StringTypable = (*durationType)(nil)
+)
+
+type durationType struct {
+	basetypes.StringType
+}
+
+var (
+	DurationType = durationType{}
+)
+
+func (t durationType) Equal(o attr.Type) bool {
+	other, ok := o.(durationType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+func (durationType) String() string {
+	return "DurationType"
+}
+
+func (t durationType) ValueFromString(_ context.Context, in types.String) (basetypes.StringValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return DurationNull(), diags
+	}
+	if in.IsUnknown() {
+		return DurationUnknown(), diags
+	}
+
+	valueString := in.ValueString()
+	if _, err := time.ParseDuration(valueString); err != nil {
+		return DurationUnknown(), diags // Must not return validation errors
+	}
+
+	return DurationValue(valueString), diags
+}
+
+func (t durationType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (durationType) ValueType(context.Context) attr.Value {
+	return Duration{}
+}
+
+var (
+	_ basetypes.StringValuable    = (*Duration)(nil)
+	_ xattr.ValidateableAttribute = (*Duration)(nil)
+)
+
+func DurationNull() Duration {
+	return Duration{StringValue: basetypes.NewStringNull()}
+}
+
+func DurationUnknown() Duration {
+	return Duration{StringValue: basetypes.NewStringUnknown()}
+}
+
+// DurationValue initializes a new Duration type with the provided value
+//
+// This function does not return diagnostics, and therefore invalid duration values
+// are not handled during construction. Invalid values will be detected by the
+// ValidateAttribute method, called by the ValidateResourceConfig RPC during
+// operations like `terraform validate`, `plan`, or `apply`.
+func DurationValue(value string) Duration {
+	// swallow any Duration parsing errors here and just pass along the
+	// zero value time.Duration. Invalid values will be handled downstream
+	// by the ValidateAttribute method.
+	v, _ := time.ParseDuration(value)
+
+	return Duration{
+		StringValue: basetypes.NewStringValue(value),
+		value:       v,
+	}
+}
+
+type Duration struct {
+	basetypes.StringValue
+	value time.Duration
+}
+
+func (v Duration) Equal(o attr.Value) bool {
+	other, ok := o.(Duration)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (Duration) Type(context.Context) attr.Type {
+	return DurationType
+}
+
+// ValueDuration returns the known time.Duration value. If Duration is null or unknown, returns 0.
+func (v Duration) ValueDuration() time.Duration {
+	return v.value
+}
+
+func (v Duration) ValidateAttribute(ctx context.Context, req xattr.ValidateAttributeRequest, resp *xattr.ValidateAttributeResponse) {
+	if v.IsNull() || v.IsUnknown() {
+		return
+	}
+
+	if _, err := time.ParseDuration(v.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Duration Value",
+			"The provided value cannot be parsed as a Duration.\n\n"+
+				"Path: "+req.Path.String()+"\n"+
+				"Error: "+err.Error(),
+		)
+	}
+}

--- a/internal/types/duration_test.go
+++ b/internal/types/duration_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	cctypes "github.com/hashicorp/terraform-provider-awscc/internal/types"
+)
+
+func TestDurationTypeValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		val      tftypes.Value
+		expected attr.Value
+	}{
+		"null value": {
+			val:      tftypes.NewValue(tftypes.String, nil),
+			expected: cctypes.DurationNull(),
+		},
+		"unknown value": {
+			val:      tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expected: cctypes.DurationUnknown(),
+		},
+		"valid duration": {
+			val:      tftypes.NewValue(tftypes.String, "2h"),
+			expected: cctypes.DurationValue("2h"),
+		},
+		"invalid duration": {
+			val:      tftypes.NewValue(tftypes.String, "not ok"),
+			expected: cctypes.DurationUnknown(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			val, err := cctypes.DurationType.ValueFromTerraform(ctx, test.val)
+
+			if err != nil {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(val, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestDurationValidateAttribute(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         cctypes.Duration
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: cctypes.DurationUnknown(),
+		},
+		"null": {
+			val: cctypes.DurationNull(),
+		},
+		"valid": {
+			val: cctypes.DurationValue("2h"),
+		},
+		"invalid": {
+			val:         cctypes.DurationValue("not ok"),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			req := xattr.ValidateAttributeRequest{}
+			resp := xattr.ValidateAttributeResponse{}
+
+			test.val.ValidateAttribute(ctx, req, &resp)
+			if resp.Diagnostics.HasError() != test.expectError {
+				t.Errorf("resp.Diagnostics.HasError() = %t, want = %t", resp.Diagnostics.HasError(), test.expectError)
+			}
+		})
+	}
+}
+
+func TestDurationToStringValue(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		duration cctypes.Duration
+		expected types.String
+	}{
+		"value": {
+			duration: cctypes.DurationValue("2h"),
+			expected: types.StringValue("2h"),
+		},
+		"null": {
+			duration: cctypes.DurationNull(),
+			expected: types.StringNull(),
+		},
+		"unknown": {
+			duration: cctypes.DurationUnknown(),
+			expected: types.StringUnknown(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			s, _ := test.duration.ToStringValue(ctx)
+
+			if !test.expected.Equal(s) {
+				t.Fatalf("expected %#v to equal %#v", s, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-awscc/issues/1810.
Closes https://github.com/hashicorp/terraform-provider-awscc/issues/1809.
Closes https://github.com/hashicorp/terraform-provider-awscc/issues/1808.
Relates https://github.com/hashicorp/terraform-provider-awscc/pull/1797.
