### PR TITLE
fix: re-order patch operations on remove

### DIFF
--- a/internal/generic/patch.go
+++ b/internal/generic/patch.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package generic
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mattbaird/jsonpatch"
+)
+
+// patchDocument returns a JSON Patch document describing the difference between `old` and `new`.
+// It sorts remove operations to ensure they are applied in reverse order to avoid index out of bounds errors.
+func patchDocument(old, new string) (string, error) {
+	patch, err := jsonpatch.CreatePatch([]byte(old), []byte(new))
+	if err != nil {
+		return "", err
+	}
+
+	// Sort the patch operations to ensure remove operations are applied in reverse order
+	sortedPatch := sortPatchOperations(patch)
+
+	// Ensure we always have a valid JSON array, even if empty
+	if len(sortedPatch) == 0 {
+		return "[]", nil
+	}
+
+	b, err := json.Marshal(sortedPatch)
+	if err != nil {
+		return "", err
+	}
+
+	// Verify that the marshaled JSON starts with '[' to ensure it's a valid JSON array
+	result := string(b)
+	if !strings.HasPrefix(result, "[") {
+		return "[]", fmt.Errorf("generated patch document is not a valid JSON array: %s", result)
+	}
+
+	return result, nil
+}
+
+// sortPatchOperations sorts the patch operations to ensure that remove operations
+// are applied in reverse order (highest index first) to avoid index out of bounds errors.
+func sortPatchOperations(patch []jsonpatch.JsonPatchOperation) []jsonpatch.JsonPatchOperation {
+	// First, separate remove operations from other operations
+	var removeOps []jsonpatch.JsonPatchOperation
+	var otherOps []jsonpatch.JsonPatchOperation
+
+	for _, op := range patch {
+		if op.Operation == "remove" {
+			removeOps = append(removeOps, op)
+		} else {
+			otherOps = append(otherOps, op)
+		}
+	}
+
+	// Sort remove operations by path in reverse order
+	sort.Slice(removeOps, func(i, j int) bool {
+		return removeOps[i].Path > removeOps[j].Path
+	})
+
+	// Combine the operations back together with remove operations first
+	return append(removeOps, otherOps...)
+}

--- a/internal/generic/resource.go
+++ b/internal/generic/resource.go
@@ -5,7 +5,6 @@ package generic
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -24,7 +23,6 @@ import (
 	ccdiag "github.com/hashicorp/terraform-provider-awscc/internal/errs/diag"
 	tfcloudcontrol "github.com/hashicorp/terraform-provider-awscc/internal/service/cloudcontrol"
 	"github.com/hashicorp/terraform-provider-awscc/internal/tfresource"
-	"github.com/mattbaird/jsonpatch"
 )
 
 // ResourceOptionsFunc is a type alias for a resource type functional option.
@@ -775,23 +773,6 @@ func (r *genericResource) bootstrapContext(ctx context.Context) context.Context 
 	ctx = r.provider.RegisterLogger(ctx)
 
 	return ctx
-}
-
-// patchDocument returns a JSON Patch document describing the difference between `old` and `new`.
-func patchDocument(old, new string) (string, error) {
-	patch, err := jsonpatch.CreatePatch([]byte(old), []byte(new))
-
-	if err != nil {
-		return "", err
-	}
-
-	b, err := json.Marshal(patch)
-
-	if err != nil {
-		return "", err
-	}
-
-	return string(b), nil
 }
 
 // propertyPathToAttributePath returns the AttributePath for the specified JSON Pointer property path.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Sorted the JSON Patch operations so that remove operations are applied in reverse order (highest index first). This ensures that removing an item at a higher index doesn't affect the position of items at lower indexes that still need to be removed.

1. Created a new file `internal/generic/patch.go` with improved patch handling
2. Implemented a function to sort patch operations, ensuring remove operations are applied in reverse order
3. Modified the existing code to use this new implementation

* #2273
* #2075

