### PR TITLE
fix: change provider docs assume_role to be list instead of object

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -182,11 +182,13 @@ Usage:
 
 ```terraform
 provider "awscc" {
-  assume_role = {
-    role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-    session_name = "SESSION_NAME"
-    external_id  = "EXTERNAL_ID"
-  }
+  assume_role = [
+    {
+      role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+      session_name = "SESSION_NAME"
+      external_id  = "EXTERNAL_ID"
+    }
+  ]
 }
 ```
 
@@ -194,12 +196,14 @@ To assume a role with role chaining, do the following:
 
 ```terraform
 provider "awscc" {
-  assume_role {
-    role_arn = "arn:aws:iam::123456789012:role/INITIAL_ROLE_NAME"
-  }
-  assume_role {
-    role_arn = "arn:aws:iam::123456789012:role/FINAL_ROLE_NAME"
-  }
+  assume_role = [
+    {
+      role_arn = "arn:aws:iam::123456789012:role/INITIAL_ROLE_NAME"
+    },
+    {
+      role_arn = "arn:aws:iam::123456789012:role/FINAL_ROLE_NAME"
+    }
+  ]
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,11 +182,11 @@ Usage:
 
 ```terraform
 provider "awscc" {
-  assume_role = {
+  assume_role = [{
     role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
     session_name = "SESSION_NAME"
     external_id  = "EXTERNAL_ID"
-  }
+  }]
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,11 +182,24 @@ Usage:
 
 ```terraform
 provider "awscc" {
-  assume_role = [{
+  assume_role = {
     role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
     session_name = "SESSION_NAME"
     external_id  = "EXTERNAL_ID"
-  }]
+  }
+}
+```
+
+To assume a role with role chaining, do the following:
+
+```terraform
+provider "awscc" {
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/INITIAL_ROLE_NAME"
+  }
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/FINAL_ROLE_NAME"
+  }
 }
 ```
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -182,11 +182,13 @@ Usage:
 
 ```terraform
 provider "awscc" {
-  assume_role = {
-    role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-    session_name = "SESSION_NAME"
-    external_id  = "EXTERNAL_ID"
-  }
+  assume_role = [
+    {
+      role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+      session_name = "SESSION_NAME"
+      external_id  = "EXTERNAL_ID"
+    }
+  ]
 }
 ```
 
@@ -194,12 +196,14 @@ To assume a role with role chaining, do the following:
 
 ```terraform
 provider "awscc" {
-  assume_role {
-    role_arn = "arn:aws:iam::123456789012:role/INITIAL_ROLE_NAME"
-  }
-  assume_role {
-    role_arn = "arn:aws:iam::123456789012:role/FINAL_ROLE_NAME"
-  }
+  assume_role = [
+    {
+      role_arn = "arn:aws:iam::123456789012:role/INITIAL_ROLE_NAME"
+    },
+    {
+      role_arn = "arn:aws:iam::123456789012:role/FINAL_ROLE_NAME"
+    }
+  ]
 }
 ```
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -190,6 +190,19 @@ provider "awscc" {
 }
 ```
 
+To assume a role with role chaining, do the following:
+
+```terraform
+provider "awscc" {
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/INITIAL_ROLE_NAME"
+  }
+  assume_role {
+    role_arn = "arn:aws:iam::123456789012:role/FINAL_ROLE_NAME"
+  }
+}
+```
+
 > **Hands-on:** Try the [Use AssumeRole to Provision AWS Resources Across Accounts](https://developer.hashicorp.com/terraform/tutorials/aws/aws-assumerole) tutorial on HashiCorp Developer page.
 
 ### Assume Role Using Web Identity


### PR DESCRIPTION
As per this [commit](https://github.com/hashicorp/terraform-provider-awscc/commit/d0e204070d3674f89d8ed966be77c3c755e3b6c5) the behaviour is changed from object to list

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

Relates https://github.com/hashicorp/terraform-provider-awscc/pull/2029.
