### PR TITLE
ci: fix goreleaser deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ archives:
       # Ensure only built binary and license file are archived
       - src: LICENSE
         dst: LICENSE.txt
-    format: zip
+    formats: ['zip']
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 before:
   hooks:


### PR DESCRIPTION
Before:

```console
% goreleaser check
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

After:

```console
% goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

Relates https://github.com/hashicorp/terraform-provider-aws/pull/41094
