### PR TITLE
Add post-promote-production workflow

### DIFF
--- a/.github/workflows/post-promote-production.yml
+++ b/.github/workflows/post-promote-production.yml
@@ -1,0 +1,154 @@
+name: post-promote-production
+
+on:
+  repository_dispatch:
+    types:
+      - post-promote-production
+      - post-promote-production::*
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  # The CRT workflow that calls this workflow has a timeout of 100 minutes, at which point it uses the API
+  # to cancel the workflow, so using an infinite loop rather than a specific number of retries.
+  registry-check:
+    name: Check Terraform Registry for Latest Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release-data.outputs.version }}
+    steps:
+      - name: Await Ingest
+        id: release-data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LATEST_GITHUB_RELEASE=$(gh release list --repo hashicorp/terraform-provider-aws --json name,isLatest --jq '.[] | select(.isLatest).name')
+
+          while :
+          do
+            LATEST_REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/323/provider-versions/latest")
+            LATEST_REGISTRY_VERSION=$(echo "$LATEST_REGISTRY_DATA" | jq -r '.data.attributes.tag')
+
+            if [[ "$LATEST_GITHUB_RELEASE" == "$LATEST_REGISTRY_VERSION" ]]; then
+              echo "Registry is now in sync with GitHub"
+              echo "version=$(echo $LATEST_REGISTRY_DATA | jq -r '.data.attributes.version')" >> "$GITHUB_OUTPUT"
+              break
+            else
+              echo "Latest Registry version ($LATEST_REGISTRY_VERSION) does not yet match lastest GitHub version ($LATEST_GITHUB_RELEASE). Waiting..."
+              sleep 300
+            fi
+          done
+
+  init-check:
+    name: Initialize Provider
+    needs: [registry-check]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_wrapper: false
+
+      - name: Set Provider Version in Terraform Configuration
+        run: |
+          cat <<EOF > main.tf
+          terraform {
+            required_providers {
+              aws = {
+                source  = "hashicorp/aws"
+                version = "${{ needs.registry-check.outputs.version }}"
+              }
+            }
+          }
+
+          provider "aws" {
+            region = "us-east-1"
+          }
+          EOF
+
+      # Explicitly setting '+o pipefail' here, as GitHub uses 'set -eo pipefail' for the bash shell
+      # and we need to capture error messages rather than outright fail
+      - name: Initialize
+        id: init
+        run: |
+          set +o pipefail
+          ERROR=$(terraform init -upgrade -json | jq --slurp '.[] | select(.diagnostic.severity == "error")')
+
+          if [[ $ERROR != "" ]]; then
+            echo "formatted_error=$(echo $ERROR | jq '.["@message"] + "\n\n" + .diagnostic.detail | @json')" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+
+      - name: Send Slack Notification on Initialization Failure
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel" : "${{ secrets.SLACK_CHANNEL }}",
+              "text": "Provider initialization for version ${{ needs.registry-check.outputs.version }} on ${{ matrix.os }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":warning: Provider initialization for version ${{ needs.registry-check.outputs.version }} on ${{ matrix.os }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                		{
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": "The output from initialization is included below. The run logs may be found at"
+                        },
+                        {
+                          "type": "link",
+                          "text": " this link.",
+                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": "\n\nRun output:",
+                          "style": {
+                            "bold": true
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": ${{ fromJSON(steps.init.outputs.formatted_error) }}
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/post-promote-production.yml
+++ b/.github/workflows/post-promote-production.yml
@@ -87,7 +87,6 @@ jobs:
             exit 1
           fi
 
-
       - name: Send Slack Notification on Initialization Failure
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/post-promote-production.yml
+++ b/.github/workflows/post-promote-production.yml
@@ -27,11 +27,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          LATEST_GITHUB_RELEASE=$(gh release list --repo hashicorp/terraform-provider-aws --json name,isLatest --jq '.[] | select(.isLatest).name')
+          LATEST_GITHUB_RELEASE=$(gh release list --json name,isLatest --jq '.[] | select(.isLatest).name')
 
           while :
           do
-            LATEST_REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/323/provider-versions/latest")
+            LATEST_REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/2242/provider-versions/latest")
             LATEST_REGISTRY_VERSION=$(echo "$LATEST_REGISTRY_DATA" | jq -r '.data.attributes.tag')
 
             if [[ "$LATEST_GITHUB_RELEASE" == "$LATEST_REGISTRY_VERSION" ]]; then
@@ -62,14 +62,14 @@ jobs:
           cat <<EOF > main.tf
           terraform {
             required_providers {
-              aws = {
-                source  = "hashicorp/aws"
+              awscc = {
+                source  = "hashicorp/awscc"
                 version = "${{ needs.registry-check.outputs.version }}"
               }
             }
           }
 
-          provider "aws" {
+          provider "awscc" {
             region = "us-east-1"
           }
           EOF

--- a/.github/workflows/post-promote-production.yml
+++ b/.github/workflows/post-promote-production.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
-          gh workflow run --repo ${{ github.repository }} --ref main slack-test.yml
+          gh workflow run --repo ${{ github.repository }} --ref main registry-check.yml

--- a/.github/workflows/post-promote-production.yml
+++ b/.github/workflows/post-promote-production.yml
@@ -6,149 +6,23 @@ on:
       - post-promote-production
       - post-promote-production::*
 
-defaults:
-  run:
-    shell: bash
-
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  # The CRT workflow that calls this workflow has a timeout of 100 minutes, at which point it uses the API
-  # to cancel the workflow, so using an infinite loop rather than a specific number of retries.
-  registry-check:
-    name: Check Terraform Registry for Latest Version
+  start-registry-check:
+    name: Start Registry Check
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.release-data.outputs.version }}
     steps:
-      - name: Await Ingest
-        id: release-data
+      - name: Generate GitHub App Token
+        id: token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
+
+      - name: Initiate Workflow
+        shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
-          LATEST_GITHUB_RELEASE=$(gh release list --json name,isLatest --jq '.[] | select(.isLatest).name')
-
-          while :
-          do
-            LATEST_REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/2242/provider-versions/latest")
-            LATEST_REGISTRY_VERSION=$(echo "$LATEST_REGISTRY_DATA" | jq -r '.data.attributes.tag')
-
-            if [[ "$LATEST_GITHUB_RELEASE" == "$LATEST_REGISTRY_VERSION" ]]; then
-              echo "Registry is now in sync with GitHub"
-              echo "version=$(echo $LATEST_REGISTRY_DATA | jq -r '.data.attributes.version')" >> "$GITHUB_OUTPUT"
-              break
-            else
-              echo "Latest Registry version ($LATEST_REGISTRY_VERSION) does not yet match lastest GitHub version ($LATEST_GITHUB_RELEASE). Waiting..."
-              sleep 300
-            fi
-          done
-
-  init-check:
-    name: Initialize Provider
-    needs: [registry-check]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_wrapper: false
-
-      - name: Set Provider Version in Terraform Configuration
-        run: |
-          cat <<EOF > main.tf
-          terraform {
-            required_providers {
-              awscc = {
-                source  = "hashicorp/awscc"
-                version = "${{ needs.registry-check.outputs.version }}"
-              }
-            }
-          }
-
-          provider "awscc" {
-            region = "us-east-1"
-          }
-          EOF
-
-      # Explicitly setting '+o pipefail' here, as GitHub uses 'set -eo pipefail' for the bash shell
-      # and we need to capture error messages rather than outright fail
-      # Reference: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
-      - name: Initialize
-        id: init
-        run: |
-          set +o pipefail
-          ERROR=$(terraform init -upgrade -json | jq --slurp '.[] | select(.diagnostic.severity == "error")')
-
-          if [[ $ERROR != "" ]]; then
-            echo "formatted_error=$(echo $ERROR | jq '.["@message"] + "\n\n" + .diagnostic.detail | @json')" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-      - name: Send Slack Notification on Initialization Failure
-        if: ${{ failure() }}
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel" : "${{ secrets.SLACK_CHANNEL }}",
-              "text": "Provider initialization for version ${{ needs.registry-check.outputs.version }} on ${{ matrix.os }}",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": ":warning: Provider initialization for version ${{ needs.registry-check.outputs.version }} on ${{ matrix.os }}",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "rich_text",
-                  "elements": [
-                		{
-                      "type": "rich_text_section",
-                      "elements": [
-                        {
-                          "type": "text",
-                          "text": "The output from initialization is included below. The run logs may be found at"
-                        },
-                        {
-                          "type": "link",
-                          "text": " this link.",
-                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "rich_text_section",
-                      "elements": [
-                        {
-                          "type": "text",
-                          "text": "\n\nRun output:",
-                          "style": {
-                            "bold": true
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "rich_text_preformatted",
-                      "elements": [
-                        {
-                          "type": "text",
-                          "text": ${{ fromJSON(steps.init.outputs.formatted_error) }}
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+          gh workflow run --repo ${{ github.repository }} --ref main slack-test.yml

--- a/.github/workflows/post-promote-production.yml
+++ b/.github/workflows/post-promote-production.yml
@@ -25,4 +25,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
-          gh workflow run --repo ${{ github.repository }} --ref main registry-check.yml
+          gh workflow run \
+            --repo ${{ github.repository }} \
+            --ref main \
+            --field version=${{ github.event.client_payload.payload.version }} \
+            registry-check.yml

--- a/.github/workflows/post-promote-production.yml
+++ b/.github/workflows/post-promote-production.yml
@@ -6,24 +6,18 @@ on:
       - post-promote-production
       - post-promote-production::*
 
-permissions: {}
+permissions:
+  actions: write
 
 jobs:
   start-registry-check:
     name: Start Registry Check
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App Token
-        id: token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PEM }}
-
       - name: Initiate Workflow
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run \
             --repo ${{ github.repository }} \

--- a/.github/workflows/post-promote-production.yml
+++ b/.github/workflows/post-promote-production.yml
@@ -76,6 +76,7 @@ jobs:
 
       # Explicitly setting '+o pipefail' here, as GitHub uses 'set -eo pipefail' for the bash shell
       # and we need to capture error messages rather than outright fail
+      # Reference: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
       - name: Initialize
         id: init
         run: |

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -2,7 +2,7 @@ on:
   workflow_dispatch:
     inputs:
       timeout:
-        description: The number of minutes to wait for Registry ingress
+        description: The number of minutes to wait for Registry ingest
         required: true
         default: 120
       version:
@@ -19,7 +19,7 @@ jobs:
     name: Check Terraform Registry for Latest Version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.registry-version.outputs.latest }}
+      version: ${{ steps.registry-ingest.outputs.version }}
       channel: ${{ steps.message.outputs.channel_id }}
       ts: ${{ steps.message.outputs.ts }}
     steps:
@@ -111,7 +111,7 @@ jobs:
             }
 
       - name: Await Ingest
-        id: registry-version
+        id: registry-ingest
         env:
           VERSION: ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}
         run: |
@@ -148,16 +148,16 @@ jobs:
               break
             fi
 
-            LATEST_REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/2242/provider-versions/latest")
-            LATEST_REGISTRY_VERSION_TAG=$(echo "$LATEST_REGISTRY_DATA" | jq -r '.data.attributes.tag')
+            REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/2242/provider-versions" | jq --arg version $VERSION '.data[] | select(.attributes.tag == $version)')
 
-            if [[ "$VERSION" == "$LATEST_REGISTRY_VERSION_TAG" ]]; then
-              echo "Registry is now in sync with GitHub"
+            if [[ -z "$REGISTRY_DATA" ]]; then
+              echo "Terraform Registry has not yet ingested version $VERSION. Continuing to wait for ingest..."
+              sleep 30
+            else
+              echo "Registry has ingested version $VERSION"
+              echo "version=$(echo $REGISTRY_DATA | jq -r '.attributes.version')" >> "$GITHUB_OUTPUT"
 
-              LATEST_REGISTRY_VERSION=$(echo $LATEST_REGISTRY_DATA | jq -r '.data.attributes.version')
-              echo "latest=$LATEST_REGISTRY_VERSION" >> "$GITHUB_OUTPUT"
-
-              UPDATED_BLOCKS=$(echo $LATEST_REGISTRY_DATA | jq -c '[
+              UPDATED_BLOCKS=$(jq -nc --arg version $VERSION '[
                 {
                   "type": "rich_text",
                   "elements": [
@@ -170,7 +170,7 @@ jobs:
                         },
                         {
                           "type": "text",
-                          "text": (" Terraform Registry has ingested version " + .data.attributes.tag + ". Initialization testing details will be threaded below.")
+                          "text": (" Terraform Registry has ingested version " + $version + ". Initialization testing details will be threaded below.")
                         }
                       ]
                     }
@@ -179,9 +179,6 @@ jobs:
               ]')
 
               break
-            else
-              echo "Terraform Registry has not yet ingressed version $VERSION. Continuing to wait for ingress..."
-              sleep 300
             fi
           done
 
@@ -202,7 +199,7 @@ jobs:
               "channel": "${{ steps.message.outputs.channel_id }}",
               "ts": "${{ steps.message.outputs.ts }}",
               "as_user": true,
-              "blocks": ${{ fromJSON(steps.registry-version.outputs.slack-payload-blocks) }}
+              "blocks": ${{ fromJSON(steps.registry-ingest.outputs.slack-payload-blocks) }}
             }
 
   init-check:

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -152,7 +152,7 @@ jobs:
 
             if [[ -z "$REGISTRY_DATA" ]]; then
               echo "Terraform Registry has not yet ingested version $VERSION. Continuing to wait for ingest..."
-              sleep 30
+              sleep 300
             else
               echo "Registry has ingested version $VERSION"
               echo "version=$(echo $REGISTRY_DATA | jq -r '.attributes.version')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -33,13 +33,15 @@ jobs:
 
       - name: Set Up Initial Slack Message Blocks
         id: parent
+        env:
+          VERSION: ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}
         run: |
-          BASE_MESSAGE_BLOCKS=$(jq -nc '[
+          BASE_MESSAGE_BLOCKS=$(jq -nc --arg version $VERSION '[
             {
               "type": "header",
               "text": {
                 "type": "plain_text",
-                "text": "Initialization Check for awscc Version ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}"
+                "text": ("Initialization Check for awscc Version " + $version)
               }
             },
             {
@@ -70,7 +72,7 @@ jobs:
             }
           ]')
 
-          INITIAL_MESSAGE_ADDITION=$(jq -nc '[
+          INITIAL_MESSAGE_ADDITION=$(jq -nc --arg version $VERSION '[
             {
               "type": "rich_text",
               "elements": [
@@ -83,7 +85,7 @@ jobs:
                     },
                     {
                       "type": "text",
-                      "text": " Waiting on Terraform Registry to ingest version ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}..."
+                      "text": (" Waiting on Terraform Registry to ingest version " + $version + "...")
                     }
                   ]
                 }
@@ -110,6 +112,8 @@ jobs:
 
       - name: Await Ingest
         id: registry-version
+        env:
+          VERSION: ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}
         run: |
           SECONDS=0
 
@@ -120,7 +124,7 @@ jobs:
               echo "Timeout has been reached, exiting."
               TIMED_OUT="true"
 
-              UPDATED_BLOCKS=$(jq -nc '[
+              UPDATED_BLOCKS=$(jq -nc --arg version $VERSION '[
                 {
                   "type": "rich_text",
                   "elements": [
@@ -133,7 +137,7 @@ jobs:
                         },
                         {
                           "type": "text",
-                          "text": " Timed out while waiting for the Terraform Registry to ingest version ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}"
+                          "text": (" Timed out while waiting for the Terraform Registry to ingest version " + $version)
                         }
                       ]
                     }
@@ -147,7 +151,7 @@ jobs:
             LATEST_REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/2242/provider-versions/latest")
             LATEST_REGISTRY_VERSION_TAG=$(echo "$LATEST_REGISTRY_DATA" | jq -r '.data.attributes.tag')
 
-            if [[ "${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}" == "$LATEST_REGISTRY_VERSION_TAG" ]]; then
+            if [[ "$VERSION" == "$LATEST_REGISTRY_VERSION_TAG" ]]; then
               echo "Registry is now in sync with GitHub"
 
               LATEST_REGISTRY_VERSION=$(echo $LATEST_REGISTRY_DATA | jq -r '.data.attributes.version')
@@ -176,7 +180,7 @@ jobs:
 
               break
             else
-              echo "Latest Registry version tag ($LATEST_REGISTRY_VERSION_TAG) does not yet match lastest GitHub release tag (${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}). Waiting..."
+              echo "Terraform Registry has not yet ingressed version $VERSION. Continuing to wait for ingress..."
               sleep 300
             fi
           done

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -5,6 +5,10 @@ on:
         description: The number of minutes to wait for Registry ingress
         required: true
         default: 120
+      version:
+        description: |
+          The version of the provider to test initialization for. If unset, will use the version pulled from the latest GitHub release.
+        required: false
 
 defaults:
   run:
@@ -20,6 +24,7 @@ jobs:
       ts: ${{ steps.message.outputs.ts }}
     steps:
       - name: Get Latest GitHub Release
+        if: inputs.version == ''
         id: github-release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -34,7 +39,7 @@ jobs:
               "type": "header",
               "text": {
                 "type": "plain_text",
-                "text": "Initialization Check for awscc Version ${{ steps.github-release.outputs.tag }}"
+                "text": "Initialization Check for awscc Version ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}"
               }
             },
             {
@@ -78,7 +83,7 @@ jobs:
                     },
                     {
                       "type": "text",
-                      "text": " Waiting on Terraform Registry to ingest version ${{ steps.github-release.outputs.tag }}..."
+                      "text": " Waiting on Terraform Registry to ingest version ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}..."
                     }
                   ]
                 }
@@ -128,7 +133,7 @@ jobs:
                         },
                         {
                           "type": "text",
-                          "text": " Timed out while waiting for the Terraform Registry to ingest version ${{ steps.github-release.outputs.tag }}"
+                          "text": " Timed out while waiting for the Terraform Registry to ingest version ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}"
                         }
                       ]
                     }
