### PR TITLE
feat: Enhance error messages for hook failures

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	basediag "github.com/hashicorp/aws-sdk-go-base/v2/diag"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
@@ -36,6 +37,7 @@ const (
 // is passed to each resource and data source in their Configure methods.
 type providerData struct {
 	ccAPIClient *cloudcontrol.Client
+	cfClient    *cloudformation.Client
 	logger      baselogging.Logger
 	region      string
 	roleARN     string
@@ -43,6 +45,10 @@ type providerData struct {
 
 func (p *providerData) CloudControlAPIClient(_ context.Context) *cloudcontrol.Client {
 	return p.ccAPIClient
+}
+
+func (p *providerData) CloudFormationClient(_ context.Context) *cloudformation.Client {
+	return p.cfClient
 }
 
 func (p *providerData) Region(_ context.Context) string {
@@ -557,8 +563,11 @@ func newProviderData(ctx context.Context, c *configModel) (*providerData, diag.D
 		}
 	})
 
+	cfClient := cloudformation.NewFromConfig(cfg)
+
 	providerData := &providerData{
 		ccAPIClient: ccAPIClient,
+		cfClient:    cfClient,
 		logger:      logger,
 		region:      cfg.Region,
 		roleARN:     c.RoleARN.ValueString(),

--- a/internal/service/cloudcontrol/delete.go
+++ b/internal/service/cloudcontrol/delete.go
@@ -41,7 +41,7 @@ func DeleteResource(ctx context.Context, conn *cloudcontrol.Client, roleARN, typ
 	}
 
 	waiter := cloudcontrol.NewResourceRequestSuccessWaiter(conn, func(o *cloudcontrol.ResourceRequestSuccessWaiterOptions) {
-		o.Retryable = RetryGetResourceRequestStatus(nil)
+		o.Retryable = RetryGetResourceRequestStatus(nil, nil)
 	})
 
 	err = waiter.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{RequestToken: output.ProgressEvent.RequestToken}, maxWaitTime)

--- a/internal/service/cloudcontrol/provider.go
+++ b/internal/service/cloudcontrol/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 )
 
 // Provider is the interface implemented by AWS Cloud Control API client providers.
@@ -14,6 +15,9 @@ import (
 type Provider interface {
 	// CloudControlApiClient returns an AWS Cloud Control API client.
 	CloudControlAPIClient(context.Context) *cloudcontrol.Client
+
+	// CloudControlApiClient returns an AWS Cloud Formation client.
+	CloudFormationClient(context.Context) *cloudformation.Client
 
 	// Region returns an AWS Cloud Control API client's region
 	Region(ctx context.Context) string

--- a/internal/service/cloudcontrol/waiter.go
+++ b/internal/service/cloudcontrol/waiter.go
@@ -6,14 +6,16 @@ package cloudcontrol
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 )
 
 // RetryGetResourceRequestStatus returns a custom retryable function for the GetResourceRequestStatus operation.
-func RetryGetResourceRequestStatus(pProgressEvent **types.ProgressEvent) func(context.Context, *cloudcontrol.GetResourceRequestStatusInput, *cloudcontrol.GetResourceRequestStatusOutput, error) (bool, error) {
+func RetryGetResourceRequestStatus(pProgressEvent **types.ProgressEvent, cfClient *cloudformation.Client) func(context.Context, *cloudcontrol.GetResourceRequestStatusInput, *cloudcontrol.GetResourceRequestStatusOutput, error) (bool, error) {
 	return func(ctx context.Context, input *cloudcontrol.GetResourceRequestStatusInput, output *cloudcontrol.GetResourceRequestStatusOutput, err error) (bool, error) {
 		if err == nil {
 			progressEvent := output.ProgressEvent
@@ -31,10 +33,38 @@ func RetryGetResourceRequestStatus(pProgressEvent **types.ProgressEvent) func(co
 					return false, nil
 				}
 
+				// Attempt to retrieve hook results
+				hookResultsMsg := ""
+				if progressEvent.StatusMessage != nil {
+					hookResults, hookErr := fetchHookResults(ctx, cfClient, aws.ToString(progressEvent.StatusMessage))
+					if hookErr == nil && hookResults != "" {
+						hookResultsMsg = fmt.Sprintf(" Hook results: \n%s", hookResults)
+					}
+					return false, fmt.Errorf("%s", hookResultsMsg)
+				}
+
 				return false, fmt.Errorf("waiter state transitioned to %s. StatusMessage: %s. ErrorCode: %s", value, aws.ToString(progressEvent.StatusMessage), progressEvent.ErrorCode)
 			}
 		}
-
 		return true, err
 	}
+}
+
+func fetchHookResults(ctx context.Context, cfClient *cloudformation.Client, hookRequestToken string) (string, error) {
+	input := &cloudformation.ListHookResultsInput{
+		TargetId:   aws.String(hookRequestToken),
+		TargetType: "CLOUD_CONTROL",
+	}
+
+	output, err := cfClient.ListHookResults(ctx, input)
+	if err != nil {
+		return "", err
+	}
+
+	var details []string
+	for _, hook := range output.HookResults {
+		details = append(details, fmt.Sprintf("StatusReason: %s", aws.ToString(hook.HookStatusReason)))
+	}
+
+	return strings.Join(details, "\n"), nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

## Description

Currently, when a Terraform deployment fails due to a hook-related issue, the `terraform apply` command provides only a generic status message. This lack of specificity makes it challenging for users to identify which rule check failed, leading to difficulties in debugging and resolving deployment issues.

### Proposed Solution

This PR enhances the error reporting mechanism by integrating with the AWS CloudFormation `ListHookResults` API. By querying this API upon a hook failure, we can retrieve detailed information about the specific hook and rule that caused the failure. This additional context will be included in the error message displayed to the user, facilitating quicker identification and resolution of issues.

### Implementation Details

- Upon detecting a hook failure during `terraform apply`, the provider will make a request to the CloudFormation `ListHookResults` API.
- The response will be parsed to extract relevant details about the failed hook and rule.
- The extracted information will be formatted and included in the error message presented to the user.

### Benefits

- Provides users with precise information about hook failures, improving the debugging experience.
- Reduces the time and effort required to identify and fix deployment issues related to hooks.
- Enhances the overall user experience by delivering more informative and actionable error messages.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->