### PR TITLE
Rework registry-check to wait for initialization

### DIFF
--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -21,8 +21,9 @@ jobs:
     name: Check Terraform Registry for Latest Version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.registry-ingest.outputs.version }}
+      elapsed-time: ${{ steps.registry-ingest.outputs.elapsed-time }}
       ts: ${{ steps.message.outputs.ts }}
+      version: ${{ steps.registry-ingest.outputs.version }}
     steps:
       - name: Get Latest GitHub Release
         if: inputs.version == ''
@@ -121,44 +122,10 @@ jobs:
           while :
           do
 
-            if [[ $(($SECONDS/60)) -ge ${{ inputs.timeout }} ]]; then
-              echo "Timeout has been reached, exiting."
-              TIMED_OUT="true"
-
-              UPDATED_BLOCKS=$(jq -nc --arg version $VERSION '[
-                {
-                  "type": "rich_text",
-                  "elements": [
-                    {
-                      "type": "rich_text_section",
-                      "elements": [
-                        {
-                          "type": "emoji",
-                          "name": "failure"
-                        },
-                        {
-                          "type": "text",
-                          "text": (" Timed out while waiting for the Terraform Registry to ingest version " + $version)
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]')
-
-              break
-            fi
-
             REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/2242/provider-versions" | jq --arg version $VERSION '.data[] | select(.attributes.tag == $version)')
 
-            if [[ -z "$REGISTRY_DATA" ]]; then
-              echo "Terraform Registry has not yet ingested version $VERSION. Continuing to wait for ingest..."
-              sleep 300
-            else
-              echo "Registry has ingested version $VERSION"
-              echo "version=$(echo $REGISTRY_DATA | jq -r '.attributes.version')" >> "$GITHUB_OUTPUT"
-
-              UPDATED_BLOCKS=$(jq -nc --arg version $VERSION '[
+            if ! [[ -z $REGISTRY_DATA ]]; then
+              echo "slack-payload-blocks=$(echo ${{ steps.parent.outputs.base-message-blocks }} | jq --arg version $VERSION '. += [
                 {
                   "type": "rich_text",
                   "elements": [
@@ -177,17 +144,43 @@ jobs:
                     }
                   ]
                 }
-              ]')
+              ] | @json')" >> "$GITHUB_OUTPUT"
 
+              echo "Registry has ingested version $VERSION"
+              echo "elapsed-time=$SECONDS" >> "$GITHUB_OUTPUT"
+              echo "version=$(echo $REGISTRY_DATA | jq -r '.attributes.version')" >> "$GITHUB_OUTPUT"
               break
+
+            elif [[ $(($SECONDS/60)) -ge ${{ inputs.timeout }} ]]; then
+              echo "slack-payload-blocks=$(echo ${{ steps.parent.outputs.base-message-blocks }} | jq --arg version $VERSION '. += [
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "failure"
+                        },
+                        {
+                          "type": "text",
+                          "text": (" Timed out while waiting for the Terraform Registry to ingest version " + $version)
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ] | @json')" >> "$GITHUB_OUTPUT"
+
+              echo "Timed out while waiting for the Terraform Registry to ingest version $VERSION" >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+
+            else
+              echo "Terraform Registry has not yet ingested version $VERSION. Continuing to wait for ingest..."
+              sleep 300
             fi
           done
-
-          echo "slack-payload-blocks=$(echo ${{ steps.parent.outputs.base-message-blocks }} | jq --argjson update "$UPDATED_BLOCKS" '. += $update | @json')" >> "$GITHUB_OUTPUT"
-
-          if [[ "$TIMED_OUT" == "true" ]]; then
-            exit 1
-          fi
 
       - name: Update Initial Slack Message
         if: ${{ success() || failure() }}
@@ -274,70 +267,92 @@ jobs:
         id: init
         run: |
           set +o pipefail
-          ERROR=$(terraform init -upgrade -json | jq --slurp '.[] | select(.diagnostic.severity == "error")')
 
-          if [[ "$ERROR" == "" ]]; then
-            echo "payload=$(jq -nc '[
-              {
-                "type": "rich_text",
-                "elements": [
-                  {
-                    "type": "rich_text_section",
-                    "elements": [
-                      {
-                        "type": "emoji",
-                        "name": "bufo-check"
-                      },
-                      {
-                        "type": "text",
-                        "text": " Initialization on ${{ matrix.os }} succeeded"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ] | @json')" >> "$GITHUB_OUTPUT"
-          else
-            echo "payload=$(echo $ERROR | jq -c '[
-              {
-                "type": "rich_text",
-                "elements": [
-                  {
-                    "type": "rich_text_section",
-                    "elements": [
-                      {
-                        "type": "emoji",
-                        "name": "failure"
-                      },
-                      {
-                        "type": "text",
-                        "text": " Initialization on ${{ matrix.os }} failed."
-                      }
-                    ]
-                  },
-                  {
-                    "type": "rich_text_section",
-                    "elements": [
-                      {
-                        "type": "text",
-                        "text": "\n\n The error produced during initialization was:"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "rich_text_preformatted",
-                    "elements": [
-                      {
-                        "type": "text",
-                        "text": (.["@message"] + "\n\n" + .diagnostic.detail)
-                      }
-                    ]
-                  }
-                ]
-              }
-            ] | @json')" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
+          SECONDS=${{ fromJSON(needs.registry-check.outputs.elapsed-time) }}
+
+          while :
+          do
+
+            ERROR=$(terraform init -upgrade -json | jq --slurp '.[] | select(.diagnostic.severity == "error")')
+
+            if [[ -z $ERROR ]]; then
+              echo "payload=$(jq -nc '[
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "bufo-check"
+                        },
+                        {
+                          "type": "text",
+                          "text": " Initialization on ${{ matrix.os }} succeeded"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ] | @json')" >> "$GITHUB_OUTPUT"
+
+              break
+
+            elif [[ $(($SECONDS/60)) -ge ${{ inputs.timeout }} ]]; then
+              echo "payload=$(echo $ERROR | jq -c '[
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "failure"
+                        },
+                        {
+                          "type": "text",
+                          "text": " Initialization on ${{ matrix.os }} failed."
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": "\n\n The error produced during initialization was:"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": (.["@message"] + "\n\n" + .diagnostic.detail)
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ] | @json')" >> "$GITHUB_OUTPUT"
+
+              echo "Timeout was reached before a successful initialization." >> "$GITHUB_STEP_SUMMARY"
+              echo >> "$GITHUB_STEP_SUMMARY"
+              echo "Error received during initialization:" >> "$GITHUB_STEP_SUMMARY"
+              echo >> "$GITHUB_STEP_SUMMARY"
+              echo '```console' >> "$GITHUB_STEP_SUMMARY"
+              echo $ERROR | jq --raw-output '.["@message"] + "\n\n" + .diagnostic.detail' >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+
+            else
+              echo "Provider initialization failed, but timeout has not yet been reached. Trying again..."
+              sleep 60
+            fi
+          done
 
       - name: Update Threaded Message with Results
         if: ${{ success() || failure() }}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

- No

## Description

This PR updates the `registry-check` workflow to include a `while` loop on the initialization step to account for times where the Registry has ingested the new version's metadata, but has not yet ingested the binaries. This should prevent the errors we've seen on the last couple of releases.