### PR TITLE
provider: Revert breaking change from IAM role chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 BUG FIXES:
 
-* provider: Rolls back breaking change introduced in #2029. IAM role chaining is no longer supported.
+* provider: Rolls back breaking change introduced in #2029. IAM role chaining is no longer supported, but will be reintroduced in a future version. ([#2043](https://github.com/hashicorp/terraform-provider-awscc/pull/2043))
 
 ## 1.16.0 (September 26, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 ## 1.17.0 (Unreleased)
+
+## 1.16.1 (September 27, 2024)
+
+BUG FIXES:
+
+* provider: Rolls back breaking change introduced in #2029. IAM role chaining is no longer supported.
+
 ## 1.16.0 (September 26, 2024)
 
 FEATURES:
 
-* provider: Adds support for IAM role chaining. The provider attribute `assume_role` now accepts multiple elements.
+* provider: Adds support for IAM role chaining. The provider attribute `assume_role` now accepts multiple elements. ([#2029](https://github.com/hashicorp/terraform-provider-awscc/pull/2029))
 
 * **New Data Source:** `awscc_amazonmq_configuration`
 * **New Data Source:** `awscc_amazonmq_configurations`

--- a/docs/index.md
+++ b/docs/index.md
@@ -234,7 +234,7 @@ credential_process = custom-process --username jdoe
 ### Optional
 
 - `access_key` (String) This is the AWS access key. It must be provided, but it can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, or via a shared credentials file if `profile` is specified.
-- `assume_role` (Attributes List) List of IAM Roles to assume. See the `assume_role` block (documented below). (see [below for nested schema](#nestedatt--assume_role))
+- `assume_role` (Attributes) An `assume_role` block (documented below). Only one `assume_role` block may be in the configuration. (see [below for nested schema](#nestedatt--assume_role))
 - `assume_role_with_web_identity` (Attributes) An `assume_role_with_web_identity` block (documented below). Only one `assume_role_with_web_identity` block may be in the configuration. (see [below for nested schema](#nestedatt--assume_role_with_web_identity))
 - `endpoints` (Attributes) An `endpoints` block (documented below). Only one `endpoints` block may be in the configuration. (see [below for nested schema](#nestedatt--endpoints))
 - `http_proxy` (String) URL of a proxy to use for HTTP requests when accessing the AWS API. Can also be set using the `HTTP_PROXY` or `http_proxy` environment variables.


### PR DESCRIPTION
The PR #2029 introduced a breaking change with the `assume_role` attribute. This PR rolls back the breaking change and removes the ability to do IAM role chaining. This will be reintroduced in a future version.

Closes #2041