### PR TITLE
Prepend `post-promote-production` with `crt-`

### DIFF
--- a/.github/workflows/crt-post-promote-production.yml
+++ b/.github/workflows/crt-post-promote-production.yml
@@ -1,10 +1,10 @@
-name: post-promote-production
+name: Post Promote Production
 
 on:
   repository_dispatch:
     types:
-      - post-promote-production
-      - post-promote-production::*
+      - crt-post-promote-production
+      - crt-post-promote-production::*
 
 permissions:
   actions: write

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -94,7 +94,7 @@ event "promote-production" {
     post-promotion {
       organization = "hashicorp"
       repository = "terraform-provider-awscc"
-      workflow = "post-promote-production.yml"
+      workflow = "crt-post-promote-production.yml"
     }
   }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes

## Description

This PR updates the `post-promote-production` workflow to prepend it with `crt-`, as described as a new requirement [here](https://hashicorp.atlassian.net/wiki/pages/diffpagesbyversion.action?pageId=2905604117&selectedPageVersions=4&selectedPageVersions=3). I also updated the `name` to make it a little more human-friendly.