### PR TITLE
fix: empty plural datasources

### DIFF
--- a/internal/service/cloudcontrol/list.go
+++ b/internal/service/cloudcontrol/list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-provider-awscc/internal/tfresource"
 )
 
 func ListResourcesByTypeName(ctx context.Context, conn *cloudcontrol.Client, roleARN, typeName string) ([]types.ResourceDescription, error) {
@@ -35,10 +34,6 @@ func ListResourcesByTypeName(ctx context.Context, conn *cloudcontrol.Client, rol
 		}
 
 		resourceDescriptions = append(resourceDescriptions, page.ResourceDescriptions...)
-	}
-
-	if len(resourceDescriptions) == 0 {
-		return nil, &tfresource.NotFoundError{Message: "Empty result"}
 	}
 
 	return resourceDescriptions, nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2225

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No.

## Description

### Changes Made:

1. Removed the error condition for empty results:
   • Deleted the check if len(resourceDescriptions) == 0 that returned NotFoundError
   • Now the function returns an empty slice []types.ResourceDescription{} when no resources are found

2. Cleaned up unused import:
   • Removed the unused "github.com/hashicorp/terraform-provider-awscc/internal/tfresource" import since we no longer use NotFoundError

### What This Fixes:

• **Before**: When no resources were found, ListResourcesByTypeName returned a NotFoundError, causing plural datasources to fail with "Empty result" error
• **After**: When no resources are found, ListResourcesByTypeName returns an empty slice, allowing plural datasources to return an empty list instead of failing