@@ -142,7 +147,7 @@ jobs:
             LATEST_REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/2242/provider-versions/latest")
             LATEST_REGISTRY_VERSION_TAG=$(echo "$LATEST_REGISTRY_DATA" | jq -r '.data.attributes.tag')
 
-            if [[ "${{ steps.github-release.outputs.tag }}" == "$LATEST_REGISTRY_VERSION_TAG" ]]; then
+            if [[ "${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}" == "$LATEST_REGISTRY_VERSION_TAG" ]]; then
               echo "Registry is now in sync with GitHub"
 
               LATEST_REGISTRY_VERSION=$(echo $LATEST_REGISTRY_DATA | jq -r '.data.attributes.version')
@@ -171,7 +176,7 @@ jobs:
 
               break
             else
-              echo "Latest Registry version tag ($LATEST_REGISTRY_VERSION_TAG) does not yet match lastest GitHub release tag (${{ steps.github-release.outputs.tag }}). Waiting..."
+              echo "Latest Registry version tag ($LATEST_REGISTRY_VERSION_TAG) does not yet match lastest GitHub release tag (${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}). Waiting..."
               sleep 300
             fi
           done

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -1,0 +1,350 @@
+on:
+  workflow_dispatch:
+    inputs:
+      timeout:
+        description: The number of minutes to wait for Registry ingress
+        required: false
+        default: 120
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  registry-check:
+    name: Check Terraform Registry for Latest Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.registry-version.outputs.latest }}
+      channel: ${{ steps.message.outputs.channel_id }}
+      ts: ${{ steps.message.outputs.ts }}
+    steps:
+      - name: Get Latest GitHub Release
+        id: github-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "tag=$(gh release list --repo ${{ github.repository }} --json name,isLatest --jq '.[] | select(.isLatest).name')" >> "$GITHUB_OUTPUT"
+
+      - name: Set Up Initial Slack Message Blocks
+        id: parent
+        run: |
+          BASE_MESSAGE_BLOCKS=$(jq -nc '[
+            {
+              "type": "header",
+              "text": {
+                "type": "plain_text",
+                "text": "Initialization Check for awscc Version ${{ steps.github-release.outputs.tag }}"
+              }
+            },
+            {
+              "type": "divider"
+            },
+            {
+              "type": "rich_text",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "\n\nView the "
+                    },
+                    {
+                      "type": "link",
+                      "text": "Run Logs",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    },
+                    {
+                      "type": "text",
+                      "text": " for additional information.\n\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]')
+
+          INITIAL_MESSAGE_ADDITION=$(jq -nc '[
+            {
+              "type": "rich_text",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "emoji",
+                      "name": "waiting-spin"
+                    },
+                    {
+                      "type": "text",
+                      "text": " Waiting on Terraform Registry to ingest version ${{ steps.github-release.outputs.tag }}..."
+                    }
+                  ]
+                }
+              ]
+            }
+          ]')
+
+          echo "base-message-blocks=$(echo $BASE_MESSAGE_BLOCKS | jq '. | @json')" >> "$GITHUB_OUTPUT"
+
+          echo "initial-message-blocks=$(echo $BASE_MESSAGE_BLOCKS | jq --argjson addition "$INITIAL_MESSAGE_ADDITION" '. += $addition | @json')" >> "$GITHUB_OUTPUT"
+
+      - name: Post Initial Slack Message
+        id: message
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_CHANNEL }}",
+              "text": "Testing Provider Initialization",
+              "blocks": ${{ fromJSON(steps.parent.outputs.initial-message-blocks) }}
+            }
+
+      - name: Await Ingest
+        id: registry-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SECONDS=0
+
+          while :
+          do
+
+            if [[ $(($SECONDS/60)) -ge ${{ inputs.timeout }} ]]; then
+              echo "Timeout has been reached, exiting."
+              TIMED_OUT="true"
+
+              UPDATED_BLOCKS=$(jq -nc '[
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "failure"
+                        },
+                        {
+                          "type": "text",
+                          "text": " Timed out while waiting for the Terraform Registry to ingest version ${{ steps.github-release.outputs.tag }}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]')
+
+              break
+            fi
+
+            LATEST_REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/2242/provider-versions/latest")
+            LATEST_REGISTRY_VERSION_TAG=$(echo "$LATEST_REGISTRY_DATA" | jq -r '.data.attributes.tag')
+
+            if [[ "${{ steps.github-release.outputs.tag }}" == "$LATEST_REGISTRY_VERSION_TAG" ]]; then
+              echo "Registry is now in sync with GitHub"
+
+              LATEST_REGISTRY_VERSION=$(echo $LATEST_REGISTRY_DATA | jq -r '.data.attributes.version')
+              echo "latest=$LATEST_REGISTRY_VERSION" >> "$GITHUB_OUTPUT"
+
+              UPDATED_BLOCKS=$(echo $LATEST_REGISTRY_DATA | jq -c '[
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "bufo-check"
+                        },
+                        {
+                          "type": "text",
+                          "text": (" Terraform Registry has ingested version " + .data.attributes.tag + ". Initialization testing details will be threaded below.")
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]')
+
+              break
+            else
+              echo "Latest Registry version tag ($LATEST_REGISTRY_VERSION_TAG) does not yet match lastest GitHub release tag (${{ steps.github-release.outputs.tag }}). Waiting..."
+              sleep 300
+            fi
+          done
+
+          echo "slack-payload-blocks=$(echo ${{ steps.parent.outputs.base-message-blocks }} | jq --argjson update "$UPDATED_BLOCKS" '. += $update | @json')" >> "$GITHUB_OUTPUT"
+
+          if [[ "$TIMED_OUT" == "true" ]]; then
+            exit 1
+          fi
+
+      - name: Update Initial Slack Message
+        if: ${{ success() || failure() }}
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ steps.message.outputs.channel_id }}",
+              "ts": "${{ steps.message.outputs.ts }}",
+              "as_user": true,
+              "blocks": ${{ fromJSON(steps.registry-version.outputs.slack-payload-blocks) }}
+            }
+
+  init-check:
+    name: Initialize Provider
+    needs: [registry-check]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Add Status Update Message in Thread
+        id: thread-message
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ needs.registry-check.outputs.channel }}",
+              "text": "Initialization details for ${{ matrix.os }}",
+              "thread_ts": "${{ needs.registry-check.outputs.ts }}",
+              "blocks": [
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "waiting-spin"
+                        },
+                        {
+                          "type": "text",
+                          "text": " Initialization check on ${{ matrix.os }} is running..."
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_wrapper: false
+
+      - name: Set Provider Version in Terraform Configuration
+        run: |
+          cat <<EOF > main.tf
+          terraform {
+            required_providers {
+              awscc = {
+                source  = "hashicorp/awscc"
+                version = "${{ needs.registry-check.outputs.version }}"
+              }
+            }
+          }
+
+          provider "awscc" {
+            region = "us-east-1"
+          }
+          EOF
+
+      # Explicitly setting '+o pipefail' here, as GitHub uses 'set -eo pipefail' for the bash shell
+      # and we need to capture error messages rather than outright fail
+      # Reference:
+      # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+      - name: Initialize
+        id: init
+        run: |
+          set +o pipefail
+          ERROR=$(terraform init -upgrade -json | jq --slurp '.[] | select(.diagnostic.severity == "error")')
+
+          if [[ "$ERROR" == "" ]]; then
+            echo "payload=$(jq -nc '[
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "emoji",
+                        "name": "bufo-check"
+                      },
+                      {
+                        "type": "text",
+                        "text": " Initialization on ${{ matrix.os }} succeeded"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ] | @json')" >> "$GITHUB_OUTPUT"
+          else
+            echo "payload=$(echo $ERROR | jq -c '[
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "emoji",
+                        "name": "failure"
+                      },
+                      {
+                        "type": "text",
+                        "text": " Initialization on ${{ matrix.os }} failed."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "\n\n The error produced during initialization was:"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": (.["@message"] + "\n\n" + .diagnostic.detail)
+                      }
+                    ]
+                  }
+                ]
+              }
+            ] | @json')" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Update Threaded Message with Results
+        if: ${{ success() || failure() }}
+        id: thread-message-update
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ needs.registry-check.outputs.channel }}",
+              "as_user": true,
+              "ts": "${{ steps.thread-message.outputs.ts }}",
+              "blocks": ${{ fromJSON(steps.init.outputs.payload) }}
+            }

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -105,8 +105,6 @@ jobs:
 
       - name: Await Ingest
         id: registry-version
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           SECONDS=0
 

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       timeout:
         description: The number of minutes to wait for Registry ingress
