### PR TITLE
Fix community check

### DIFF
--- a/.github/actions/community_check/action.yml
+++ b/.github/actions/community_check/action.yml
@@ -41,16 +41,16 @@ runs:
       id: core_contributor
       if: inputs.core_contributors != ''
       shell: bash
-      run: echo "check=$(echo $INPUT_CORE_CONTRIBUTORS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+      run: echo "check=$(echo ${{ inputs.core_contributors }} | base64 --decode | jq --arg u ${{ inputs.user_login }} '. | contains([$u])')" >> "$GITHUB_OUTPUT"
 
     - name: Maintainers
       id: maintainer
       if: inputs.maintainers != ''
       shell: bash
-      run: echo "check=$(echo $INPUT_MAINTAINERS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+      run: echo "check=$(echo ${{ inputs.maintainers }} | base64 --decode | jq --arg u ${{ inputs.user_login }} '. | contains([$u])')" >> "$GITHUB_OUTPUT"
 
     - name: Partners
       id: partner
       if: inputs.partners != ''
       shell: bash
-      run: echo "check=$(echo $INPUT_PARTNERS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+      run: echo "check=$(echo ${{ inputs.partners }} | base64 --decode | jq --arg u ${{ inputs.user_login }} '. | contains([$u])')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

Relates https://github.com/hashicorp/terraform-provider-aws/pull/38585

Fixes the community check by replacing the `$INPUT_*` variables with their `${{ inputs.* }}` counterparts.
