### PR TITLE
fix: reference path in example awscc_sagemaker_cluster

### DIFF
--- a/docs/resources/sagemaker_cluster.md
+++ b/docs/resources/sagemaker_cluster.md
@@ -72,7 +72,7 @@ resource "awscc_sagemaker_cluster" "this" {
       instance_type       = "ml.c5.2xlarge"
       instance_group_name = "example"
       life_cycle_config = {
-        source_s3_uri = "s3://${aws_s3_bucket.this.id}/base-config/"
+        source_s3_uri = "s3://${aws_s3_bucket.this.id}/config/"
         on_create     = "on_create_noop.sh"
       }
     }

--- a/examples/resources/awscc_sagemaker_cluster/sagemaker_cluster_eks.tf
+++ b/examples/resources/awscc_sagemaker_cluster/sagemaker_cluster_eks.tf
@@ -7,7 +7,7 @@ resource "awscc_sagemaker_cluster" "this" {
       instance_type       = "ml.c5.2xlarge"
       instance_group_name = "example"
       life_cycle_config = {
-        source_s3_uri = "s3://${aws_s3_bucket.this.id}/base-config/"
+        source_s3_uri = "s3://${aws_s3_bucket.this.id}/config/"
         on_create     = "on_create_noop.sh"
       }
     }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes a path string which was set to `base-config` instead of `config`