-        required: false
+        required: true
         default: 120
 
 defaults:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -93,7 +93,7 @@ event "promote-production" {
 
     post-promotion {
       organization = "hashicorp"
-      repo = "terraform-provider-awscc"
+      repository = "terraform-provider-awscc"
       workflow = "post-promote-production"
     }
   }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -94,7 +94,7 @@ event "promote-production" {
     post-promotion {
       organization = "hashicorp"
       repository = "terraform-provider-awscc"
-      workflow = "post-promote-production"
+      workflow = "post-promote-production.yml"
     }
   }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -88,6 +88,16 @@ event "promote-production" {
     config       = ""
   }
 
+  promotion-events {
+    bump-version-patch = true
+
+    post-promotion {
+      organization = "hashicorp"
+      repo = "terraform-provider-awscc"
+      workflow = "post-promote-production"
+    }
+  }
+
   depends = ["trigger-production"]
 
   notification {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

This PR adds a workflow to be run after the CRT workflow for promoting to production. The workflow itself is similar to what we have in the mainline AWS provider for testing that the provider can be initialized.

A few notes, since this process isn't well documented:

> [!WARNING]
> We need to verify that the GitHub App used to generate the token has read access to metadata and write access to actions in order for this to work.

#### CRT-related changes

- [This is the section](https://github.com/hashicorp/crt-workflows-common/blob/ec6d7f4365e35c406fd59c579fb07a7f8b263d22/.github/workflows/crt-promote-production.yml#L487-L513) of the `crt-promote-production` workflow that calls the [`crt-post-promote-production` reusable workflow](https://github.com/hashicorp/crt-workflows-common/blob/main/.github/workflows/crt-post-promote-production.yml).
- [This section](https://github.com/hashicorp/crt-core-helloworld/blob/6a324c01eef7b53a81c437da4ad8d219d3fc7238/.release/ci.hcl#L65-L73) of the `crt-core-helloworld` repo is where I pulled the prior art for configuring the `.release/ci.hcl` changes. That didn't really tell me everything I needed to know to confidently make the changes, so I also referenced the [struct definitions](https://github.com/hashicorp/crt-orchestrator/blob/8282b6546d222099b250b3c3d342b9d38f49a380/internal/config/event.go#L3-L27) in the `crt-orchestrator` repo

#### Relating to the workflow 

- By using the `gh` CLI to trigger a run of the `registry-check` workflow, the `post-promote-production` workflow is not dependent on the initialization check in order to finish, preventing the release process from failing due to the initialization check being held up by Registry ingress.
- By default, the `registry-check` workflow will time out after 2 hours, but that can be adjusted by either changing the default value for the `timeout` input, or by specifying a value for the `timeout` variable when triggering the workflow.
- Since the `registry-check` workflow is triggered by `workflow_dispatch`, we can manually re-trigger the workflow in order to test again if it happens to fail.
- The `registry-check` workflow takes an input of `version`, allowing us to optionally pass a specific version to test initialization for. For CRT usage, the version is pulled from the payload delivered by CRT. When triggering manually, we can optionally choose a specific version, or alternatively, let the `gh` CLI pull the latest release from GitHub and use that version.

#### Other notes

- In addition to running the workflow defined in this PR, the changes to `.release/ci.hcl` also set CRT to bump the version defined in `version/VERSION`. If that's not desirable at this time, it wouldn't affect the workflow to remove that bit.
- Since we can only trigger one workflow via the `crt-post-promote-production` pipeline, if there's other actions we want to take, we'd either need to add additional jobs, or configure this workflow to call out to trigger other workflows. With that in mind, this is just a starting point / proof of functionality.