### PR TITLE
Update community check to Composite Action

### DIFF
--- a/.github/actions/community_check/README.md
+++ b/.github/actions/community_check/README.md
@@ -1,0 +1,40 @@
+# Community Check
+
+Check a username to see if it's in one of our community lists. We use this to help automate tasks within the repository.
+
+## Usage
+
+### Inputs
+
+| Input               | Required | Description                                   |
+| ------------------- | -------- | --------------------------------------------- |
+| `user_login`        | true     | The GitHub username to check                  |
+| `core_contributors` | false    | The base64 encoded list of Core Contributors  |
+| `maintainers`       | false    | The base64 encoded list of maintainers        |
+| `partners`          | false    | The base64 encoded list of partner contritors |
+
+### Outputs
+
+| Output             | Default | Description                               |
+| ------------------ | ------- | ----------------------------------------- |
+| `core_contributor` | `null`  | Whether the user is a Core Contributor    |
+| `maintainer`       | `null`  | Whether the user is a maintainer          |
+| `partner`          | `null`  | Whether the user is a partner contributor |
+
+### Example
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    with:
+      sparse-checkout: .github/actions/community_check
+
+  - name: Community Check
+    uses: ./.github/actions/community_check
+    with:
+      user_login: ${{ github.event.issue.user.login }}
+      maintainers: ${{ secrets.MAINTAINERS }}
+      core_contributors: ${{ secrets.CORE_CONTRIBUTORS }}
+      partners: ${{ secrets.PARTNERS }}
+```

--- a/.github/actions/community_check/action.yml
+++ b/.github/actions/community_check/action.yml
@@ -1,0 +1,53 @@
+name: Community Check
+description: Check a username against our lists of groups within the community
+
+inputs:
+  user_login:
+    description: The GitHub username to check
+    required: true
+
+  core_contributors:
+    description: The base64 encoded list of Core Contributors
+    required: false
+
+  maintainers:
+    description: The base64 encoded list of maintainers
+    required: false
+
+  partners:
+    description: The base64 encoded list of partners
+    required: false
+
+outputs:
+  core_contributor:
+    description: Whether the user is a Core Contributor
+    value: ${{ steps.core_contributor.outputs.check }}
+
+  maintainer:
+    description: Whether the user is a maintainer
+    value: ${{ steps.maintainer.outputs.check }}
+
+  partner:
+    description: Whether the user is a partner
+    value: ${{ steps.partner.outputs.check }}
+
+runs:
+  using: composite
+  steps:
+    - name: Core Contributor
+      id: core_contributor
+      if: inputs.core_contributors != ''
+      shell: bash
+      run: echo "check=$(echo $INPUT_CORE_CONTRIBUTORS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+
+    - name: Maintainers
+      id: maintainer
+      if: inputs.maintainers != ''
+      shell: bash
+      run: echo "check=$(echo $INPUT_MAINTAINERS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+
+    - name: Partners
+      id: partner
+      if: inputs.partners != ''
+      shell: bash
+      run: echo "check=$(echo $INPUT_PARTNERS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/labelers.yml
+++ b/.github/workflows/labelers.yml
@@ -1,6 +1,7 @@
 name: Label Automations
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 
@@ -32,27 +33,27 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       ISSUE_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
       LABELS: ${{ toJSON(github.event.issue.labels.*.name || github.event.pull_request.labels.*.name) }}
-      MAINTAINERS: ${{ secrets.MAINTAINERS }}
 
     steps:
+      - name: Checkout Community Check
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          sparse-checkout: .github/actions/community_check
+
       - name: "Community Check: Author"
         id: author
         if: github.event.action == 'opened'
-        env:
-          AUTHOR_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
-          CORE_CONTRIBUTORS: ${{ secrets.CORE_CONTRIBUTORS }}
-          PARTNERS: ${{ secrets.PARTNERS }}
-        run: |
-          echo "is_core_contributor=$(echo $CORE_CONTRIBUTORS | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
-
-          echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
-
-          echo "is_partner=$(echo $PARTNERS | base64 --decode | jq --arg u $AUTHOR_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/community_check
+        with:
+          user_login: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
+          maintainers: ${{ secrets.MAINTAINERS }}
+          core_contributors: ${{ secrets.CORE_CONTRIBUTORS }}
+          partners: ${{ secrets.PARTNERS }}
 
       - name: Indicate That Triage is Required
         if: |
           steps.author.conclusion != 'skipped'
-          && !fromJSON(steps.author.outputs.is_maintainer)
+          && steps.author.outputs.maintainer != 'true'
         run: |
           gh $GH_CLI_SUBCOMMAND edit "$ISSUE_URL" --add-label needs-triage
 
@@ -60,7 +61,7 @@ jobs:
         if: |
           github.event_name == 'pull_request_target'
           && steps.author.conclusion != 'skipped'
-          && fromJSON(steps.author.outputs.is_core_contributor)
+          && steps.author.outputs.core_contributor == 'true'
         run: |
           gh pr edit "$ISSUE_URL" --add-label external-maintainer
 
@@ -68,7 +69,7 @@ jobs:
         if: |
           github.event_name == 'pull_request_target'
           && steps.author.conclusion != 'skipped'
-          && fromJSON(steps.author.outputs.is_maintainer)
+          && steps.author.outputs.maintainer == 'true'
         run: |
           gh pr edit "$ISSUE_URL" --add-label prioritized
 
@@ -76,36 +77,36 @@ jobs:
         if: |
           github.event_name == 'pull_request_target'
           && steps.author.conclusion != 'skipped'
-          && fromJSON(steps.author.outputs.is_partner)
+          && steps.author.outputs.partner == 'true'
         run: |
           gh pr edit "$ISSUE_URL" --add-label partner
 
       - name: "Community Check: Assignee"
         id: assignee
         if: github.event.action == 'assigned'
-        env:
-          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
-        run: |
-          echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/community_check
+        with:
+          user_login: ${{ github.event.assignee.login }}
+          maintainers: ${{ secrets.MAINTAINERS }}
 
       - name: Add prioritized to Maintainer Assignments
         if: |
           steps.assignee.conclusion != 'skipped'
-          && fromJSON(steps.assignee.outputs.is_maintainer)
+          && steps.assignee.outputs.maintainer == 'true'
         run: |
           gh $GH_CLI_SUBCOMMAND edit "$ISSUE_URL" --add-label prioritized
 
       - name: "Community Check: Editor"
         id: editor
         if: github.event.action == 'edited'
-        env:
-          EDITOR_LOGIN: ${{ github.event.sender.login }}
-        run: |
-          echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $ASSIGNEE_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/community_check
+        with:
+          user_login: ${{ github.event.sender.login }}
+          maintainers: ${{ secrets.MAINTAINERS }}
 
       - name: Remove Stale Indicators on Non-Maintainer Edit
         if: |
-          (steps.editor.conclusion != 'skipped' && !fromJSON(steps.editor.outputs.is_maintainer))
+          (steps.editor.conclusion != 'skipped' && steps.editor.outputs.maintainer != 'true')
           && (contains(fromJSON(env.LABELS), 'stale') || contains(fromJSON(env.LABELS), 'waiting-response'))
         run: |
           gh $GH_CLI_SUBCOMMAND edit "$ISSUE_URL" --remove-label stale,waiting-response
@@ -113,14 +114,14 @@ jobs:
       - name: "Community Check: Commenter"
         id: commenter
         if: github.event.action == 'created'
-        env:
-          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
-        run: |
-          echo "is_maintainer=$(echo $MAINTAINERS | base64 --decode | jq --arg u $COMMENTER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/community_check
+        with:
+          user_login: ${{ github.event.comment.user.login }}
+          maintainers: ${{ secrets.MAINTAINERS }}
 
       - name: Remove Stale Indicators on Non-Maintainer Comment
         if: |
-          (steps.commenter.conclusion != 'skipped' && !fromJSON(steps.commenter.outputs.is_maintainer))
+          (steps.commenter.conclusion != 'skipped' && steps.commenter.outputs.maintainer != 'true')
           && (contains(fromJSON(env.LABELS), 'stale') || contains(fromJSON(env.LABELS), 'waiting-response'))
         run: |
           gh $GH_CLI_SUBCOMMAND edit "$ISSUE_URL" --remove-label stale,waiting-response


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

### About

This PR adds a [composite action](https://docs.github.com/en/actions/creating-actions/about-custom-actions#composite-actions) for the community check, in a shift away from how we've handled this before.

Composite Actions are called at the `step` level, so don't appear as a separate job in the pull request check UI like reusable workflows do. Since the action is within its own directory, I took the opportunity to add a README as well.

**Note:** I was able to test the Composite Action locally with `act`, but `act` skips the `checkout` step, so the `sparse-checkout` bit is best-effort