### PR TITLE
fix: pagination on plural datasources

### DIFF
--- a/internal/service/cloudcontrol/list.go
+++ b/internal/service/cloudcontrol/list.go
@@ -27,23 +27,14 @@ func ListResourcesByTypeName(ctx context.Context, conn *cloudcontrol.Client, rol
 		input.RoleArn = aws.String(roleARN)
 	}
 
-	for {
-		output, err := conn.ListResources(ctx, input)
+	paginator := cloudcontrol.NewListResourcesPaginator(conn, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		if output == nil {
-			break
-		}
-
-		resourceDescriptions = append(resourceDescriptions, output.ResourceDescriptions...)
-
-		if output.NextToken == nil {
-			break
-		}
-
-		input.NextToken = output.NextToken
+		resourceDescriptions = append(resourceDescriptions, page.ResourceDescriptions...)
 	}
 
 	if len(resourceDescriptions) == 0 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2204

This PR updates the list operation to handle pagination for plural datasources. 

Tests with IAM roles:
![Screenshot 2025-02-14 at 18 23 49](https://github.com/user-attachments/assets/d9c350aa-c318-4ece-87aa-fd907296167d)

Config:
```
data "awscc_iam_roles" "ids" {}

output "ids" {
  value = length(data.awscc_iam_roles.ids.ids)
}
```

Before : 
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
Outputs:
ids = 100
```

After:

```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
Outputs:
ids = 244
```



