### PR TITLE
[chore] Update for goreleaser deprecations

### DIFF
--- a/.github/goreleaser-cross-compiler-test.yml
+++ b/.github/goreleaser-cross-compiler-test.yml
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+version: 2
 archives:
   - files:
       # Ensure only built binary is archived
@@ -27,4 +28,4 @@ builds:
       - -s -w -X version.ProviderVersion={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,4 +81,4 @@ signs:
     id: key-id
     signature: ${artifact}.72D7468F.sig
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

https://github.com/hashicorp/terraform-provider-awscc/actions/runs/11007471411/job/30563431668?pr=2032

```console
/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser build --config .github/goreleaser-cross-compiler-test.yml --id 32-bit-arch --snapshot
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  • single build in config, '--id' ignored
  • skipping validate...
  • loading environment variables
  • getting and validating git state
    • ignoring errors because this is a snapshot     error=git doesn't contain any tags. Either add a tag or use --snapshot
    • git state                                      commit=5b[14](https://github.com/hashicorp/terraform-provider-awscc/actions/runs/11007471411/job/30563431668?pr=2032#step:5:15)565e8f02408760324b220cd261ed37c811fa branch=HEAD current_tag=v0.0.0 previous_tag=<unknown> dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
```

- https://goreleaser.com/deprecations
