### PR TITLE
split make targets for docs generation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ default: build
 
 .PHONY: all build default docs golangci-lint lint plural-data-sources resources schemas singular-data-sources test testacc tools
 
-all: schemas resources singular-data-sources plural-data-sources build docs
+all: schemas resources singular-data-sources plural-data-sources build docs-all
 
 build: prereq-go
 	$(GO_VER) install
@@ -61,11 +61,15 @@ tools: prereq-go
 	cd tools && $(GO_VER) install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 	cd tools && $(GO_VER) install golang.org/x/tools/cmd/goimports@latest
 
+docs-all: docs-import docs
+
 docs: prereq-go
-	$(GO_VER) generate internal/provider/import_examples.go
 	rm -f docs/data-sources/*.md
 	rm -f docs/resources/*.md
 	@tfplugindocs generate
+
+docs-import: prereq-go
+	$(GO_VER) generate internal/provider/import_examples.go
 
 prereq-go: ## If $(GO_VER) is not installed, install it
 	@if ! type "$(GO_VER)" > /dev/null 2>&1 ; then \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ GO_VER              ?= go
 
 default: build
 
-.PHONY: all build default docs docs-all docs-import lint plural-data-sources resources schemas singular-data-sources test testacc tools
+.PHONY: all build default docs docs-all docs-import golangci-lint lint plural-data-sources resources schemas singular-data-sources test testacc tools
 
 all: schemas resources singular-data-sources plural-data-sources build docs-all
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ GO_VER              ?= go
 
 default: build
 
-.PHONY: all build default docs golangci-lint lint plural-data-sources resources schemas singular-data-sources test testacc tools
+.PHONY: all build default docs docs-all docs-import lint plural-data-sources resources schemas singular-data-sources test testacc tools
 
 all: schemas resources singular-data-sources plural-data-sources build docs-all
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Description

Generating import examples can take a long time to run and are not relevant for more general docs updates. Make targets are have been updated:

- `docs`: generates docs using `tfplugindocs`
- `docs-import`: generates import statements based on the primary identifier from schemas. Only necessary when resource schemas change.
- `docs-all`: runs both `docs-import` and `docs`
