### PR TITLE
fix: add awscc_gamelift_container_group_definition schema update

### DIFF
--- a/docs/data-sources/gamelift_container_group_definition.md
+++ b/docs/data-sources/gamelift_container_group_definition.md
@@ -21,37 +21,38 @@ Data Source schema for AWS::GameLift::ContainerGroupDefinition
 
 ### Read-Only
 
-- `container_definitions` (Attributes Set) A collection of container definitions that define the containers in this group. (see [below for nested schema](#nestedatt--container_definitions))
 - `container_group_definition_arn` (String) The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.
+- `container_group_type` (String) The scope of the container group
 - `creation_time` (String) A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").
+- `game_server_container_definition` (Attributes) Specifies the information required to run game servers with this container group (see [below for nested schema](#nestedatt--game_server_container_definition))
 - `name` (String) A descriptive label for the container group definition.
 - `operating_system` (String) The operating system of the container group
-- `scheduling_strategy` (String) Specifies whether the container group includes replica or daemon containers.
+- `source_version_number` (Number) A specific ContainerGroupDefinition version to be updated
+- `status` (String) A string indicating ContainerGroupDefinition status.
+- `status_reason` (String) A string indicating the reason for ContainerGroupDefinition status.
+- `support_container_definitions` (Attributes Set) A collection of support container definitions that define the containers in this group. (see [below for nested schema](#nestedatt--support_container_definitions))
 - `tags` (Attributes Set) An array of key-value pairs to apply to this resource. (see [below for nested schema](#nestedatt--tags))
-- `total_cpu_limit` (Number) The maximum number of CPU units reserved for this container group. The value is expressed as an integer amount of CPU units. (1 vCPU is equal to 1024 CPU units.)
-- `total_memory_limit` (Number) The maximum amount of memory (in MiB) to allocate for this container group.
+- `total_memory_limit_mebibytes` (Number) The total memory limit of container groups following this definition in MiB
+- `total_vcpu_limit` (Number) The total amount of virtual CPUs on the container group definition
+- `version_description` (String) The description of this version
+- `version_number` (Number) The version of this ContainerGroupDefinition
 
-<a id="nestedatt--container_definitions"></a>
-### Nested Schema for `container_definitions`
+<a id="nestedatt--game_server_container_definition"></a>
+### Nested Schema for `game_server_container_definition`
 
 Read-Only:
 
-- `command` (List of String) The command that's passed to the container.
 - `container_name` (String) A descriptive label for the container definition. Container definition names must be unique with a container group definition.
-- `cpu` (Number) The maximum number of CPU units reserved for this container. The value is expressed as an integer amount of CPU units. 1 vCPU is equal to 1024 CPU units
-- `depends_on` (Attributes List) A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers. (see [below for nested schema](#nestedatt--container_definitions--depends_on))
-- `entry_point` (List of String) The entry point that's passed to the container so that it will run as an executable. If there are multiple arguments, each argument is a string in the array.
-- `environment` (Attributes Set) The environment variables to pass to a container. (see [below for nested schema](#nestedatt--container_definitions--environment))
-- `essential` (Boolean) Specifies if the container is essential. If an essential container fails a health check, then all containers in the container group will be restarted. You must specify exactly 1 essential container in a container group.
-- `health_check` (Attributes) Specifies how the health of the containers will be checked. (see [below for nested schema](#nestedatt--container_definitions--health_check))
+- `depends_on` (Attributes List) A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers. (see [below for nested schema](#nestedatt--game_server_container_definition--depends_on))
+- `environment_override` (Attributes Set) The environment variables to pass to a container. (see [below for nested schema](#nestedatt--game_server_container_definition--environment_override))
 - `image_uri` (String) Specifies the image URI of this container.
-- `memory_limits` (Attributes) Specifies how much memory is available to the container. You must specify at least this parameter or the TotalMemoryLimit parameter of the ContainerGroupDefinition. (see [below for nested schema](#nestedatt--container_definitions--memory_limits))
-- `port_configuration` (Attributes) Defines the ports on the container. (see [below for nested schema](#nestedatt--container_definitions--port_configuration))
+- `mount_points` (Attributes Set) A list of mount point configurations to be used in a container. (see [below for nested schema](#nestedatt--game_server_container_definition--mount_points))
+- `port_configuration` (Attributes) Defines the ports on the container. (see [below for nested schema](#nestedatt--game_server_container_definition--port_configuration))
 - `resolved_image_digest` (String) The digest of the container image.
-- `working_directory` (String) The working directory to run commands inside the container in.
+- `server_sdk_version` (String) The version of the server SDK used in this container group
 
-<a id="nestedatt--container_definitions--depends_on"></a>
-### Nested Schema for `container_definitions.depends_on`
+<a id="nestedatt--game_server_container_definition--depends_on"></a>
+### Nested Schema for `game_server_container_definition.depends_on`
 
 Read-Only:
 
@@ -59,8 +60,8 @@ Read-Only:
 - `container_name` (String) A descriptive label for the container definition. The container being defined depends on this container's condition.
 
 
-<a id="nestedatt--container_definitions--environment"></a>
-### Nested Schema for `container_definitions.environment`
+<a id="nestedatt--game_server_container_definition--environment_override"></a>
+### Nested Schema for `game_server_container_definition.environment_override`
 
 Read-Only:
 
@@ -68,8 +69,72 @@ Read-Only:
 - `value` (String) The environment variable value.
 
 
-<a id="nestedatt--container_definitions--health_check"></a>
-### Nested Schema for `container_definitions.health_check`
+<a id="nestedatt--game_server_container_definition--mount_points"></a>
+### Nested Schema for `game_server_container_definition.mount_points`
+
+Read-Only:
+
+- `access_level` (String) The access permissions for the mounted path.
+- `container_path` (String) The path inside the container where the mount is accessible.
+- `instance_path` (String) The path on the host that will be mounted in the container.
+
+
+<a id="nestedatt--game_server_container_definition--port_configuration"></a>
+### Nested Schema for `game_server_container_definition.port_configuration`
+
+Read-Only:
+
+- `container_port_ranges` (Attributes Set) Specifies one or more ranges of ports on a container. (see [below for nested schema](#nestedatt--game_server_container_definition--port_configuration--container_port_ranges))
+
+<a id="nestedatt--game_server_container_definition--port_configuration--container_port_ranges"></a>
+### Nested Schema for `game_server_container_definition.port_configuration.container_port_ranges`
+
+Read-Only:
+
+- `from_port` (Number) A starting value for the range of allowed port numbers.
+- `protocol` (String) Defines the protocol of these ports.
+- `to_port` (Number) An ending value for the range of allowed port numbers. Port numbers are end-inclusive. This value must be equal to or greater than FromPort.
+
+
+
+
+<a id="nestedatt--support_container_definitions"></a>
+### Nested Schema for `support_container_definitions`
+
+Read-Only:
+
+- `container_name` (String) A descriptive label for the container definition.
+- `depends_on` (Attributes List) A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers. (see [below for nested schema](#nestedatt--support_container_definitions--depends_on))
+- `environment_override` (Attributes Set) The environment variables to pass to a container. (see [below for nested schema](#nestedatt--support_container_definitions--environment_override))
+- `essential` (Boolean) Specifies if the container is essential. If an essential container fails a health check, then all containers in the container group will be restarted. You must specify exactly 1 essential container in a container group.
+- `health_check` (Attributes) Specifies how the health of the containers will be checked. (see [below for nested schema](#nestedatt--support_container_definitions--health_check))
+- `image_uri` (String) Specifies the image URI of this container.
+- `memory_hard_limit_mebibytes` (Number) The total memory limit of container groups following this definition in MiB
+- `mount_points` (Attributes Set) A list of mount point configurations to be used in a container. (see [below for nested schema](#nestedatt--support_container_definitions--mount_points))
+- `port_configuration` (Attributes) Defines the ports on the container. (see [below for nested schema](#nestedatt--support_container_definitions--port_configuration))
+- `resolved_image_digest` (String) The digest of the container image.
+- `vcpu` (Number) The number of virtual CPUs to give to the support group
+
+<a id="nestedatt--support_container_definitions--depends_on"></a>
+### Nested Schema for `support_container_definitions.depends_on`
+
+Read-Only:
+
+- `condition` (String) The type of dependency.
+- `container_name` (String) A descriptive label for the container definition. The container being defined depends on this container's condition.
+
+
+<a id="nestedatt--support_container_definitions--environment_override"></a>
+### Nested Schema for `support_container_definitions.environment_override`
+
+Read-Only:
+
+- `name` (String) The environment variable name.
+- `value` (String) The environment variable value.
+
+
+<a id="nestedatt--support_container_definitions--health_check"></a>
+### Nested Schema for `support_container_definitions.health_check`
 
 Read-Only:
 
@@ -80,24 +145,25 @@ Read-Only:
 - `timeout` (Number) How many seconds the process manager allows the command to run before canceling it.
 
 
-<a id="nestedatt--container_definitions--memory_limits"></a>
-### Nested Schema for `container_definitions.memory_limits`
+<a id="nestedatt--support_container_definitions--mount_points"></a>
+### Nested Schema for `support_container_definitions.mount_points`
 
 Read-Only:
 
-- `hard_limit` (Number) The hard limit of memory to reserve for the container.
-- `soft_limit` (Number) The amount of memory that is reserved for the container.
+- `access_level` (String) The access permissions for the mounted path.
+- `container_path` (String) The path inside the container where the mount is accessible.
+- `instance_path` (String) The path on the host that will be mounted in the container.
 
 
-<a id="nestedatt--container_definitions--port_configuration"></a>
-### Nested Schema for `container_definitions.port_configuration`
+<a id="nestedatt--support_container_definitions--port_configuration"></a>
+### Nested Schema for `support_container_definitions.port_configuration`
 
 Read-Only:
 
-- `container_port_ranges` (Attributes Set) Specifies one or more ranges of ports on a container. (see [below for nested schema](#nestedatt--container_definitions--port_configuration--container_port_ranges))
+- `container_port_ranges` (Attributes Set) Specifies one or more ranges of ports on a container. (see [below for nested schema](#nestedatt--support_container_definitions--port_configuration--container_port_ranges))
 
-<a id="nestedatt--container_definitions--port_configuration--container_port_ranges"></a>
-### Nested Schema for `container_definitions.port_configuration.container_port_ranges`
+<a id="nestedatt--support_container_definitions--port_configuration--container_port_ranges"></a>
+### Nested Schema for `support_container_definitions.port_configuration.container_port_ranges`
 
 Read-Only:
 

--- a/docs/resources/gamelift_container_group_definition.md
+++ b/docs/resources/gamelift_container_group_definition.md
@@ -17,47 +17,45 @@ The AWS::GameLift::ContainerGroupDefinition resource creates an Amazon GameLift 
 
 ### Required
 
-- `container_definitions` (Attributes Set) A collection of container definitions that define the containers in this group. (see [below for nested schema](#nestedatt--container_definitions))
 - `name` (String) A descriptive label for the container group definition.
 - `operating_system` (String) The operating system of the container group
-- `total_cpu_limit` (Number) The maximum number of CPU units reserved for this container group. The value is expressed as an integer amount of CPU units. (1 vCPU is equal to 1024 CPU units.)
-- `total_memory_limit` (Number) The maximum amount of memory (in MiB) to allocate for this container group.
+- `total_memory_limit_mebibytes` (Number) The total memory limit of container groups following this definition in MiB
+- `total_vcpu_limit` (Number) The total amount of virtual CPUs on the container group definition
 
 ### Optional
 
-- `scheduling_strategy` (String) Specifies whether the container group includes replica or daemon containers.
+- `container_group_type` (String) The scope of the container group
+- `game_server_container_definition` (Attributes) Specifies the information required to run game servers with this container group (see [below for nested schema](#nestedatt--game_server_container_definition))
+- `source_version_number` (Number) A specific ContainerGroupDefinition version to be updated
+- `support_container_definitions` (Attributes Set) A collection of support container definitions that define the containers in this group. (see [below for nested schema](#nestedatt--support_container_definitions))
 - `tags` (Attributes Set) An array of key-value pairs to apply to this resource. (see [below for nested schema](#nestedatt--tags))
+- `version_description` (String) The description of this version
 
 ### Read-Only
 
 - `container_group_definition_arn` (String) The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.
 - `creation_time` (String) A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").
 - `id` (String) Uniquely identifies the resource.
+- `status` (String) A string indicating ContainerGroupDefinition status.
+- `status_reason` (String) A string indicating the reason for ContainerGroupDefinition status.
+- `version_number` (Number) The version of this ContainerGroupDefinition
 
-<a id="nestedatt--container_definitions"></a>
-### Nested Schema for `container_definitions`
-
-Required:
-
-- `container_name` (String) A descriptive label for the container definition. Container definition names must be unique with a container group definition.
-- `image_uri` (String) Specifies the image URI of this container.
+<a id="nestedatt--game_server_container_definition"></a>
+### Nested Schema for `game_server_container_definition`
 
 Optional:
 
-- `command` (List of String) The command that's passed to the container.
-- `cpu` (Number) The maximum number of CPU units reserved for this container. The value is expressed as an integer amount of CPU units. 1 vCPU is equal to 1024 CPU units
-- `depends_on` (Attributes List) A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers. (see [below for nested schema](#nestedatt--container_definitions--depends_on))
-- `entry_point` (List of String) The entry point that's passed to the container so that it will run as an executable. If there are multiple arguments, each argument is a string in the array.
-- `environment` (Attributes Set) The environment variables to pass to a container. (see [below for nested schema](#nestedatt--container_definitions--environment))
-- `essential` (Boolean) Specifies if the container is essential. If an essential container fails a health check, then all containers in the container group will be restarted. You must specify exactly 1 essential container in a container group.
-- `health_check` (Attributes) Specifies how the health of the containers will be checked. (see [below for nested schema](#nestedatt--container_definitions--health_check))
-- `memory_limits` (Attributes) Specifies how much memory is available to the container. You must specify at least this parameter or the TotalMemoryLimit parameter of the ContainerGroupDefinition. (see [below for nested schema](#nestedatt--container_definitions--memory_limits))
-- `port_configuration` (Attributes) Defines the ports on the container. (see [below for nested schema](#nestedatt--container_definitions--port_configuration))
+- `container_name` (String) A descriptive label for the container definition. Container definition names must be unique with a container group definition.
+- `depends_on` (Attributes List) A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers. (see [below for nested schema](#nestedatt--game_server_container_definition--depends_on))
+- `environment_override` (Attributes Set) The environment variables to pass to a container. (see [below for nested schema](#nestedatt--game_server_container_definition--environment_override))
+- `image_uri` (String) Specifies the image URI of this container.
+- `mount_points` (Attributes Set) A list of mount point configurations to be used in a container. (see [below for nested schema](#nestedatt--game_server_container_definition--mount_points))
+- `port_configuration` (Attributes) Defines the ports on the container. (see [below for nested schema](#nestedatt--game_server_container_definition--port_configuration))
 - `resolved_image_digest` (String) The digest of the container image.
-- `working_directory` (String) The working directory to run commands inside the container in.
+- `server_sdk_version` (String) The version of the server SDK used in this container group
 
-<a id="nestedatt--container_definitions--depends_on"></a>
-### Nested Schema for `container_definitions.depends_on`
+<a id="nestedatt--game_server_container_definition--depends_on"></a>
+### Nested Schema for `game_server_container_definition.depends_on`
 
 Optional:
 
@@ -65,8 +63,8 @@ Optional:
 - `container_name` (String) A descriptive label for the container definition. The container being defined depends on this container's condition.
 
 
-<a id="nestedatt--container_definitions--environment"></a>
-### Nested Schema for `container_definitions.environment`
+<a id="nestedatt--game_server_container_definition--environment_override"></a>
+### Nested Schema for `game_server_container_definition.environment_override`
 
 Optional:
 
@@ -74,8 +72,72 @@ Optional:
 - `value` (String) The environment variable value.
 
 
-<a id="nestedatt--container_definitions--health_check"></a>
-### Nested Schema for `container_definitions.health_check`
+<a id="nestedatt--game_server_container_definition--mount_points"></a>
+### Nested Schema for `game_server_container_definition.mount_points`
+
+Optional:
+
+- `access_level` (String) The access permissions for the mounted path.
+- `container_path` (String) The path inside the container where the mount is accessible.
+- `instance_path` (String) The path on the host that will be mounted in the container.
+
+
+<a id="nestedatt--game_server_container_definition--port_configuration"></a>
+### Nested Schema for `game_server_container_definition.port_configuration`
+
+Optional:
+
+- `container_port_ranges` (Attributes Set) Specifies one or more ranges of ports on a container. (see [below for nested schema](#nestedatt--game_server_container_definition--port_configuration--container_port_ranges))
+
+<a id="nestedatt--game_server_container_definition--port_configuration--container_port_ranges"></a>
+### Nested Schema for `game_server_container_definition.port_configuration.container_port_ranges`
+
+Optional:
+
+- `from_port` (Number) A starting value for the range of allowed port numbers.
+- `protocol` (String) Defines the protocol of these ports.
+- `to_port` (Number) An ending value for the range of allowed port numbers. Port numbers are end-inclusive. This value must be equal to or greater than FromPort.
+
+
+
+
+<a id="nestedatt--support_container_definitions"></a>
+### Nested Schema for `support_container_definitions`
+
+Optional:
+
+- `container_name` (String) A descriptive label for the container definition.
+- `depends_on` (Attributes List) A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers. (see [below for nested schema](#nestedatt--support_container_definitions--depends_on))
+- `environment_override` (Attributes Set) The environment variables to pass to a container. (see [below for nested schema](#nestedatt--support_container_definitions--environment_override))
+- `essential` (Boolean) Specifies if the container is essential. If an essential container fails a health check, then all containers in the container group will be restarted. You must specify exactly 1 essential container in a container group.
+- `health_check` (Attributes) Specifies how the health of the containers will be checked. (see [below for nested schema](#nestedatt--support_container_definitions--health_check))
+- `image_uri` (String) Specifies the image URI of this container.
+- `memory_hard_limit_mebibytes` (Number) The total memory limit of container groups following this definition in MiB
+- `mount_points` (Attributes Set) A list of mount point configurations to be used in a container. (see [below for nested schema](#nestedatt--support_container_definitions--mount_points))
+- `port_configuration` (Attributes) Defines the ports on the container. (see [below for nested schema](#nestedatt--support_container_definitions--port_configuration))
+- `resolved_image_digest` (String) The digest of the container image.
+- `vcpu` (Number) The number of virtual CPUs to give to the support group
+
+<a id="nestedatt--support_container_definitions--depends_on"></a>
+### Nested Schema for `support_container_definitions.depends_on`
+
+Optional:
+
+- `condition` (String) The type of dependency.
+- `container_name` (String) A descriptive label for the container definition. The container being defined depends on this container's condition.
+
+
+<a id="nestedatt--support_container_definitions--environment_override"></a>
+### Nested Schema for `support_container_definitions.environment_override`
+
+Optional:
+
+- `name` (String) The environment variable name.
+- `value` (String) The environment variable value.
+
+
+<a id="nestedatt--support_container_definitions--health_check"></a>
+### Nested Schema for `support_container_definitions.health_check`
 
 Optional:
 
@@ -86,24 +148,25 @@ Optional:
 - `timeout` (Number) How many seconds the process manager allows the command to run before canceling it.
 
 
-<a id="nestedatt--container_definitions--memory_limits"></a>
-### Nested Schema for `container_definitions.memory_limits`
+<a id="nestedatt--support_container_definitions--mount_points"></a>
+### Nested Schema for `support_container_definitions.mount_points`
 
 Optional:
 
-- `hard_limit` (Number) The hard limit of memory to reserve for the container.
-- `soft_limit` (Number) The amount of memory that is reserved for the container.
+- `access_level` (String) The access permissions for the mounted path.
+- `container_path` (String) The path inside the container where the mount is accessible.
+- `instance_path` (String) The path on the host that will be mounted in the container.
 
 
-<a id="nestedatt--container_definitions--port_configuration"></a>
-### Nested Schema for `container_definitions.port_configuration`
+<a id="nestedatt--support_container_definitions--port_configuration"></a>
+### Nested Schema for `support_container_definitions.port_configuration`
 
 Optional:
 
-- `container_port_ranges` (Attributes Set) Specifies one or more ranges of ports on a container. (see [below for nested schema](#nestedatt--container_definitions--port_configuration--container_port_ranges))
+- `container_port_ranges` (Attributes Set) Specifies one or more ranges of ports on a container. (see [below for nested schema](#nestedatt--support_container_definitions--port_configuration--container_port_ranges))
 
-<a id="nestedatt--container_definitions--port_configuration--container_port_ranges"></a>
-### Nested Schema for `container_definitions.port_configuration.container_port_ranges`
+<a id="nestedatt--support_container_definitions--port_configuration--container_port_ranges"></a>
+### Nested Schema for `support_container_definitions.port_configuration.container_port_ranges`
 
 Optional:
 

--- a/internal/aws/gamelift/container_group_definition_resource_gen.go
+++ b/internal/aws/gamelift/container_group_definition_resource_gen.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -16,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
@@ -37,42 +39,655 @@ func init() {
 // This Terraform resource corresponds to the CloudFormation AWS::GameLift::ContainerGroupDefinition resource.
 func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, error) {
 	attributes := map[string]schema.Attribute{ /*START SCHEMA*/
-		// Property: ContainerDefinitions
+		// Property: ContainerGroupDefinitionArn
 		// CloudFormation resource type schema:
 		//
 		//	{
-		//	  "description": "A collection of container definitions that define the containers in this group.",
+		//	  "description": "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
+		//	  "maxLength": 512,
+		//	  "minLength": 1,
+		//	  "pattern": "^arn:.*:containergroupdefinition\\/[a-zA-Z0-9\\-]+(:[0-9]+)?$",
+		//	  "type": "string"
+		//	}
+		"container_group_definition_arn": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+				stringplanmodifier.UseStateForUnknown(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: ContainerGroupType
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The scope of the container group",
+		//	  "enum": [
+		//	    "GAME_SERVER",
+		//	    "PER_INSTANCE"
+		//	  ],
+		//	  "type": "string"
+		//	}
+		"container_group_type": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "The scope of the container group",
+			Optional:    true,
+			Computed:    true,
+			Validators: []validator.String{ /*START VALIDATORS*/
+				stringvalidator.OneOf(
+					"GAME_SERVER",
+					"PER_INSTANCE",
+				),
+			}, /*END VALIDATORS*/
+			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+				stringplanmodifier.UseStateForUnknown(),
+				stringplanmodifier.RequiresReplaceIfConfigured(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: CreationTime
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
+		//	  "type": "string"
+		//	}
+		"creation_time": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+				stringplanmodifier.UseStateForUnknown(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: GameServerContainerDefinition
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "additionalProperties": false,
+		//	  "description": "Specifies the information required to run game servers with this container group",
+		//	  "properties": {
+		//	    "ContainerName": {
+		//	      "description": "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
+		//	      "maxLength": 128,
+		//	      "minLength": 1,
+		//	      "pattern": "^[a-zA-Z0-9-]+$",
+		//	      "type": "string"
+		//	    },
+		//	    "DependsOn": {
+		//	      "description": "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
+		//	      "insertionOrder": true,
+		//	      "items": {
+		//	        "additionalProperties": false,
+		//	        "description": "A dependency that impacts a container's startup and shutdown.",
+		//	        "properties": {
+		//	          "Condition": {
+		//	            "description": "The type of dependency.",
+		//	            "enum": [
+		//	              "START",
+		//	              "COMPLETE",
+		//	              "SUCCESS",
+		//	              "HEALTHY"
+		//	            ],
+		//	            "type": "string"
+		//	          },
+		//	          "ContainerName": {
+		//	            "description": "A descriptive label for the container definition. The container being defined depends on this container's condition.",
+		//	            "maxLength": 128,
+		//	            "minLength": 1,
+		//	            "pattern": "^[a-zA-Z0-9-]+$",
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "ContainerName",
+		//	          "Condition"
+		//	        ],
+		//	        "type": "object"
+		//	      },
+		//	      "maxItems": 10,
+		//	      "minItems": 1,
+		//	      "type": "array",
+		//	      "uniqueItems": true
+		//	    },
+		//	    "EnvironmentOverride": {
+		//	      "description": "The environment variables to pass to a container.",
+		//	      "insertionOrder": false,
+		//	      "items": {
+		//	        "additionalProperties": false,
+		//	        "description": "An environment variable to set inside a container, in the form of a key-value pair.",
+		//	        "properties": {
+		//	          "Name": {
+		//	            "description": "The environment variable name.",
+		//	            "maxLength": 255,
+		//	            "minLength": 1,
+		//	            "pattern": "^.*$",
+		//	            "type": "string"
+		//	          },
+		//	          "Value": {
+		//	            "description": "The environment variable value.",
+		//	            "maxLength": 255,
+		//	            "minLength": 1,
+		//	            "pattern": "^.*$",
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "Name",
+		//	          "Value"
+		//	        ],
+		//	        "type": "object"
+		//	      },
+		//	      "maxItems": 20,
+		//	      "minItems": 1,
+		//	      "type": "array",
+		//	      "uniqueItems": true
+		//	    },
+		//	    "ImageUri": {
+		//	      "description": "Specifies the image URI of this container.",
+		//	      "maxLength": 255,
+		//	      "minLength": 1,
+		//	      "pattern": "^[a-zA-Z0-9-_\\.@\\/:]+$",
+		//	      "type": "string"
+		//	    },
+		//	    "MountPoints": {
+		//	      "description": "A list of mount point configurations to be used in a container.",
+		//	      "insertionOrder": false,
+		//	      "items": {
+		//	        "additionalProperties": false,
+		//	        "description": "Defines the mount point configuration within a container.",
+		//	        "properties": {
+		//	          "AccessLevel": {
+		//	            "description": "The access permissions for the mounted path.",
+		//	            "enum": [
+		//	              "READ_ONLY",
+		//	              "READ_AND_WRITE"
+		//	            ],
+		//	            "type": "string"
+		//	          },
+		//	          "ContainerPath": {
+		//	            "description": "The path inside the container where the mount is accessible.",
+		//	            "maxLength": 1024,
+		//	            "minLength": 1,
+		//	            "pattern": "^(\\/+[^\\/]+\\/*)+$",
+		//	            "type": "string"
+		//	          },
+		//	          "InstancePath": {
+		//	            "description": "The path on the host that will be mounted in the container.",
+		//	            "maxLength": 1024,
+		//	            "minLength": 1,
+		//	            "pattern": "^\\/[\\s\\S]*$",
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "InstancePath"
+		//	        ],
+		//	        "type": "object"
+		//	      },
+		//	      "maxItems": 10,
+		//	      "minItems": 1,
+		//	      "type": "array",
+		//	      "uniqueItems": true
+		//	    },
+		//	    "PortConfiguration": {
+		//	      "additionalProperties": false,
+		//	      "description": "Defines the ports on the container.",
+		//	      "properties": {
+		//	        "ContainerPortRanges": {
+		//	          "description": "Specifies one or more ranges of ports on a container.",
+		//	          "insertionOrder": false,
+		//	          "items": {
+		//	            "additionalProperties": false,
+		//	            "description": "A set of one or more port numbers that can be opened on the container.",
+		//	            "properties": {
+		//	              "FromPort": {
+		//	                "description": "A starting value for the range of allowed port numbers.",
+		//	                "maximum": 60000,
+		//	                "minimum": 1,
+		//	                "type": "integer"
+		//	              },
+		//	              "Protocol": {
+		//	                "description": "Defines the protocol of these ports.",
+		//	                "enum": [
+		//	                  "TCP",
+		//	                  "UDP"
+		//	                ],
+		//	                "type": "string"
+		//	              },
+		//	              "ToPort": {
+		//	                "description": "An ending value for the range of allowed port numbers. Port numbers are end-inclusive. This value must be equal to or greater than FromPort.",
+		//	                "maximum": 60000,
+		//	                "minimum": 1,
+		//	                "type": "integer"
+		//	              }
+		//	            },
+		//	            "required": [
+		//	              "FromPort",
+		//	              "Protocol",
+		//	              "ToPort"
+		//	            ],
+		//	            "type": "object"
+		//	          },
+		//	          "maxItems": 100,
+		//	          "minItems": 1,
+		//	          "type": "array",
+		//	          "uniqueItems": true
+		//	        }
+		//	      },
+		//	      "required": [
+		//	        "ContainerPortRanges"
+		//	      ],
+		//	      "type": "object"
+		//	    },
+		//	    "ResolvedImageDigest": {
+		//	      "description": "The digest of the container image.",
+		//	      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+		//	      "type": "string"
+		//	    },
+		//	    "ServerSdkVersion": {
+		//	      "description": "The version of the server SDK used in this container group",
+		//	      "maxLength": 128,
+		//	      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+		//	      "type": "string"
+		//	    }
+		//	  },
+		//	  "required": [
+		//	    "ContainerName",
+		//	    "ImageUri",
+		//	    "ServerSdkVersion"
+		//	  ],
+		//	  "type": "object"
+		//	}
+		"game_server_container_definition": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+			Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+				// Property: ContainerName
+				"container_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+					Description: "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
+					Optional:    true,
+					Computed:    true,
+					Validators: []validator.String{ /*START VALIDATORS*/
+						stringvalidator.LengthBetween(1, 128),
+						stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9-]+$"), ""),
+						fwvalidators.NotNullString(),
+					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+						stringplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+				// Property: DependsOn
+				"depends_on": schema.ListNestedAttribute{ /*START ATTRIBUTE*/
+					NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: Condition
+							"condition": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The type of dependency.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.OneOf(
+										"START",
+										"COMPLETE",
+										"SUCCESS",
+										"HEALTHY",
+									),
+									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+							// Property: ContainerName
+							"container_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "A descriptive label for the container definition. The container being defined depends on this container's condition.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.LengthBetween(1, 128),
+									stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9-]+$"), ""),
+									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+					}, /*END NESTED OBJECT*/
+					Description: "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
+					Optional:    true,
+					Computed:    true,
+					Validators: []validator.List{ /*START VALIDATORS*/
+						listvalidator.SizeBetween(1, 10),
+						listvalidator.UniqueValues(),
+					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
+						listplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+				// Property: EnvironmentOverride
+				"environment_override": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+					NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: Name
+							"name": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The environment variable name.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.LengthBetween(1, 255),
+									stringvalidator.RegexMatches(regexp.MustCompile("^.*$"), ""),
+									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+							// Property: Value
+							"value": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The environment variable value.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.LengthBetween(1, 255),
+									stringvalidator.RegexMatches(regexp.MustCompile("^.*$"), ""),
+									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+					}, /*END NESTED OBJECT*/
+					Description: "The environment variables to pass to a container.",
+					Optional:    true,
+					Computed:    true,
+					Validators: []validator.Set{ /*START VALIDATORS*/
+						setvalidator.SizeBetween(1, 20),
+					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.Set{ /*START PLAN MODIFIERS*/
+						setplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+				// Property: ImageUri
+				"image_uri": schema.StringAttribute{ /*START ATTRIBUTE*/
+					Description: "Specifies the image URI of this container.",
+					Optional:    true,
+					Computed:    true,
+					Validators: []validator.String{ /*START VALIDATORS*/
+						stringvalidator.LengthBetween(1, 255),
+						stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9-_\\.@\\/:]+$"), ""),
+						fwvalidators.NotNullString(),
+					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+						stringplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+				// Property: MountPoints
+				"mount_points": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+					NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: AccessLevel
+							"access_level": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The access permissions for the mounted path.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.OneOf(
+										"READ_ONLY",
+										"READ_AND_WRITE",
+									),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+							// Property: ContainerPath
+							"container_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The path inside the container where the mount is accessible.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.LengthBetween(1, 1024),
+									stringvalidator.RegexMatches(regexp.MustCompile("^(\\/+[^\\/]+\\/*)+$"), ""),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+							// Property: InstancePath
+							"instance_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The path on the host that will be mounted in the container.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.LengthBetween(1, 1024),
+									stringvalidator.RegexMatches(regexp.MustCompile("^\\/[\\s\\S]*$"), ""),
+									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+					}, /*END NESTED OBJECT*/
+					Description: "A list of mount point configurations to be used in a container.",
+					Optional:    true,
+					Computed:    true,
+					Validators: []validator.Set{ /*START VALIDATORS*/
+						setvalidator.SizeBetween(1, 10),
+					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.Set{ /*START PLAN MODIFIERS*/
+						setplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+				// Property: PortConfiguration
+				"port_configuration": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+					Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+						// Property: ContainerPortRanges
+						"container_port_ranges": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+							NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+								Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+									// Property: FromPort
+									"from_port": schema.Int64Attribute{ /*START ATTRIBUTE*/
+										Description: "A starting value for the range of allowed port numbers.",
+										Optional:    true,
+										Computed:    true,
+										Validators: []validator.Int64{ /*START VALIDATORS*/
+											int64validator.Between(1, 60000),
+											fwvalidators.NotNullInt64(),
+										}, /*END VALIDATORS*/
+										PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+											int64planmodifier.UseStateForUnknown(),
+										}, /*END PLAN MODIFIERS*/
+									}, /*END ATTRIBUTE*/
+									// Property: Protocol
+									"protocol": schema.StringAttribute{ /*START ATTRIBUTE*/
+										Description: "Defines the protocol of these ports.",
+										Optional:    true,
+										Computed:    true,
+										Validators: []validator.String{ /*START VALIDATORS*/
+											stringvalidator.OneOf(
+												"TCP",
+												"UDP",
+											),
+											fwvalidators.NotNullString(),
+										}, /*END VALIDATORS*/
+										PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+											stringplanmodifier.UseStateForUnknown(),
+										}, /*END PLAN MODIFIERS*/
+									}, /*END ATTRIBUTE*/
+									// Property: ToPort
+									"to_port": schema.Int64Attribute{ /*START ATTRIBUTE*/
+										Description: "An ending value for the range of allowed port numbers. Port numbers are end-inclusive. This value must be equal to or greater than FromPort.",
+										Optional:    true,
+										Computed:    true,
+										Validators: []validator.Int64{ /*START VALIDATORS*/
+											int64validator.Between(1, 60000),
+											fwvalidators.NotNullInt64(),
+										}, /*END VALIDATORS*/
+										PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+											int64planmodifier.UseStateForUnknown(),
+										}, /*END PLAN MODIFIERS*/
+									}, /*END ATTRIBUTE*/
+								}, /*END SCHEMA*/
+							}, /*END NESTED OBJECT*/
+							Description: "Specifies one or more ranges of ports on a container.",
+							Optional:    true,
+							Computed:    true,
+							Validators: []validator.Set{ /*START VALIDATORS*/
+								setvalidator.SizeBetween(1, 100),
+								fwvalidators.NotNullSet(),
+							}, /*END VALIDATORS*/
+							PlanModifiers: []planmodifier.Set{ /*START PLAN MODIFIERS*/
+								setplanmodifier.UseStateForUnknown(),
+							}, /*END PLAN MODIFIERS*/
+						}, /*END ATTRIBUTE*/
+					}, /*END SCHEMA*/
+					Description: "Defines the ports on the container.",
+					Optional:    true,
+					Computed:    true,
+					PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+						objectplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+				// Property: ResolvedImageDigest
+				"resolved_image_digest": schema.StringAttribute{ /*START ATTRIBUTE*/
+					Description: "The digest of the container image.",
+					Optional:    true,
+					Computed:    true,
+					Validators: []validator.String{ /*START VALIDATORS*/
+						stringvalidator.RegexMatches(regexp.MustCompile("^sha256:[a-fA-F0-9]{64}$"), ""),
+					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+						stringplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+				// Property: ServerSdkVersion
+				"server_sdk_version": schema.StringAttribute{ /*START ATTRIBUTE*/
+					Description: "The version of the server SDK used in this container group",
+					Optional:    true,
+					Computed:    true,
+					Validators: []validator.String{ /*START VALIDATORS*/
+						stringvalidator.LengthAtMost(128),
+						stringvalidator.RegexMatches(regexp.MustCompile("^\\d+\\.\\d+\\.\\d+$"), ""),
+						fwvalidators.NotNullString(),
+					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+						stringplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+			}, /*END SCHEMA*/
+			Description: "Specifies the information required to run game servers with this container group",
+			Optional:    true,
+			Computed:    true,
+			PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+				objectplanmodifier.UseStateForUnknown(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: Name
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A descriptive label for the container group definition.",
+		//	  "maxLength": 128,
+		//	  "minLength": 1,
+		//	  "pattern": "^[a-zA-Z0-9-]+$",
+		//	  "type": "string"
+		//	}
+		"name": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "A descriptive label for the container group definition.",
+			Required:    true,
+			Validators: []validator.String{ /*START VALIDATORS*/
+				stringvalidator.LengthBetween(1, 128),
+				stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9-]+$"), ""),
+			}, /*END VALIDATORS*/
+			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+				stringplanmodifier.RequiresReplace(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: OperatingSystem
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The operating system of the container group",
+		//	  "enum": [
+		//	    "AMAZON_LINUX_2023"
+		//	  ],
+		//	  "type": "string"
+		//	}
+		"operating_system": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "The operating system of the container group",
+			Required:    true,
+			Validators: []validator.String{ /*START VALIDATORS*/
+				stringvalidator.OneOf(
+					"AMAZON_LINUX_2023",
+				),
+			}, /*END VALIDATORS*/
+		}, /*END ATTRIBUTE*/
+		// Property: SourceVersionNumber
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A specific ContainerGroupDefinition version to be updated",
+		//	  "minimum": 0,
+		//	  "type": "integer"
+		//	}
+		"source_version_number": schema.Int64Attribute{ /*START ATTRIBUTE*/
+			Description: "A specific ContainerGroupDefinition version to be updated",
+			Optional:    true,
+			Computed:    true,
+			Validators: []validator.Int64{ /*START VALIDATORS*/
+				int64validator.AtLeast(0),
+			}, /*END VALIDATORS*/
+			PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+				int64planmodifier.UseStateForUnknown(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: Status
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A string indicating ContainerGroupDefinition status.",
+		//	  "enum": [
+		//	    "READY",
+		//	    "COPYING",
+		//	    "FAILED"
+		//	  ],
+		//	  "type": "string"
+		//	}
+		"status": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "A string indicating ContainerGroupDefinition status.",
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+				stringplanmodifier.UseStateForUnknown(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: StatusReason
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A string indicating the reason for ContainerGroupDefinition status.",
+		//	  "type": "string"
+		//	}
+		"status_reason": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "A string indicating the reason for ContainerGroupDefinition status.",
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+				stringplanmodifier.UseStateForUnknown(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: SupportContainerDefinitions
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A collection of support container definitions that define the containers in this group.",
 		//	  "insertionOrder": false,
 		//	  "items": {
 		//	    "additionalProperties": false,
-		//	    "description": "Details about a container that is used in a container fleet",
+		//	    "description": "Supports the function of the main container group",
 		//	    "properties": {
-		//	      "Command": {
-		//	        "description": "The command that's passed to the container.",
-		//	        "insertionOrder": true,
-		//	        "items": {
-		//	          "maxLength": 255,
-		//	          "minLength": 1,
-		//	          "pattern": "^.*$",
-		//	          "type": "string"
-		//	        },
-		//	        "maxItems": 20,
-		//	        "minItems": 1,
-		//	        "type": "array",
-		//	        "uniqueItems": false
-		//	      },
 		//	      "ContainerName": {
-		//	        "description": "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
+		//	        "description": "A descriptive label for the container definition.",
 		//	        "maxLength": 128,
 		//	        "minLength": 1,
 		//	        "pattern": "^[a-zA-Z0-9-]+$",
 		//	        "type": "string"
-		//	      },
-		//	      "Cpu": {
-		//	        "description": "The maximum number of CPU units reserved for this container. The value is expressed as an integer amount of CPU units. 1 vCPU is equal to 1024 CPU units",
-		//	        "maximum": 10240,
-		//	        "minimum": 1,
-		//	        "type": "integer"
 		//	      },
 		//	      "DependsOn": {
 		//	        "description": "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
@@ -110,20 +725,7 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 		//	        "type": "array",
 		//	        "uniqueItems": true
 		//	      },
-		//	      "EntryPoint": {
-		//	        "description": "The entry point that's passed to the container so that it will run as an executable. If there are multiple arguments, each argument is a string in the array.",
-		//	        "insertionOrder": true,
-		//	        "items": {
-		//	          "maxLength": 1024,
-		//	          "minLength": 1,
-		//	          "type": "string"
-		//	        },
-		//	        "maxItems": 20,
-		//	        "minItems": 1,
-		//	        "type": "array",
-		//	        "uniqueItems": false
-		//	      },
-		//	      "Environment": {
+		//	      "EnvironmentOverride": {
 		//	        "description": "The environment variables to pass to a container.",
 		//	        "insertionOrder": false,
 		//	        "items": {
@@ -215,24 +817,51 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 		//	        "pattern": "^[a-zA-Z0-9-_\\.@\\/:]+$",
 		//	        "type": "string"
 		//	      },
-		//	      "MemoryLimits": {
-		//	        "additionalProperties": false,
-		//	        "description": "Specifies how much memory is available to the container. You must specify at least this parameter or the TotalMemoryLimit parameter of the ContainerGroupDefinition.",
-		//	        "properties": {
-		//	          "HardLimit": {
-		//	            "description": "The hard limit of memory to reserve for the container.",
-		//	            "maximum": 1024000,
-		//	            "minimum": 4,
-		//	            "type": "integer"
+		//	      "MemoryHardLimitMebibytes": {
+		//	        "description": "The total memory limit of container groups following this definition in MiB",
+		//	        "maximum": 1024000,
+		//	        "minimum": 4,
+		//	        "type": "integer"
+		//	      },
+		//	      "MountPoints": {
+		//	        "description": "A list of mount point configurations to be used in a container.",
+		//	        "insertionOrder": false,
+		//	        "items": {
+		//	          "additionalProperties": false,
+		//	          "description": "Defines the mount point configuration within a container.",
+		//	          "properties": {
+		//	            "AccessLevel": {
+		//	              "description": "The access permissions for the mounted path.",
+		//	              "enum": [
+		//	                "READ_ONLY",
+		//	                "READ_AND_WRITE"
+		//	              ],
+		//	              "type": "string"
+		//	            },
+		//	            "ContainerPath": {
+		//	              "description": "The path inside the container where the mount is accessible.",
+		//	              "maxLength": 1024,
+		//	              "minLength": 1,
+		//	              "pattern": "^(\\/+[^\\/]+\\/*)+$",
+		//	              "type": "string"
+		//	            },
+		//	            "InstancePath": {
+		//	              "description": "The path on the host that will be mounted in the container.",
+		//	              "maxLength": 1024,
+		//	              "minLength": 1,
+		//	              "pattern": "^\\/[\\s\\S]*$",
+		//	              "type": "string"
+		//	            }
 		//	          },
-		//	          "SoftLimit": {
-		//	            "description": "The amount of memory that is reserved for the container.",
-		//	            "maximum": 1024000,
-		//	            "minimum": 4,
-		//	            "type": "integer"
-		//	          }
+		//	          "required": [
+		//	            "InstancePath"
+		//	          ],
+		//	          "type": "object"
 		//	        },
-		//	        "type": "object"
+		//	        "maxItems": 10,
+		//	        "minItems": 1,
+		//	        "type": "array",
+		//	        "uniqueItems": true
 		//	      },
 		//	      "PortConfiguration": {
 		//	        "additionalProperties": false,
@@ -289,12 +918,11 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 		//	        "pattern": "^sha256:[a-fA-F0-9]{64}$",
 		//	        "type": "string"
 		//	      },
-		//	      "WorkingDirectory": {
-		//	        "description": "The working directory to run commands inside the container in.",
-		//	        "maxLength": 255,
-		//	        "minLength": 1,
-		//	        "pattern": "^.*$",
-		//	        "type": "string"
+		//	      "Vcpu": {
+		//	        "description": "The number of virtual CPUs to give to the support group",
+		//	        "maximum": 10,
+		//	        "minimum": 0.125,
+		//	        "type": "number"
 		//	      }
 		//	    },
 		//	    "required": [
@@ -308,45 +936,21 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 		//	  "type": "array",
 		//	  "uniqueItems": true
 		//	}
-		"container_definitions": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+		"support_container_definitions": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
 			NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
 				Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
-					// Property: Command
-					"command": schema.ListAttribute{ /*START ATTRIBUTE*/
-						ElementType: types.StringType,
-						Description: "The command that's passed to the container.",
-						Optional:    true,
-						Computed:    true,
-						Validators: []validator.List{ /*START VALIDATORS*/
-							listvalidator.SizeBetween(1, 20),
-							listvalidator.ValueStringsAre(
-								stringvalidator.LengthBetween(1, 255),
-								stringvalidator.RegexMatches(regexp.MustCompile("^.*$"), ""),
-							),
-						}, /*END VALIDATORS*/
-						PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
-							listplanmodifier.UseStateForUnknown(),
-						}, /*END PLAN MODIFIERS*/
-					}, /*END ATTRIBUTE*/
 					// Property: ContainerName
 					"container_name": schema.StringAttribute{ /*START ATTRIBUTE*/
-						Description: "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
-						Required:    true,
+						Description: "A descriptive label for the container definition.",
+						Optional:    true,
+						Computed:    true,
 						Validators: []validator.String{ /*START VALIDATORS*/
 							stringvalidator.LengthBetween(1, 128),
 							stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9-]+$"), ""),
+							fwvalidators.NotNullString(),
 						}, /*END VALIDATORS*/
-					}, /*END ATTRIBUTE*/
-					// Property: Cpu
-					"cpu": schema.Int64Attribute{ /*START ATTRIBUTE*/
-						Description: "The maximum number of CPU units reserved for this container. The value is expressed as an integer amount of CPU units. 1 vCPU is equal to 1024 CPU units",
-						Optional:    true,
-						Computed:    true,
-						Validators: []validator.Int64{ /*START VALIDATORS*/
-							int64validator.Between(1, 10240),
-						}, /*END VALIDATORS*/
-						PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
-							int64planmodifier.UseStateForUnknown(),
+						PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+							stringplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
 					// Property: DependsOn
@@ -398,24 +1002,8 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 							listplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
-					// Property: EntryPoint
-					"entry_point": schema.ListAttribute{ /*START ATTRIBUTE*/
-						ElementType: types.StringType,
-						Description: "The entry point that's passed to the container so that it will run as an executable. If there are multiple arguments, each argument is a string in the array.",
-						Optional:    true,
-						Computed:    true,
-						Validators: []validator.List{ /*START VALIDATORS*/
-							listvalidator.SizeBetween(1, 20),
-							listvalidator.ValueStringsAre(
-								stringvalidator.LengthBetween(1, 1024),
-							),
-						}, /*END VALIDATORS*/
-						PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
-							listplanmodifier.UseStateForUnknown(),
-						}, /*END PLAN MODIFIERS*/
-					}, /*END ATTRIBUTE*/
-					// Property: Environment
-					"environment": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+					// Property: EnvironmentOverride
+					"environment_override": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
 						NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
 							Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
 								// Property: Name
@@ -547,45 +1135,85 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 					// Property: ImageUri
 					"image_uri": schema.StringAttribute{ /*START ATTRIBUTE*/
 						Description: "Specifies the image URI of this container.",
-						Required:    true,
+						Optional:    true,
+						Computed:    true,
 						Validators: []validator.String{ /*START VALIDATORS*/
 							stringvalidator.LengthBetween(1, 255),
 							stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9-_\\.@\\/:]+$"), ""),
+							fwvalidators.NotNullString(),
 						}, /*END VALIDATORS*/
+						PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+							stringplanmodifier.UseStateForUnknown(),
+						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
-					// Property: MemoryLimits
-					"memory_limits": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
-						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
-							// Property: HardLimit
-							"hard_limit": schema.Int64Attribute{ /*START ATTRIBUTE*/
-								Description: "The hard limit of memory to reserve for the container.",
-								Optional:    true,
-								Computed:    true,
-								Validators: []validator.Int64{ /*START VALIDATORS*/
-									int64validator.Between(4, 1024000),
-								}, /*END VALIDATORS*/
-								PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
-									int64planmodifier.UseStateForUnknown(),
-								}, /*END PLAN MODIFIERS*/
-							}, /*END ATTRIBUTE*/
-							// Property: SoftLimit
-							"soft_limit": schema.Int64Attribute{ /*START ATTRIBUTE*/
-								Description: "The amount of memory that is reserved for the container.",
-								Optional:    true,
-								Computed:    true,
-								Validators: []validator.Int64{ /*START VALIDATORS*/
-									int64validator.Between(4, 1024000),
-								}, /*END VALIDATORS*/
-								PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
-									int64planmodifier.UseStateForUnknown(),
-								}, /*END PLAN MODIFIERS*/
-							}, /*END ATTRIBUTE*/
-						}, /*END SCHEMA*/
-						Description: "Specifies how much memory is available to the container. You must specify at least this parameter or the TotalMemoryLimit parameter of the ContainerGroupDefinition.",
+					// Property: MemoryHardLimitMebibytes
+					"memory_hard_limit_mebibytes": schema.Int64Attribute{ /*START ATTRIBUTE*/
+						Description: "The total memory limit of container groups following this definition in MiB",
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
-							objectplanmodifier.UseStateForUnknown(),
+						Validators: []validator.Int64{ /*START VALIDATORS*/
+							int64validator.Between(4, 1024000),
+						}, /*END VALIDATORS*/
+						PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+							int64planmodifier.UseStateForUnknown(),
+						}, /*END PLAN MODIFIERS*/
+					}, /*END ATTRIBUTE*/
+					// Property: MountPoints
+					"mount_points": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+						NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+							Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+								// Property: AccessLevel
+								"access_level": schema.StringAttribute{ /*START ATTRIBUTE*/
+									Description: "The access permissions for the mounted path.",
+									Optional:    true,
+									Computed:    true,
+									Validators: []validator.String{ /*START VALIDATORS*/
+										stringvalidator.OneOf(
+											"READ_ONLY",
+											"READ_AND_WRITE",
+										),
+									}, /*END VALIDATORS*/
+									PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+										stringplanmodifier.UseStateForUnknown(),
+									}, /*END PLAN MODIFIERS*/
+								}, /*END ATTRIBUTE*/
+								// Property: ContainerPath
+								"container_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+									Description: "The path inside the container where the mount is accessible.",
+									Optional:    true,
+									Computed:    true,
+									Validators: []validator.String{ /*START VALIDATORS*/
+										stringvalidator.LengthBetween(1, 1024),
+										stringvalidator.RegexMatches(regexp.MustCompile("^(\\/+[^\\/]+\\/*)+$"), ""),
+									}, /*END VALIDATORS*/
+									PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+										stringplanmodifier.UseStateForUnknown(),
+									}, /*END PLAN MODIFIERS*/
+								}, /*END ATTRIBUTE*/
+								// Property: InstancePath
+								"instance_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+									Description: "The path on the host that will be mounted in the container.",
+									Optional:    true,
+									Computed:    true,
+									Validators: []validator.String{ /*START VALIDATORS*/
+										stringvalidator.LengthBetween(1, 1024),
+										stringvalidator.RegexMatches(regexp.MustCompile("^\\/[\\s\\S]*$"), ""),
+										fwvalidators.NotNullString(),
+									}, /*END VALIDATORS*/
+									PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+										stringplanmodifier.UseStateForUnknown(),
+									}, /*END PLAN MODIFIERS*/
+								}, /*END ATTRIBUTE*/
+							}, /*END SCHEMA*/
+						}, /*END NESTED OBJECT*/
+						Description: "A list of mount point configurations to be used in a container.",
+						Optional:    true,
+						Computed:    true,
+						Validators: []validator.Set{ /*START VALIDATORS*/
+							setvalidator.SizeBetween(1, 10),
+						}, /*END VALIDATORS*/
+						PlanModifiers: []planmodifier.Set{ /*START PLAN MODIFIERS*/
+							setplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
 					// Property: PortConfiguration
@@ -670,128 +1298,28 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 							stringplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
-					// Property: WorkingDirectory
-					"working_directory": schema.StringAttribute{ /*START ATTRIBUTE*/
-						Description: "The working directory to run commands inside the container in.",
+					// Property: Vcpu
+					"vcpu": schema.Float64Attribute{ /*START ATTRIBUTE*/
+						Description: "The number of virtual CPUs to give to the support group",
 						Optional:    true,
 						Computed:    true,
-						Validators: []validator.String{ /*START VALIDATORS*/
-							stringvalidator.LengthBetween(1, 255),
-							stringvalidator.RegexMatches(regexp.MustCompile("^.*$"), ""),
+						Validators: []validator.Float64{ /*START VALIDATORS*/
+							float64validator.Between(0.125000, 10.000000),
 						}, /*END VALIDATORS*/
-						PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
-							stringplanmodifier.UseStateForUnknown(),
+						PlanModifiers: []planmodifier.Float64{ /*START PLAN MODIFIERS*/
+							float64planmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
 				}, /*END SCHEMA*/
 			}, /*END NESTED OBJECT*/
-			Description: "A collection of container definitions that define the containers in this group.",
-			Required:    true,
+			Description: "A collection of support container definitions that define the containers in this group.",
+			Optional:    true,
+			Computed:    true,
 			Validators: []validator.Set{ /*START VALIDATORS*/
 				setvalidator.SizeBetween(1, 10),
 			}, /*END VALIDATORS*/
 			PlanModifiers: []planmodifier.Set{ /*START PLAN MODIFIERS*/
-				setplanmodifier.RequiresReplace(),
-			}, /*END PLAN MODIFIERS*/
-		}, /*END ATTRIBUTE*/
-		// Property: ContainerGroupDefinitionArn
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
-		//	  "maxLength": 512,
-		//	  "minLength": 1,
-		//	  "pattern": "^arn:.*:containergroupdefinition/containergroupdefinition-[a-zA-Z0-9-]+$|^arn:.*:containergroupdefinition/[a-zA-Z0-9-\\:]+$",
-		//	  "type": "string"
-		//	}
-		"container_group_definition_arn": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
-			Computed:    true,
-			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
-				stringplanmodifier.UseStateForUnknown(),
-			}, /*END PLAN MODIFIERS*/
-		}, /*END ATTRIBUTE*/
-		// Property: CreationTime
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
-		//	  "type": "string"
-		//	}
-		"creation_time": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
-			Computed:    true,
-			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
-				stringplanmodifier.UseStateForUnknown(),
-			}, /*END PLAN MODIFIERS*/
-		}, /*END ATTRIBUTE*/
-		// Property: Name
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "A descriptive label for the container group definition.",
-		//	  "maxLength": 128,
-		//	  "minLength": 1,
-		//	  "pattern": "^[a-zA-Z0-9-]+$",
-		//	  "type": "string"
-		//	}
-		"name": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "A descriptive label for the container group definition.",
-			Required:    true,
-			Validators: []validator.String{ /*START VALIDATORS*/
-				stringvalidator.LengthBetween(1, 128),
-				stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9-]+$"), ""),
-			}, /*END VALIDATORS*/
-			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
-				stringplanmodifier.RequiresReplace(),
-			}, /*END PLAN MODIFIERS*/
-		}, /*END ATTRIBUTE*/
-		// Property: OperatingSystem
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "The operating system of the container group",
-		//	  "enum": [
-		//	    "AMAZON_LINUX_2023"
-		//	  ],
-		//	  "type": "string"
-		//	}
-		"operating_system": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "The operating system of the container group",
-			Required:    true,
-			Validators: []validator.String{ /*START VALIDATORS*/
-				stringvalidator.OneOf(
-					"AMAZON_LINUX_2023",
-				),
-			}, /*END VALIDATORS*/
-			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
-				stringplanmodifier.RequiresReplace(),
-			}, /*END PLAN MODIFIERS*/
-		}, /*END ATTRIBUTE*/
-		// Property: SchedulingStrategy
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "Specifies whether the container group includes replica or daemon containers.",
-		//	  "enum": [
-		//	    "REPLICA",
-		//	    "DAEMON"
-		//	  ],
-		//	  "type": "string"
-		//	}
-		"scheduling_strategy": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "Specifies whether the container group includes replica or daemon containers.",
-			Optional:    true,
-			Computed:    true,
-			Validators: []validator.String{ /*START VALIDATORS*/
-				stringvalidator.OneOf(
-					"REPLICA",
-					"DAEMON",
-				),
-			}, /*END VALIDATORS*/
-			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
-				stringplanmodifier.UseStateForUnknown(),
-				stringplanmodifier.RequiresReplaceIfConfigured(),
+				setplanmodifier.UseStateForUnknown(),
 			}, /*END PLAN MODIFIERS*/
 		}, /*END ATTRIBUTE*/
 		// Property: Tags
@@ -873,42 +1401,71 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 				setplanmodifier.UseStateForUnknown(),
 			}, /*END PLAN MODIFIERS*/
 		}, /*END ATTRIBUTE*/
-		// Property: TotalCpuLimit
+		// Property: TotalMemoryLimitMebibytes
 		// CloudFormation resource type schema:
 		//
 		//	{
-		//	  "description": "The maximum number of CPU units reserved for this container group. The value is expressed as an integer amount of CPU units. (1 vCPU is equal to 1024 CPU units.)",
-		//	  "maximum": 10240,
-		//	  "minimum": 128,
-		//	  "type": "integer"
-		//	}
-		"total_cpu_limit": schema.Int64Attribute{ /*START ATTRIBUTE*/
-			Description: "The maximum number of CPU units reserved for this container group. The value is expressed as an integer amount of CPU units. (1 vCPU is equal to 1024 CPU units.)",
-			Required:    true,
-			Validators: []validator.Int64{ /*START VALIDATORS*/
-				int64validator.Between(128, 10240),
-			}, /*END VALIDATORS*/
-			PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
-				int64planmodifier.RequiresReplace(),
-			}, /*END PLAN MODIFIERS*/
-		}, /*END ATTRIBUTE*/
-		// Property: TotalMemoryLimit
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "The maximum amount of memory (in MiB) to allocate for this container group.",
+		//	  "description": "The total memory limit of container groups following this definition in MiB",
 		//	  "maximum": 1024000,
 		//	  "minimum": 4,
 		//	  "type": "integer"
 		//	}
-		"total_memory_limit": schema.Int64Attribute{ /*START ATTRIBUTE*/
-			Description: "The maximum amount of memory (in MiB) to allocate for this container group.",
+		"total_memory_limit_mebibytes": schema.Int64Attribute{ /*START ATTRIBUTE*/
+			Description: "The total memory limit of container groups following this definition in MiB",
 			Required:    true,
 			Validators: []validator.Int64{ /*START VALIDATORS*/
 				int64validator.Between(4, 1024000),
 			}, /*END VALIDATORS*/
+		}, /*END ATTRIBUTE*/
+		// Property: TotalVcpuLimit
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The total amount of virtual CPUs on the container group definition",
+		//	  "maximum": 10,
+		//	  "minimum": 0.125,
+		//	  "type": "number"
+		//	}
+		"total_vcpu_limit": schema.Float64Attribute{ /*START ATTRIBUTE*/
+			Description: "The total amount of virtual CPUs on the container group definition",
+			Required:    true,
+			Validators: []validator.Float64{ /*START VALIDATORS*/
+				float64validator.Between(0.125000, 10.000000),
+			}, /*END VALIDATORS*/
+		}, /*END ATTRIBUTE*/
+		// Property: VersionDescription
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The description of this version",
+		//	  "maxLength": 1024,
+		//	  "minLength": 1,
+		//	  "type": "string"
+		//	}
+		"version_description": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "The description of this version",
+			Optional:    true,
+			Computed:    true,
+			Validators: []validator.String{ /*START VALIDATORS*/
+				stringvalidator.LengthBetween(1, 1024),
+			}, /*END VALIDATORS*/
+			PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+				stringplanmodifier.UseStateForUnknown(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: VersionNumber
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The version of this ContainerGroupDefinition",
+		//	  "minimum": 0,
+		//	  "type": "integer"
+		//	}
+		"version_number": schema.Int64Attribute{ /*START ATTRIBUTE*/
+			Description: "The version of this ContainerGroupDefinition",
+			Computed:    true,
 			PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
-				int64planmodifier.RequiresReplace(),
+				int64planmodifier.UseStateForUnknown(),
 			}, /*END PLAN MODIFIERS*/
 		}, /*END ATTRIBUTE*/
 	} /*END SCHEMA*/
@@ -933,41 +1490,48 @@ func containerGroupDefinitionResource(ctx context.Context) (resource.Resource, e
 	opts = opts.WithCloudFormationTypeName("AWS::GameLift::ContainerGroupDefinition").WithTerraformTypeName("awscc_gamelift_container_group_definition")
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
-		"command":                        "Command",
-		"condition":                      "Condition",
-		"container_definitions":          "ContainerDefinitions",
-		"container_group_definition_arn": "ContainerGroupDefinitionArn",
-		"container_name":                 "ContainerName",
-		"container_port_ranges":          "ContainerPortRanges",
-		"cpu":                            "Cpu",
-		"creation_time":                  "CreationTime",
-		"depends_on":                     "DependsOn",
-		"entry_point":                    "EntryPoint",
-		"environment":                    "Environment",
-		"essential":                      "Essential",
-		"from_port":                      "FromPort",
-		"hard_limit":                     "HardLimit",
-		"health_check":                   "HealthCheck",
-		"image_uri":                      "ImageUri",
-		"interval":                       "Interval",
-		"key":                            "Key",
-		"memory_limits":                  "MemoryLimits",
-		"name":                           "Name",
-		"operating_system":               "OperatingSystem",
-		"port_configuration":             "PortConfiguration",
-		"protocol":                       "Protocol",
-		"resolved_image_digest":          "ResolvedImageDigest",
-		"retries":                        "Retries",
-		"scheduling_strategy":            "SchedulingStrategy",
-		"soft_limit":                     "SoftLimit",
-		"start_period":                   "StartPeriod",
-		"tags":                           "Tags",
-		"timeout":                        "Timeout",
-		"to_port":                        "ToPort",
-		"total_cpu_limit":                "TotalCpuLimit",
-		"total_memory_limit":             "TotalMemoryLimit",
-		"value":                          "Value",
-		"working_directory":              "WorkingDirectory",
+		"access_level":                     "AccessLevel",
+		"command":                          "Command",
+		"condition":                        "Condition",
+		"container_group_definition_arn":   "ContainerGroupDefinitionArn",
+		"container_group_type":             "ContainerGroupType",
+		"container_name":                   "ContainerName",
+		"container_path":                   "ContainerPath",
+		"container_port_ranges":            "ContainerPortRanges",
+		"creation_time":                    "CreationTime",
+		"depends_on":                       "DependsOn",
+		"environment_override":             "EnvironmentOverride",
+		"essential":                        "Essential",
+		"from_port":                        "FromPort",
+		"game_server_container_definition": "GameServerContainerDefinition",
+		"health_check":                     "HealthCheck",
+		"image_uri":                        "ImageUri",
+		"instance_path":                    "InstancePath",
+		"interval":                         "Interval",
+		"key":                              "Key",
+		"memory_hard_limit_mebibytes":      "MemoryHardLimitMebibytes",
+		"mount_points":                     "MountPoints",
+		"name":                             "Name",
+		"operating_system":                 "OperatingSystem",
+		"port_configuration":               "PortConfiguration",
+		"protocol":                         "Protocol",
+		"resolved_image_digest":            "ResolvedImageDigest",
+		"retries":                          "Retries",
+		"server_sdk_version":               "ServerSdkVersion",
+		"source_version_number":            "SourceVersionNumber",
+		"start_period":                     "StartPeriod",
+		"status":                           "Status",
+		"status_reason":                    "StatusReason",
+		"support_container_definitions":    "SupportContainerDefinitions",
+		"tags":                             "Tags",
+		"timeout":                          "Timeout",
+		"to_port":                          "ToPort",
+		"total_memory_limit_mebibytes":     "TotalMemoryLimitMebibytes",
+		"total_vcpu_limit":                 "TotalVcpuLimit",
+		"value":                            "Value",
+		"vcpu":                             "Vcpu",
+		"version_description":              "VersionDescription",
+		"version_number":                   "VersionNumber",
 	})
 
 	opts = opts.WithCreateTimeoutInMinutes(0).WithDeleteTimeoutInMinutes(0)

--- a/internal/aws/gamelift/container_group_definition_singular_data_source_gen.go
+++ b/internal/aws/gamelift/container_group_definition_singular_data_source_gen.go
@@ -23,42 +23,447 @@ func init() {
 // This Terraform data source corresponds to the CloudFormation AWS::GameLift::ContainerGroupDefinition resource.
 func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSource, error) {
 	attributes := map[string]schema.Attribute{ /*START SCHEMA*/
-		// Property: ContainerDefinitions
+		// Property: ContainerGroupDefinitionArn
 		// CloudFormation resource type schema:
 		//
 		//	{
-		//	  "description": "A collection of container definitions that define the containers in this group.",
+		//	  "description": "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
+		//	  "maxLength": 512,
+		//	  "minLength": 1,
+		//	  "pattern": "^arn:.*:containergroupdefinition\\/[a-zA-Z0-9\\-]+(:[0-9]+)?$",
+		//	  "type": "string"
+		//	}
+		"container_group_definition_arn": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: ContainerGroupType
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The scope of the container group",
+		//	  "enum": [
+		//	    "GAME_SERVER",
+		//	    "PER_INSTANCE"
+		//	  ],
+		//	  "type": "string"
+		//	}
+		"container_group_type": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "The scope of the container group",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: CreationTime
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
+		//	  "type": "string"
+		//	}
+		"creation_time": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: GameServerContainerDefinition
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "additionalProperties": false,
+		//	  "description": "Specifies the information required to run game servers with this container group",
+		//	  "properties": {
+		//	    "ContainerName": {
+		//	      "description": "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
+		//	      "maxLength": 128,
+		//	      "minLength": 1,
+		//	      "pattern": "^[a-zA-Z0-9-]+$",
+		//	      "type": "string"
+		//	    },
+		//	    "DependsOn": {
+		//	      "description": "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
+		//	      "insertionOrder": true,
+		//	      "items": {
+		//	        "additionalProperties": false,
+		//	        "description": "A dependency that impacts a container's startup and shutdown.",
+		//	        "properties": {
+		//	          "Condition": {
+		//	            "description": "The type of dependency.",
+		//	            "enum": [
+		//	              "START",
+		//	              "COMPLETE",
+		//	              "SUCCESS",
+		//	              "HEALTHY"
+		//	            ],
+		//	            "type": "string"
+		//	          },
+		//	          "ContainerName": {
+		//	            "description": "A descriptive label for the container definition. The container being defined depends on this container's condition.",
+		//	            "maxLength": 128,
+		//	            "minLength": 1,
+		//	            "pattern": "^[a-zA-Z0-9-]+$",
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "ContainerName",
+		//	          "Condition"
+		//	        ],
+		//	        "type": "object"
+		//	      },
+		//	      "maxItems": 10,
+		//	      "minItems": 1,
+		//	      "type": "array",
+		//	      "uniqueItems": true
+		//	    },
+		//	    "EnvironmentOverride": {
+		//	      "description": "The environment variables to pass to a container.",
+		//	      "insertionOrder": false,
+		//	      "items": {
+		//	        "additionalProperties": false,
+		//	        "description": "An environment variable to set inside a container, in the form of a key-value pair.",
+		//	        "properties": {
+		//	          "Name": {
+		//	            "description": "The environment variable name.",
+		//	            "maxLength": 255,
+		//	            "minLength": 1,
+		//	            "pattern": "^.*$",
+		//	            "type": "string"
+		//	          },
+		//	          "Value": {
+		//	            "description": "The environment variable value.",
+		//	            "maxLength": 255,
+		//	            "minLength": 1,
+		//	            "pattern": "^.*$",
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "Name",
+		//	          "Value"
+		//	        ],
+		//	        "type": "object"
+		//	      },
+		//	      "maxItems": 20,
+		//	      "minItems": 1,
+		//	      "type": "array",
+		//	      "uniqueItems": true
+		//	    },
+		//	    "ImageUri": {
+		//	      "description": "Specifies the image URI of this container.",
+		//	      "maxLength": 255,
+		//	      "minLength": 1,
+		//	      "pattern": "^[a-zA-Z0-9-_\\.@\\/:]+$",
+		//	      "type": "string"
+		//	    },
+		//	    "MountPoints": {
+		//	      "description": "A list of mount point configurations to be used in a container.",
+		//	      "insertionOrder": false,
+		//	      "items": {
+		//	        "additionalProperties": false,
+		//	        "description": "Defines the mount point configuration within a container.",
+		//	        "properties": {
+		//	          "AccessLevel": {
+		//	            "description": "The access permissions for the mounted path.",
+		//	            "enum": [
+		//	              "READ_ONLY",
+		//	              "READ_AND_WRITE"
+		//	            ],
+		//	            "type": "string"
+		//	          },
+		//	          "ContainerPath": {
+		//	            "description": "The path inside the container where the mount is accessible.",
+		//	            "maxLength": 1024,
+		//	            "minLength": 1,
+		//	            "pattern": "^(\\/+[^\\/]+\\/*)+$",
+		//	            "type": "string"
+		//	          },
+		//	          "InstancePath": {
+		//	            "description": "The path on the host that will be mounted in the container.",
+		//	            "maxLength": 1024,
+		//	            "minLength": 1,
+		//	            "pattern": "^\\/[\\s\\S]*$",
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "InstancePath"
+		//	        ],
+		//	        "type": "object"
+		//	      },
+		//	      "maxItems": 10,
+		//	      "minItems": 1,
+		//	      "type": "array",
+		//	      "uniqueItems": true
+		//	    },
+		//	    "PortConfiguration": {
+		//	      "additionalProperties": false,
+		//	      "description": "Defines the ports on the container.",
+		//	      "properties": {
+		//	        "ContainerPortRanges": {
+		//	          "description": "Specifies one or more ranges of ports on a container.",
+		//	          "insertionOrder": false,
+		//	          "items": {
+		//	            "additionalProperties": false,
+		//	            "description": "A set of one or more port numbers that can be opened on the container.",
+		//	            "properties": {
+		//	              "FromPort": {
+		//	                "description": "A starting value for the range of allowed port numbers.",
+		//	                "maximum": 60000,
+		//	                "minimum": 1,
+		//	                "type": "integer"
+		//	              },
+		//	              "Protocol": {
+		//	                "description": "Defines the protocol of these ports.",
+		//	                "enum": [
+		//	                  "TCP",
+		//	                  "UDP"
+		//	                ],
+		//	                "type": "string"
+		//	              },
+		//	              "ToPort": {
+		//	                "description": "An ending value for the range of allowed port numbers. Port numbers are end-inclusive. This value must be equal to or greater than FromPort.",
+		//	                "maximum": 60000,
+		//	                "minimum": 1,
+		//	                "type": "integer"
+		//	              }
+		//	            },
+		//	            "required": [
+		//	              "FromPort",
+		//	              "Protocol",
+		//	              "ToPort"
+		//	            ],
+		//	            "type": "object"
+		//	          },
+		//	          "maxItems": 100,
+		//	          "minItems": 1,
+		//	          "type": "array",
+		//	          "uniqueItems": true
+		//	        }
+		//	      },
+		//	      "required": [
+		//	        "ContainerPortRanges"
+		//	      ],
+		//	      "type": "object"
+		//	    },
+		//	    "ResolvedImageDigest": {
+		//	      "description": "The digest of the container image.",
+		//	      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+		//	      "type": "string"
+		//	    },
+		//	    "ServerSdkVersion": {
+		//	      "description": "The version of the server SDK used in this container group",
+		//	      "maxLength": 128,
+		//	      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+		//	      "type": "string"
+		//	    }
+		//	  },
+		//	  "required": [
+		//	    "ContainerName",
+		//	    "ImageUri",
+		//	    "ServerSdkVersion"
+		//	  ],
+		//	  "type": "object"
+		//	}
+		"game_server_container_definition": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+			Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+				// Property: ContainerName
+				"container_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+					Description: "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+				// Property: DependsOn
+				"depends_on": schema.ListNestedAttribute{ /*START ATTRIBUTE*/
+					NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: Condition
+							"condition": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The type of dependency.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+							// Property: ContainerName
+							"container_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "A descriptive label for the container definition. The container being defined depends on this container's condition.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+					}, /*END NESTED OBJECT*/
+					Description: "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+				// Property: EnvironmentOverride
+				"environment_override": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+					NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: Name
+							"name": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The environment variable name.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+							// Property: Value
+							"value": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The environment variable value.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+					}, /*END NESTED OBJECT*/
+					Description: "The environment variables to pass to a container.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+				// Property: ImageUri
+				"image_uri": schema.StringAttribute{ /*START ATTRIBUTE*/
+					Description: "Specifies the image URI of this container.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+				// Property: MountPoints
+				"mount_points": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+					NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: AccessLevel
+							"access_level": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The access permissions for the mounted path.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+							// Property: ContainerPath
+							"container_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The path inside the container where the mount is accessible.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+							// Property: InstancePath
+							"instance_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The path on the host that will be mounted in the container.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+					}, /*END NESTED OBJECT*/
+					Description: "A list of mount point configurations to be used in a container.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+				// Property: PortConfiguration
+				"port_configuration": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+					Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+						// Property: ContainerPortRanges
+						"container_port_ranges": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+							NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+								Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+									// Property: FromPort
+									"from_port": schema.Int64Attribute{ /*START ATTRIBUTE*/
+										Description: "A starting value for the range of allowed port numbers.",
+										Computed:    true,
+									}, /*END ATTRIBUTE*/
+									// Property: Protocol
+									"protocol": schema.StringAttribute{ /*START ATTRIBUTE*/
+										Description: "Defines the protocol of these ports.",
+										Computed:    true,
+									}, /*END ATTRIBUTE*/
+									// Property: ToPort
+									"to_port": schema.Int64Attribute{ /*START ATTRIBUTE*/
+										Description: "An ending value for the range of allowed port numbers. Port numbers are end-inclusive. This value must be equal to or greater than FromPort.",
+										Computed:    true,
+									}, /*END ATTRIBUTE*/
+								}, /*END SCHEMA*/
+							}, /*END NESTED OBJECT*/
+							Description: "Specifies one or more ranges of ports on a container.",
+							Computed:    true,
+						}, /*END ATTRIBUTE*/
+					}, /*END SCHEMA*/
+					Description: "Defines the ports on the container.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+				// Property: ResolvedImageDigest
+				"resolved_image_digest": schema.StringAttribute{ /*START ATTRIBUTE*/
+					Description: "The digest of the container image.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+				// Property: ServerSdkVersion
+				"server_sdk_version": schema.StringAttribute{ /*START ATTRIBUTE*/
+					Description: "The version of the server SDK used in this container group",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+			}, /*END SCHEMA*/
+			Description: "Specifies the information required to run game servers with this container group",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: Name
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A descriptive label for the container group definition.",
+		//	  "maxLength": 128,
+		//	  "minLength": 1,
+		//	  "pattern": "^[a-zA-Z0-9-]+$",
+		//	  "type": "string"
+		//	}
+		"name": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "A descriptive label for the container group definition.",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: OperatingSystem
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The operating system of the container group",
+		//	  "enum": [
+		//	    "AMAZON_LINUX_2023"
+		//	  ],
+		//	  "type": "string"
+		//	}
+		"operating_system": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "The operating system of the container group",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: SourceVersionNumber
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A specific ContainerGroupDefinition version to be updated",
+		//	  "minimum": 0,
+		//	  "type": "integer"
+		//	}
+		"source_version_number": schema.Int64Attribute{ /*START ATTRIBUTE*/
+			Description: "A specific ContainerGroupDefinition version to be updated",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: Status
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A string indicating ContainerGroupDefinition status.",
+		//	  "enum": [
+		//	    "READY",
+		//	    "COPYING",
+		//	    "FAILED"
+		//	  ],
+		//	  "type": "string"
+		//	}
+		"status": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "A string indicating ContainerGroupDefinition status.",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: StatusReason
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A string indicating the reason for ContainerGroupDefinition status.",
+		//	  "type": "string"
+		//	}
+		"status_reason": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "A string indicating the reason for ContainerGroupDefinition status.",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: SupportContainerDefinitions
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "A collection of support container definitions that define the containers in this group.",
 		//	  "insertionOrder": false,
 		//	  "items": {
 		//	    "additionalProperties": false,
-		//	    "description": "Details about a container that is used in a container fleet",
+		//	    "description": "Supports the function of the main container group",
 		//	    "properties": {
-		//	      "Command": {
-		//	        "description": "The command that's passed to the container.",
-		//	        "insertionOrder": true,
-		//	        "items": {
-		//	          "maxLength": 255,
-		//	          "minLength": 1,
-		//	          "pattern": "^.*$",
-		//	          "type": "string"
-		//	        },
-		//	        "maxItems": 20,
-		//	        "minItems": 1,
-		//	        "type": "array",
-		//	        "uniqueItems": false
-		//	      },
 		//	      "ContainerName": {
-		//	        "description": "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
+		//	        "description": "A descriptive label for the container definition.",
 		//	        "maxLength": 128,
 		//	        "minLength": 1,
 		//	        "pattern": "^[a-zA-Z0-9-]+$",
 		//	        "type": "string"
-		//	      },
-		//	      "Cpu": {
-		//	        "description": "The maximum number of CPU units reserved for this container. The value is expressed as an integer amount of CPU units. 1 vCPU is equal to 1024 CPU units",
-		//	        "maximum": 10240,
-		//	        "minimum": 1,
-		//	        "type": "integer"
 		//	      },
 		//	      "DependsOn": {
 		//	        "description": "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
@@ -96,20 +501,7 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 		//	        "type": "array",
 		//	        "uniqueItems": true
 		//	      },
-		//	      "EntryPoint": {
-		//	        "description": "The entry point that's passed to the container so that it will run as an executable. If there are multiple arguments, each argument is a string in the array.",
-		//	        "insertionOrder": true,
-		//	        "items": {
-		//	          "maxLength": 1024,
-		//	          "minLength": 1,
-		//	          "type": "string"
-		//	        },
-		//	        "maxItems": 20,
-		//	        "minItems": 1,
-		//	        "type": "array",
-		//	        "uniqueItems": false
-		//	      },
-		//	      "Environment": {
+		//	      "EnvironmentOverride": {
 		//	        "description": "The environment variables to pass to a container.",
 		//	        "insertionOrder": false,
 		//	        "items": {
@@ -201,24 +593,51 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 		//	        "pattern": "^[a-zA-Z0-9-_\\.@\\/:]+$",
 		//	        "type": "string"
 		//	      },
-		//	      "MemoryLimits": {
-		//	        "additionalProperties": false,
-		//	        "description": "Specifies how much memory is available to the container. You must specify at least this parameter or the TotalMemoryLimit parameter of the ContainerGroupDefinition.",
-		//	        "properties": {
-		//	          "HardLimit": {
-		//	            "description": "The hard limit of memory to reserve for the container.",
-		//	            "maximum": 1024000,
-		//	            "minimum": 4,
-		//	            "type": "integer"
+		//	      "MemoryHardLimitMebibytes": {
+		//	        "description": "The total memory limit of container groups following this definition in MiB",
+		//	        "maximum": 1024000,
+		//	        "minimum": 4,
+		//	        "type": "integer"
+		//	      },
+		//	      "MountPoints": {
+		//	        "description": "A list of mount point configurations to be used in a container.",
+		//	        "insertionOrder": false,
+		//	        "items": {
+		//	          "additionalProperties": false,
+		//	          "description": "Defines the mount point configuration within a container.",
+		//	          "properties": {
+		//	            "AccessLevel": {
+		//	              "description": "The access permissions for the mounted path.",
+		//	              "enum": [
+		//	                "READ_ONLY",
+		//	                "READ_AND_WRITE"
+		//	              ],
+		//	              "type": "string"
+		//	            },
+		//	            "ContainerPath": {
+		//	              "description": "The path inside the container where the mount is accessible.",
+		//	              "maxLength": 1024,
+		//	              "minLength": 1,
+		//	              "pattern": "^(\\/+[^\\/]+\\/*)+$",
+		//	              "type": "string"
+		//	            },
+		//	            "InstancePath": {
+		//	              "description": "The path on the host that will be mounted in the container.",
+		//	              "maxLength": 1024,
+		//	              "minLength": 1,
+		//	              "pattern": "^\\/[\\s\\S]*$",
+		//	              "type": "string"
+		//	            }
 		//	          },
-		//	          "SoftLimit": {
-		//	            "description": "The amount of memory that is reserved for the container.",
-		//	            "maximum": 1024000,
-		//	            "minimum": 4,
-		//	            "type": "integer"
-		//	          }
+		//	          "required": [
+		//	            "InstancePath"
+		//	          ],
+		//	          "type": "object"
 		//	        },
-		//	        "type": "object"
+		//	        "maxItems": 10,
+		//	        "minItems": 1,
+		//	        "type": "array",
+		//	        "uniqueItems": true
 		//	      },
 		//	      "PortConfiguration": {
 		//	        "additionalProperties": false,
@@ -275,12 +694,11 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 		//	        "pattern": "^sha256:[a-fA-F0-9]{64}$",
 		//	        "type": "string"
 		//	      },
-		//	      "WorkingDirectory": {
-		//	        "description": "The working directory to run commands inside the container in.",
-		//	        "maxLength": 255,
-		//	        "minLength": 1,
-		//	        "pattern": "^.*$",
-		//	        "type": "string"
+		//	      "Vcpu": {
+		//	        "description": "The number of virtual CPUs to give to the support group",
+		//	        "maximum": 10,
+		//	        "minimum": 0.125,
+		//	        "type": "number"
 		//	      }
 		//	    },
 		//	    "required": [
@@ -294,23 +712,12 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 		//	  "type": "array",
 		//	  "uniqueItems": true
 		//	}
-		"container_definitions": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+		"support_container_definitions": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
 			NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
 				Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
-					// Property: Command
-					"command": schema.ListAttribute{ /*START ATTRIBUTE*/
-						ElementType: types.StringType,
-						Description: "The command that's passed to the container.",
-						Computed:    true,
-					}, /*END ATTRIBUTE*/
 					// Property: ContainerName
 					"container_name": schema.StringAttribute{ /*START ATTRIBUTE*/
-						Description: "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
-						Computed:    true,
-					}, /*END ATTRIBUTE*/
-					// Property: Cpu
-					"cpu": schema.Int64Attribute{ /*START ATTRIBUTE*/
-						Description: "The maximum number of CPU units reserved for this container. The value is expressed as an integer amount of CPU units. 1 vCPU is equal to 1024 CPU units",
+						Description: "A descriptive label for the container definition.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
 					// Property: DependsOn
@@ -332,14 +739,8 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 						Description: "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
-					// Property: EntryPoint
-					"entry_point": schema.ListAttribute{ /*START ATTRIBUTE*/
-						ElementType: types.StringType,
-						Description: "The entry point that's passed to the container so that it will run as an executable. If there are multiple arguments, each argument is a string in the array.",
-						Computed:    true,
-					}, /*END ATTRIBUTE*/
-					// Property: Environment
-					"environment": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+					// Property: EnvironmentOverride
+					"environment_override": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
 						NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
 							Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
 								// Property: Name
@@ -400,21 +801,33 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 						Description: "Specifies the image URI of this container.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
-					// Property: MemoryLimits
-					"memory_limits": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
-						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
-							// Property: HardLimit
-							"hard_limit": schema.Int64Attribute{ /*START ATTRIBUTE*/
-								Description: "The hard limit of memory to reserve for the container.",
-								Computed:    true,
-							}, /*END ATTRIBUTE*/
-							// Property: SoftLimit
-							"soft_limit": schema.Int64Attribute{ /*START ATTRIBUTE*/
-								Description: "The amount of memory that is reserved for the container.",
-								Computed:    true,
-							}, /*END ATTRIBUTE*/
-						}, /*END SCHEMA*/
-						Description: "Specifies how much memory is available to the container. You must specify at least this parameter or the TotalMemoryLimit parameter of the ContainerGroupDefinition.",
+					// Property: MemoryHardLimitMebibytes
+					"memory_hard_limit_mebibytes": schema.Int64Attribute{ /*START ATTRIBUTE*/
+						Description: "The total memory limit of container groups following this definition in MiB",
+						Computed:    true,
+					}, /*END ATTRIBUTE*/
+					// Property: MountPoints
+					"mount_points": schema.SetNestedAttribute{ /*START ATTRIBUTE*/
+						NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+							Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+								// Property: AccessLevel
+								"access_level": schema.StringAttribute{ /*START ATTRIBUTE*/
+									Description: "The access permissions for the mounted path.",
+									Computed:    true,
+								}, /*END ATTRIBUTE*/
+								// Property: ContainerPath
+								"container_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+									Description: "The path inside the container where the mount is accessible.",
+									Computed:    true,
+								}, /*END ATTRIBUTE*/
+								// Property: InstancePath
+								"instance_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+									Description: "The path on the host that will be mounted in the container.",
+									Computed:    true,
+								}, /*END ATTRIBUTE*/
+							}, /*END SCHEMA*/
+						}, /*END NESTED OBJECT*/
+						Description: "A list of mount point configurations to be used in a container.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
 					// Property: PortConfiguration
@@ -453,82 +866,14 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 						Description: "The digest of the container image.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
-					// Property: WorkingDirectory
-					"working_directory": schema.StringAttribute{ /*START ATTRIBUTE*/
-						Description: "The working directory to run commands inside the container in.",
+					// Property: Vcpu
+					"vcpu": schema.Float64Attribute{ /*START ATTRIBUTE*/
+						Description: "The number of virtual CPUs to give to the support group",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
 				}, /*END SCHEMA*/
 			}, /*END NESTED OBJECT*/
-			Description: "A collection of container definitions that define the containers in this group.",
-			Computed:    true,
-		}, /*END ATTRIBUTE*/
-		// Property: ContainerGroupDefinitionArn
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
-		//	  "maxLength": 512,
-		//	  "minLength": 1,
-		//	  "pattern": "^arn:.*:containergroupdefinition/containergroupdefinition-[a-zA-Z0-9-]+$|^arn:.*:containergroupdefinition/[a-zA-Z0-9-\\:]+$",
-		//	  "type": "string"
-		//	}
-		"container_group_definition_arn": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
-			Computed:    true,
-		}, /*END ATTRIBUTE*/
-		// Property: CreationTime
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
-		//	  "type": "string"
-		//	}
-		"creation_time": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
-			Computed:    true,
-		}, /*END ATTRIBUTE*/
-		// Property: Name
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "A descriptive label for the container group definition.",
-		//	  "maxLength": 128,
-		//	  "minLength": 1,
-		//	  "pattern": "^[a-zA-Z0-9-]+$",
-		//	  "type": "string"
-		//	}
-		"name": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "A descriptive label for the container group definition.",
-			Computed:    true,
-		}, /*END ATTRIBUTE*/
-		// Property: OperatingSystem
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "The operating system of the container group",
-		//	  "enum": [
-		//	    "AMAZON_LINUX_2023"
-		//	  ],
-		//	  "type": "string"
-		//	}
-		"operating_system": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "The operating system of the container group",
-			Computed:    true,
-		}, /*END ATTRIBUTE*/
-		// Property: SchedulingStrategy
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "Specifies whether the container group includes replica or daemon containers.",
-		//	  "enum": [
-		//	    "REPLICA",
-		//	    "DAEMON"
-		//	  ],
-		//	  "type": "string"
-		//	}
-		"scheduling_strategy": schema.StringAttribute{ /*START ATTRIBUTE*/
-			Description: "Specifies whether the container group includes replica or daemon containers.",
+			Description: "A collection of support container definitions that define the containers in this group.",
 			Computed:    true,
 		}, /*END ATTRIBUTE*/
 		// Property: Tags
@@ -585,30 +930,55 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 			Description: "An array of key-value pairs to apply to this resource.",
 			Computed:    true,
 		}, /*END ATTRIBUTE*/
-		// Property: TotalCpuLimit
+		// Property: TotalMemoryLimitMebibytes
 		// CloudFormation resource type schema:
 		//
 		//	{
-		//	  "description": "The maximum number of CPU units reserved for this container group. The value is expressed as an integer amount of CPU units. (1 vCPU is equal to 1024 CPU units.)",
-		//	  "maximum": 10240,
-		//	  "minimum": 128,
-		//	  "type": "integer"
-		//	}
-		"total_cpu_limit": schema.Int64Attribute{ /*START ATTRIBUTE*/
-			Description: "The maximum number of CPU units reserved for this container group. The value is expressed as an integer amount of CPU units. (1 vCPU is equal to 1024 CPU units.)",
-			Computed:    true,
-		}, /*END ATTRIBUTE*/
-		// Property: TotalMemoryLimit
-		// CloudFormation resource type schema:
-		//
-		//	{
-		//	  "description": "The maximum amount of memory (in MiB) to allocate for this container group.",
+		//	  "description": "The total memory limit of container groups following this definition in MiB",
 		//	  "maximum": 1024000,
 		//	  "minimum": 4,
 		//	  "type": "integer"
 		//	}
-		"total_memory_limit": schema.Int64Attribute{ /*START ATTRIBUTE*/
-			Description: "The maximum amount of memory (in MiB) to allocate for this container group.",
+		"total_memory_limit_mebibytes": schema.Int64Attribute{ /*START ATTRIBUTE*/
+			Description: "The total memory limit of container groups following this definition in MiB",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: TotalVcpuLimit
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The total amount of virtual CPUs on the container group definition",
+		//	  "maximum": 10,
+		//	  "minimum": 0.125,
+		//	  "type": "number"
+		//	}
+		"total_vcpu_limit": schema.Float64Attribute{ /*START ATTRIBUTE*/
+			Description: "The total amount of virtual CPUs on the container group definition",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: VersionDescription
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The description of this version",
+		//	  "maxLength": 1024,
+		//	  "minLength": 1,
+		//	  "type": "string"
+		//	}
+		"version_description": schema.StringAttribute{ /*START ATTRIBUTE*/
+			Description: "The description of this version",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: VersionNumber
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "description": "The version of this ContainerGroupDefinition",
+		//	  "minimum": 0,
+		//	  "type": "integer"
+		//	}
+		"version_number": schema.Int64Attribute{ /*START ATTRIBUTE*/
+			Description: "The version of this ContainerGroupDefinition",
 			Computed:    true,
 		}, /*END ATTRIBUTE*/
 	} /*END SCHEMA*/
@@ -628,41 +998,48 @@ func containerGroupDefinitionDataSource(ctx context.Context) (datasource.DataSou
 	opts = opts.WithCloudFormationTypeName("AWS::GameLift::ContainerGroupDefinition").WithTerraformTypeName("awscc_gamelift_container_group_definition")
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
-		"command":                        "Command",
-		"condition":                      "Condition",
-		"container_definitions":          "ContainerDefinitions",
-		"container_group_definition_arn": "ContainerGroupDefinitionArn",
-		"container_name":                 "ContainerName",
-		"container_port_ranges":          "ContainerPortRanges",
-		"cpu":                            "Cpu",
-		"creation_time":                  "CreationTime",
-		"depends_on":                     "DependsOn",
-		"entry_point":                    "EntryPoint",
-		"environment":                    "Environment",
-		"essential":                      "Essential",
-		"from_port":                      "FromPort",
-		"hard_limit":                     "HardLimit",
-		"health_check":                   "HealthCheck",
-		"image_uri":                      "ImageUri",
-		"interval":                       "Interval",
-		"key":                            "Key",
-		"memory_limits":                  "MemoryLimits",
-		"name":                           "Name",
-		"operating_system":               "OperatingSystem",
-		"port_configuration":             "PortConfiguration",
-		"protocol":                       "Protocol",
-		"resolved_image_digest":          "ResolvedImageDigest",
-		"retries":                        "Retries",
-		"scheduling_strategy":            "SchedulingStrategy",
-		"soft_limit":                     "SoftLimit",
-		"start_period":                   "StartPeriod",
-		"tags":                           "Tags",
-		"timeout":                        "Timeout",
-		"to_port":                        "ToPort",
-		"total_cpu_limit":                "TotalCpuLimit",
-		"total_memory_limit":             "TotalMemoryLimit",
-		"value":                          "Value",
-		"working_directory":              "WorkingDirectory",
+		"access_level":                     "AccessLevel",
+		"command":                          "Command",
+		"condition":                        "Condition",
+		"container_group_definition_arn":   "ContainerGroupDefinitionArn",
+		"container_group_type":             "ContainerGroupType",
+		"container_name":                   "ContainerName",
+		"container_path":                   "ContainerPath",
+		"container_port_ranges":            "ContainerPortRanges",
+		"creation_time":                    "CreationTime",
+		"depends_on":                       "DependsOn",
+		"environment_override":             "EnvironmentOverride",
+		"essential":                        "Essential",
+		"from_port":                        "FromPort",
+		"game_server_container_definition": "GameServerContainerDefinition",
+		"health_check":                     "HealthCheck",
+		"image_uri":                        "ImageUri",
+		"instance_path":                    "InstancePath",
+		"interval":                         "Interval",
+		"key":                              "Key",
+		"memory_hard_limit_mebibytes":      "MemoryHardLimitMebibytes",
+		"mount_points":                     "MountPoints",
+		"name":                             "Name",
+		"operating_system":                 "OperatingSystem",
+		"port_configuration":               "PortConfiguration",
+		"protocol":                         "Protocol",
+		"resolved_image_digest":            "ResolvedImageDigest",
+		"retries":                          "Retries",
+		"server_sdk_version":               "ServerSdkVersion",
+		"source_version_number":            "SourceVersionNumber",
+		"start_period":                     "StartPeriod",
+		"status":                           "Status",
+		"status_reason":                    "StatusReason",
+		"support_container_definitions":    "SupportContainerDefinitions",
+		"tags":                             "Tags",
+		"timeout":                          "Timeout",
+		"to_port":                          "ToPort",
+		"total_memory_limit_mebibytes":     "TotalMemoryLimitMebibytes",
+		"total_vcpu_limit":                 "TotalVcpuLimit",
+		"value":                            "Value",
+		"vcpu":                             "Vcpu",
+		"version_description":              "VersionDescription",
+		"version_number":                   "VersionNumber",
 	})
 
 	v, err := generic.NewSingularDataSource(ctx, opts...)

--- a/internal/provider/all_schemas.hcl
+++ b/internal/provider/all_schemas.hcl
@@ -2251,11 +2251,6 @@ resource_schema "aws_gamelift_container_fleet" {
 
 resource_schema "aws_gamelift_container_group_definition" {
   cloudformation_type_name = "AWS::GameLift::ContainerGroupDefinition"
-
-  # Latest schema updates are suppressed.
-  # git checkout internal/service/cloudformation/schemas/AWS_GameLift_ContainerGroupDefinition.json
-  # Suppression Reason: set of unknown type
-  # https://github.com/hashicorp/terraform-provider-awscc/issues/2069
 }
 
 resource_schema "aws_gamelift_fleet" {

--- a/internal/service/cloudformation/schemas/AWS_GameLift_ContainerGroupDefinition.json
+++ b/internal/service/cloudformation/schemas/AWS_GameLift_ContainerGroupDefinition.json
@@ -1,50 +1,517 @@
 {
+  "$schema": "https://schema.cloudformation.us-east-1.amazonaws.com/provider.definition.schema.v1.json",
+  "typeName": "AWS::GameLift::ContainerGroupDefinition",
+  "description": "The AWS::GameLift::ContainerGroupDefinition resource creates an Amazon GameLift container group definition.",
+  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-gamelift.git",
   "tagging": {
+    "taggable": true,
+    "cloudFormationSystemTags": false,
+    "tagOnCreate": true,
+    "tagUpdatable": true,
+    "tagProperty": "/properties/Tags",
     "permissions": [
       "gamelift:ListTagsForResource",
       "gamelift:TagResource",
       "gamelift:UntagResource"
-    ],
-    "taggable": true,
-    "tagOnCreate": true,
-    "tagUpdatable": true,
-    "tagProperty": "/properties/Tags",
-    "cloudFormationSystemTags": false
+    ]
   },
-  "$schema": "https://schema.cloudformation.us-east-1.amazonaws.com/provider.definition.schema.v1.json",
-  "typeName": "AWS::GameLift::ContainerGroupDefinition",
+  "definitions": {
+    "ContainerPortRange": {
+      "description": "A set of one or more port numbers that can be opened on the container.",
+      "type": "object",
+      "properties": {
+        "FromPort": {
+          "description": "A starting value for the range of allowed port numbers.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 60000
+        },
+        "Protocol": {
+          "description": "Defines the protocol of these ports.",
+          "type": "string",
+          "enum": [
+            "TCP",
+            "UDP"
+          ]
+        },
+        "ToPort": {
+          "description": "An ending value for the range of allowed port numbers. Port numbers are end-inclusive. This value must be equal to or greater than FromPort.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 60000
+        }
+      },
+      "required": [
+        "FromPort",
+        "Protocol",
+        "ToPort"
+      ],
+      "additionalProperties": false
+    },
+    "ContainerHealthCheck": {
+      "description": "Specifies how the process manager checks the health of containers.",
+      "type": "object",
+      "properties": {
+        "Command": {
+          "description": "A string array representing the command that the container runs to determine if it is healthy.",
+          "type": "array",
+          "uniqueItems": false,
+          "insertionOrder": true,
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^.*$"
+          }
+        },
+        "Interval": {
+          "description": "How often (in seconds) the health is checked.",
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 300
+        },
+        "Timeout": {
+          "description": "How many seconds the process manager allows the command to run before canceling it.",
+          "type": "integer",
+          "minimum": 30,
+          "maximum": 60
+        },
+        "Retries": {
+          "description": "How many times the process manager will retry the command after a timeout. (The first run of the command does not count as a retry.)",
+          "type": "integer",
+          "minimum": 5,
+          "maximum": 10
+        },
+        "StartPeriod": {
+          "description": "The optional grace period (in seconds) to give a container time to boostrap before teh health check is declared failed.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 300
+        }
+      },
+      "required": [
+        "Command"
+      ],
+      "additionalProperties": false
+    },
+    "PortConfiguration": {
+      "description": "Defines the ports on a container.",
+      "type": "object",
+      "properties": {
+        "ContainerPortRanges": {
+          "description": "Specifies one or more ranges of ports on a container.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": false,
+          "minItems": 1,
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/ContainerPortRange"
+          }
+        }
+      },
+      "required": [
+        "ContainerPortRanges"
+      ],
+      "additionalProperties": false
+    },
+    "ContainerEnvironment": {
+      "description": "An environment variable to set inside a container, in the form of a key-value pair.",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The environment variable name.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255,
+          "pattern": "^.*$"
+        },
+        "Value": {
+          "description": "The environment variable value.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255,
+          "pattern": "^.*$"
+        }
+      },
+      "required": [
+        "Name",
+        "Value"
+      ],
+      "additionalProperties": false
+    },
+    "ContainerMountPoint": {
+      "description": "Defines the mount point configuration within a container.",
+      "type": "object",
+      "properties": {
+        "InstancePath": {
+          "description": "The path on the host that will be mounted in the container.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024,
+          "pattern": "^\\/[\\s\\S]*$"
+        },
+        "ContainerPath": {
+          "description": "The path inside the container where the mount is accessible.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024,
+          "pattern": "^(\\/+[^\\/]+\\/*)+$"
+        },
+        "AccessLevel": {
+          "description": "The access permissions for the mounted path.",
+          "type": "string",
+          "enum": [
+            "READ_ONLY",
+            "READ_AND_WRITE"
+          ]
+        }
+      },
+      "required": [
+        "InstancePath"
+      ],
+      "additionalProperties": false
+    },
+    "ContainerDependency": {
+      "description": "A dependency that impacts a container's startup and shutdown.",
+      "type": "object",
+      "properties": {
+        "ContainerName": {
+          "description": "A descriptive label for the container definition. The container being defined depends on this container's condition.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[a-zA-Z0-9-]+$"
+        },
+        "Condition": {
+          "description": "The type of dependency.",
+          "type": "string",
+          "enum": [
+            "START",
+            "COMPLETE",
+            "SUCCESS",
+            "HEALTHY"
+          ]
+        }
+      },
+      "required": [
+        "ContainerName",
+        "Condition"
+      ],
+      "additionalProperties": false
+    },
+    "Tag": {
+      "description": "A key-value pair to associate with a resource.",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^.*$"
+        },
+        "Value": {
+          "description": "The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length.",
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 256,
+          "pattern": "^.*$"
+        }
+      },
+      "required": [
+        "Key",
+        "Value"
+      ],
+      "additionalProperties": false
+    },
+    "GameServerContainerDefinition": {
+      "description": "Specifies the information required to run game servers with this container group",
+      "type": "object",
+      "properties": {
+        "ContainerName": {
+          "description": "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[a-zA-Z0-9-]+$"
+        },
+        "DependsOn": {
+          "description": "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": true,
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/definitions/ContainerDependency"
+          }
+        },
+        "ServerSdkVersion": {
+          "description": "The version of the server SDK used in this container group",
+          "type": "string",
+          "maxLength": 128,
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "ImageUri": {
+          "description": "Specifies the image URI of this container.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255,
+          "pattern": "^[a-zA-Z0-9-_\\.@\\/:]+$"
+        },
+        "ResolvedImageDigest": {
+          "description": "The digest of the container image.",
+          "type": "string",
+          "pattern": "^sha256:[a-fA-F0-9]{64}$"
+        },
+        "EnvironmentOverride": {
+          "description": "The environment variables to pass to a container.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": false,
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/ContainerEnvironment"
+          }
+        },
+        "PortConfiguration": {
+          "description": "Defines the ports on the container.",
+          "$ref": "#/definitions/PortConfiguration"
+        },
+        "MountPoints": {
+          "description": "A list of mount point configurations to be used in a container.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": false,
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/definitions/ContainerMountPoint"
+          }
+        }
+      },
+      "required": [
+        "ContainerName",
+        "ImageUri",
+        "ServerSdkVersion"
+      ],
+      "additionalProperties": false
+    },
+    "SupportContainerDefinition": {
+      "description": "Supports the function of the main container group",
+      "type": "object",
+      "properties": {
+        "ContainerName": {
+          "description": "A descriptive label for the container definition.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[a-zA-Z0-9-]+$"
+        },
+        "Vcpu": {
+          "description": "The number of virtual CPUs to give to the support group",
+          "type": "number",
+          "minimum": 0.125,
+          "maximum": 10
+        },
+        "DependsOn": {
+          "description": "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": true,
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/definitions/ContainerDependency"
+          }
+        },
+        "Essential": {
+          "description": "Specifies if the container is essential. If an essential container fails a health check, then all containers in the container group will be restarted. You must specify exactly 1 essential container in a container group.",
+          "type": "boolean"
+        },
+        "ImageUri": {
+          "description": "Specifies the image URI of this container.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255,
+          "pattern": "^[a-zA-Z0-9-_\\.@\\/:]+$"
+        },
+        "ResolvedImageDigest": {
+          "description": "The digest of the container image.",
+          "type": "string",
+          "pattern": "^sha256:[a-fA-F0-9]{64}$"
+        },
+        "MemoryHardLimitMebibytes": {
+          "description": "The total memory limit of container groups following this definition in MiB",
+          "type": "integer",
+          "minimum": 4,
+          "maximum": 1024000
+        },
+        "EnvironmentOverride": {
+          "description": "The environment variables to pass to a container.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": false,
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/ContainerEnvironment"
+          }
+        },
+        "PortConfiguration": {
+          "description": "Defines the ports on the container.",
+          "$ref": "#/definitions/PortConfiguration"
+        },
+        "HealthCheck": {
+          "description": "Specifies how the health of the containers will be checked.",
+          "$ref": "#/definitions/ContainerHealthCheck"
+        },
+        "MountPoints": {
+          "description": "A list of mount point configurations to be used in a container.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": false,
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/definitions/ContainerMountPoint"
+          }
+        }
+      },
+      "required": [
+        "ContainerName",
+        "ImageUri"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "ContainerGroupDefinitionArn": {
+      "description": "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^arn:.*:containergroupdefinition\\/[a-zA-Z0-9\\-]+(:[0-9]+)?$"
+    },
+    "CreationTime": {
+      "description": "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
+      "type": "string"
+    },
+    "OperatingSystem": {
+      "description": "The operating system of the container group",
+      "type": "string",
+      "enum": [
+        "AMAZON_LINUX_2023"
+      ]
+    },
+    "Name": {
+      "description": "A descriptive label for the container group definition.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9-]+$"
+    },
+    "ContainerGroupType": {
+      "description": "The scope of the container group",
+      "type": "string",
+      "enum": [
+        "GAME_SERVER",
+        "PER_INSTANCE"
+      ]
+    },
+    "TotalMemoryLimitMebibytes": {
+      "description": "The total memory limit of container groups following this definition in MiB",
+      "type": "integer",
+      "minimum": 4,
+      "maximum": 1024000
+    },
+    "TotalVcpuLimit": {
+      "description": "The total amount of virtual CPUs on the container group definition",
+      "type": "number",
+      "minimum": 0.125,
+      "maximum": 10
+    },
+    "GameServerContainerDefinition": {
+      "$ref": "#/definitions/GameServerContainerDefinition"
+    },
+    "SupportContainerDefinitions": {
+      "description": "A collection of support container definitions that define the containers in this group.",
+      "type": "array",
+      "uniqueItems": true,
+      "insertionOrder": false,
+      "minItems": 1,
+      "maxItems": 10,
+      "items": {
+        "$ref": "#/definitions/SupportContainerDefinition"
+      }
+    },
+    "VersionNumber": {
+      "description": "The version of this ContainerGroupDefinition",
+      "type": "integer",
+      "minimum": 0
+    },
+    "SourceVersionNumber": {
+      "description": "A specific ContainerGroupDefinition version to be updated",
+      "type": "integer",
+      "minimum": 0
+    },
+    "VersionDescription": {
+      "description": "The description of this version",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "Status": {
+      "description": "A string indicating ContainerGroupDefinition status.",
+      "type": "string",
+      "enum": [
+        "READY",
+        "COPYING",
+        "FAILED"
+      ]
+    },
+    "StatusReason": {
+      "description": "A string indicating the reason for ContainerGroupDefinition status.",
+      "type": "string"
+    },
+    "Tags": {
+      "description": "An array of key-value pairs to apply to this resource.",
+      "type": "array",
+      "uniqueItems": true,
+      "insertionOrder": false,
+      "minItems": 0,
+      "maxItems": 200,
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "OperatingSystem",
+    "TotalMemoryLimitMebibytes",
+    "TotalVcpuLimit"
+  ],
+  "createOnlyProperties": [
+    "/properties/Name",
+    "/properties/ContainerGroupType"
+  ],
   "readOnlyProperties": [
     "/properties/ContainerGroupDefinitionArn",
     "/properties/CreationTime",
-    "/properties/ContainerDefinitions/*/ResolvedImageDigest"
-  ],
-  "description": "The AWS::GameLift::ContainerGroupDefinition resource creates an Amazon GameLift container group definition.",
-  "createOnlyProperties": [
-    "/properties/Name",
-    "/properties/SchedulingStrategy",
-    "/properties/TotalMemoryLimit",
-    "/properties/TotalCpuLimit",
-    "/properties/ContainerDefinitions",
-    "/properties/OperatingSystem"
+    "/properties/VersionNumber",
+    "/properties/Status",
+    "/properties/StatusReason"
   ],
   "primaryIdentifier": [
     "/properties/Name"
   ],
-  "required": [
-    "Name",
-    "TotalMemoryLimit",
-    "TotalCpuLimit",
-    "ContainerDefinitions",
-    "OperatingSystem"
-  ],
-  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-gamelift.git",
   "handlers": {
-    "read": {
-      "permissions": [
-        "gamelift:DescribeContainerGroupDefinition",
-        "gamelift:ListTagsForResource"
-      ]
-    },
     "create": {
       "permissions": [
         "gamelift:CreateContainerGroupDefinition",
@@ -57,16 +524,18 @@
         "ecr:DescribeImages"
       ]
     },
+    "read": {
+      "permissions": [
+        "gamelift:DescribeContainerGroupDefinition",
+        "gamelift:ListTagsForResource"
+      ]
+    },
     "update": {
       "permissions": [
+        "gamelift:UpdateContainerGroupDefinition",
         "gamelift:ListTagsForResource",
         "gamelift:TagResource",
         "gamelift:UntagResource"
-      ]
-    },
-    "list": {
-      "permissions": [
-        "gamelift:ListContainerGroupDefinitions"
       ]
     },
     "delete": {
@@ -74,384 +543,11 @@
         "gamelift:DescribeContainerGroupDefinition",
         "gamelift:DeleteContainerGroupDefinition"
       ]
-    }
-  },
-  "additionalProperties": false,
-  "definitions": {
-    "ContainerPortRange": {
-      "description": "A set of one or more port numbers that can be opened on the container.",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "FromPort": {
-          "description": "A starting value for the range of allowed port numbers.",
-          "maximum": 60000,
-          "type": "integer",
-          "minimum": 1
-        },
-        "ToPort": {
-          "description": "An ending value for the range of allowed port numbers. Port numbers are end-inclusive. This value must be equal to or greater than FromPort.",
-          "maximum": 60000,
-          "type": "integer",
-          "minimum": 1
-        },
-        "Protocol": {
-          "description": "Defines the protocol of these ports.",
-          "type": "string",
-          "enum": [
-            "TCP",
-            "UDP"
-          ]
-        }
-      },
-      "required": [
-        "FromPort",
-        "Protocol",
-        "ToPort"
+    },
+    "list": {
+      "permissions": [
+        "gamelift:ListContainerGroupDefinitions"
       ]
-    },
-    "MemoryLimits": {
-      "description": "Specifies how much memory is available to the container.",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "SoftLimit": {
-          "description": "The amount of memory that is reserved for the container.",
-          "maximum": 1024000,
-          "type": "integer",
-          "minimum": 4
-        },
-        "HardLimit": {
-          "description": "The hard limit of memory to reserve for the container.",
-          "maximum": 1024000,
-          "type": "integer",
-          "minimum": 4
-        }
-      }
-    },
-    "ContainerDependency": {
-      "description": "A dependency that impacts a container's startup and shutdown.",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "Condition": {
-          "description": "The type of dependency.",
-          "type": "string",
-          "enum": [
-            "START",
-            "COMPLETE",
-            "SUCCESS",
-            "HEALTHY"
-          ]
-        },
-        "ContainerName": {
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9-]+$",
-          "description": "A descriptive label for the container definition. The container being defined depends on this container's condition.",
-          "type": "string",
-          "maxLength": 128
-        }
-      },
-      "required": [
-        "ContainerName",
-        "Condition"
-      ]
-    },
-    "ContainerEnvironment": {
-      "description": "An environment variable to set inside a container, in the form of a key-value pair.",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "Value": {
-          "minLength": 1,
-          "pattern": "^.*$",
-          "description": "The environment variable value.",
-          "type": "string",
-          "maxLength": 255
-        },
-        "Name": {
-          "minLength": 1,
-          "pattern": "^.*$",
-          "description": "The environment variable name.",
-          "type": "string",
-          "maxLength": 255
-        }
-      },
-      "required": [
-        "Name",
-        "Value"
-      ]
-    },
-    "ContainerDefinition": {
-      "description": "Details about a container that is used in a container fleet",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "WorkingDirectory": {
-          "minLength": 1,
-          "pattern": "^.*$",
-          "description": "The working directory to run commands inside the container in.",
-          "type": "string",
-          "maxLength": 255
-        },
-        "MemoryLimits": {
-          "description": "Specifies how much memory is available to the container. You must specify at least this parameter or the TotalMemoryLimit parameter of the ContainerGroupDefinition.",
-          "$ref": "#/definitions/MemoryLimits"
-        },
-        "HealthCheck": {
-          "description": "Specifies how the health of the containers will be checked.",
-          "$ref": "#/definitions/ContainerHealthCheck"
-        },
-        "Cpu": {
-          "description": "The maximum number of CPU units reserved for this container. The value is expressed as an integer amount of CPU units. 1 vCPU is equal to 1024 CPU units",
-          "maximum": 10240,
-          "type": "integer",
-          "minimum": 1
-        },
-        "EntryPoint": {
-          "minItems": 1,
-          "maxItems": 20,
-          "uniqueItems": false,
-          "description": "The entry point that's passed to the container so that it will run as an executable. If there are multiple arguments, each argument is a string in the array.",
-          "insertionOrder": true,
-          "type": "array",
-          "items": {
-            "minLength": 1,
-            "type": "string",
-            "maxLength": 1024
-          }
-        },
-        "ImageUri": {
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9-_\\.@\\/:]+$",
-          "description": "Specifies the image URI of this container.",
-          "type": "string",
-          "maxLength": 255
-        },
-        "ResolvedImageDigest": {
-          "pattern": "^sha256:[a-fA-F0-9]{64}$",
-          "description": "The digest of the container image.",
-          "type": "string"
-        },
-        "Essential": {
-          "description": "Specifies if the container is essential. If an essential container fails a health check, then all containers in the container group will be restarted. You must specify exactly 1 essential container in a container group.",
-          "type": "boolean"
-        },
-        "PortConfiguration": {
-          "description": "Defines the ports on the container.",
-          "$ref": "#/definitions/PortConfiguration"
-        },
-        "DependsOn": {
-          "minItems": 1,
-          "maxItems": 10,
-          "uniqueItems": true,
-          "description": "A list of container dependencies that determines when this container starts up and shuts down. For container groups with multiple containers, dependencies let you define a startup/shutdown sequence across the containers.",
-          "insertionOrder": true,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ContainerDependency"
-          }
-        },
-        "ContainerName": {
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9-]+$",
-          "description": "A descriptive label for the container definition. Container definition names must be unique with a container group definition.",
-          "type": "string",
-          "maxLength": 128
-        },
-        "Command": {
-          "minItems": 1,
-          "maxItems": 20,
-          "uniqueItems": false,
-          "description": "The command that's passed to the container.",
-          "insertionOrder": true,
-          "type": "array",
-          "items": {
-            "minLength": 1,
-            "pattern": "^.*$",
-            "type": "string",
-            "maxLength": 255
-          }
-        },
-        "Environment": {
-          "minItems": 1,
-          "maxItems": 20,
-          "uniqueItems": true,
-          "description": "The environment variables to pass to a container.",
-          "insertionOrder": false,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ContainerEnvironment"
-          }
-        }
-      },
-      "required": [
-        "ContainerName",
-        "ImageUri"
-      ]
-    },
-    "Tag": {
-      "description": "A key-value pair to associate with a resource.",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "Value": {
-          "minLength": 0,
-          "pattern": "^.*$",
-          "description": "The value for the tag. You can specify a value that is 0 to 256 Unicode characters in length.",
-          "type": "string",
-          "maxLength": 256
-        },
-        "Key": {
-          "minLength": 1,
-          "pattern": "^.*$",
-          "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length.",
-          "type": "string",
-          "maxLength": 128
-        }
-      },
-      "required": [
-        "Key",
-        "Value"
-      ]
-    },
-    "PortConfiguration": {
-      "description": "Defines the ports on a container.",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "ContainerPortRanges": {
-          "minItems": 1,
-          "maxItems": 100,
-          "uniqueItems": true,
-          "description": "Specifies one or more ranges of ports on a container.",
-          "insertionOrder": false,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ContainerPortRange"
-          }
-        }
-      },
-      "required": [
-        "ContainerPortRanges"
-      ]
-    },
-    "ContainerHealthCheck": {
-      "description": "Specifies how the process manager checks the health of containers.",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "Command": {
-          "minItems": 1,
-          "maxItems": 20,
-          "uniqueItems": false,
-          "description": "A string array representing the command that the container runs to determine if it is healthy.",
-          "insertionOrder": true,
-          "type": "array",
-          "items": {
-            "minLength": 1,
-            "pattern": "^.*$",
-            "type": "string",
-            "maxLength": 255
-          }
-        },
-        "Timeout": {
-          "description": "How many seconds the process manager allows the command to run before canceling it.",
-          "maximum": 60,
-          "type": "integer",
-          "minimum": 30
-        },
-        "Retries": {
-          "description": "How many times the process manager will retry the command after a timeout. (The first run of the command does not count as a retry.)",
-          "maximum": 10,
-          "type": "integer",
-          "minimum": 5
-        },
-        "Interval": {
-          "description": "How often (in seconds) the health is checked.",
-          "maximum": 300,
-          "type": "integer",
-          "minimum": 60
-        },
-        "StartPeriod": {
-          "description": "The optional grace period (in seconds) to give a container time to boostrap before teh health check is declared failed.",
-          "maximum": 300,
-          "type": "integer",
-          "minimum": 0
-        }
-      },
-      "required": [
-        "Command"
-      ]
-    }
-  },
-  "properties": {
-    "OperatingSystem": {
-      "description": "The operating system of the container group",
-      "type": "string",
-      "enum": [
-        "AMAZON_LINUX_2023"
-      ]
-    },
-    "Name": {
-      "minLength": 1,
-      "pattern": "^[a-zA-Z0-9-]+$",
-      "description": "A descriptive label for the container group definition.",
-      "type": "string",
-      "maxLength": 128
-    },
-    "ContainerGroupDefinitionArn": {
-      "minLength": 1,
-      "pattern": "^arn:.*:containergroupdefinition/containergroupdefinition-[a-zA-Z0-9-]+$|^arn:.*:containergroupdefinition/[a-zA-Z0-9-\\:]+$",
-      "description": "The Amazon Resource Name (ARN) that is assigned to a Amazon GameLift container group resource and uniquely identifies it across all AWS Regions.",
-      "type": "string",
-      "maxLength": 512
-    },
-    "SchedulingStrategy": {
-      "description": "Specifies whether the container group includes replica or daemon containers.",
-      "type": "string",
-      "enum": [
-        "REPLICA",
-        "DAEMON"
-      ]
-    },
-    "TotalMemoryLimit": {
-      "description": "The maximum amount of memory (in MiB) to allocate for this container group.",
-      "maximum": 1024000,
-      "type": "integer",
-      "minimum": 4
-    },
-    "CreationTime": {
-      "description": "A time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example \"1469498468.057\").",
-      "type": "string"
-    },
-    "ContainerDefinitions": {
-      "minItems": 1,
-      "maxItems": 10,
-      "uniqueItems": true,
-      "description": "A collection of container definitions that define the containers in this group.",
-      "insertionOrder": false,
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ContainerDefinition"
-      }
-    },
-    "Tags": {
-      "minItems": 0,
-      "maxItems": 200,
-      "uniqueItems": true,
-      "description": "An array of key-value pairs to apply to this resource.",
-      "insertionOrder": false,
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Tag"
-      }
-    },
-    "TotalCpuLimit": {
-      "description": "The maximum number of CPU units reserved for this container group. The value is expressed as an integer amount of CPU units. (1 vCPU is equal to 1024 CPU units.)",
-      "maximum": 10240,
-      "type": "integer",
-      "minimum": 128
     }
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

### Description

Updated the Schema update for `awscc_gamelift_container_group_definition` as the previous reasons for schema suppression were addressed. 

- Validated successful build with the schema update.
- Plan based on the locally built provider
```
the following symbols:
  + create

Terraform will perform the following actions:

  # awscc_gamelift_container_group_definition.example will be created
  + resource "awscc_gamelift_container_group_definition" "example" {
      + container_group_definition_arn   = (known after apply)
      + container_group_type             = (known after apply)
      + creation_time                    = (known after apply)
      + game_server_container_definition = {
          + container_name        = "example"
          + depends_on            = (known after apply)
          + environment_override  = (known after apply)
          + image_uri             = "public.ecr.aws/aws-containers/stateful-counter:latest"
          + mount_points          = (known after apply)
          + port_configuration    = {
              + container_port_ranges = [
                  + {
                      + from_port = 1935
                      + protocol  = "UDP"
                      + to_port   = 1935
                    },
                ]
            }
          + resolved_image_digest = (known after apply)
          + server_sdk_version    = "5.2.0"
        }
      + id                               = (known after apply)
      + name                             = "example"
      + operating_system                 = "AMAZON_LINUX_2023"
      + source_version_number            = (known after apply)
      + status                           = (known after apply)
      + status_reason                    = (known after apply)
      + support_container_definitions    = (known after apply)
      + tags                             = (known after apply)
      + total_memory_limit_mebibytes     = 4
      + total_vcpu_limit                 = 10
      + version_description              = (known after apply)
      + version_number                   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
awscc_gamelift_container_group_definition.example: Creating...
awscc_gamelift_container_group_definition.example: Still creating... [10s elapsed]
awscc_gamelift_container_group_definition.example: Still creating... [20s elapsed]
awscc_gamelift_container_group_definition.example: Still creating... [30s elapsed]
awscc_gamelift_container_group_definition.example: Creation complete after 34s [id=example]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

- Note : `game_server_container_definition` is required, though it is marked optional in schema. Will be opening a service ticket on the same. 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2069 

