### PR TITLE
fix: examples for awscc_networkmanager_vpc_attachment

### DIFF
--- a/docs/resources/networkmanager_vpc_attachment.md
+++ b/docs/resources/networkmanager_vpc_attachment.md
@@ -22,7 +22,46 @@ This example demonstrates how to attach a VPC to an AWS Network Manager Core Net
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-# Create VPC and subnets
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.name
+}
+
+resource "awscc_networkmanager_global_network" "example" {
+  description = "Example Global Network"
+  tags = [{
+    key   = "Modified By"
+    value = "AWSCC"
+  }]
+}
+
+# Core Network - segment-actions cannot reference attachment IDs during creation
+# as attachments don't exist yet. This creates circular dependencies on both
+# create and destroy operations. Use blackhole or add segment-actions later.
+resource "awscc_networkmanager_core_network" "example" {
+  description       = "Example Core Network"
+  global_network_id = awscc_networkmanager_global_network.example.id
+  policy_document = jsonencode({
+    "version" : "2021.12",
+    "core-network-configuration" : {
+      "vpn-ecmp-support" : true,
+      "asn-ranges" : ["64512-65534"],
+      "edge-locations" : [{
+        "location" : local.region
+      }]
+    },
+    "segments" : [{
+      "name" : "shared",
+      "description" : "Segment for shared services",
+      "require-attachment-acceptance" : false
+    }]
+  })
+  tags = [{
+    key   = "Modified By"
+    value = "AWSCC"
+  }]
+}
+
 resource "awscc_ec2_vpc" "example" {
   cidr_block = "10.0.0.0/16"
   tags = [{
@@ -34,7 +73,7 @@ resource "awscc_ec2_vpc" "example" {
 resource "awscc_ec2_subnet" "example_subnet1" {
   vpc_id            = awscc_ec2_vpc.example.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "${data.aws_region.current.name}a"
+  availability_zone = "${local.region}a"
   tags = [{
     key   = "Name"
     value = "example-subnet-1"
@@ -44,71 +83,19 @@ resource "awscc_ec2_subnet" "example_subnet1" {
 resource "awscc_ec2_subnet" "example_subnet2" {
   vpc_id            = awscc_ec2_vpc.example.id
   cidr_block        = "10.0.2.0/24"
-  availability_zone = "${data.aws_region.current.name}b"
+  availability_zone = "${local.region}b"
   tags = [{
     key   = "Name"
     value = "example-subnet-2"
   }]
 }
 
-# Create Network Manager resources
-resource "awscc_networkmanager_global_network" "example" {
-  description = "Example Global Network"
-  tags = [{
-    key   = "Modified By"
-    value = "AWSCC"
-  }]
-}
-
-resource "awscc_networkmanager_core_network" "example" {
-  description       = "Example Core Network"
-  global_network_id = awscc_networkmanager_global_network.example.id
-  policy_document = jsonencode({
-    "version" : "2021.12",
-    "core-network-configuration" : {
-      "vpn-ecmp-support" : true,
-      "asn-ranges" : [
-        "64512-65534"
-      ],
-      "edge-locations" : [
-        {
-          "location" : data.aws_region.current.name
-        }
-      ]
-    },
-    "segments" : [
-      {
-        "name" : "shared",
-        "description" : "Segment for shared services",
-        "require-attachment-acceptance" : false
-      }
-    ],
-    "segment-actions" : [
-      {
-        "action" : "create-route",
-        "destination-cidr-blocks" : [
-          "0.0.0.0/0"
-        ],
-        "destinations" : [
-          "attachment"
-        ],
-        "segment" : "shared"
-      }
-    ]
-  })
-  tags = [{
-    key   = "Modified By"
-    value = "AWSCC"
-  }]
-}
-
-# Create VPC Attachment
 resource "awscc_networkmanager_vpc_attachment" "example" {
   core_network_id = awscc_networkmanager_core_network.example.id
-  vpc_arn         = format("arn:aws:ec2:%s:%s:vpc/%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, awscc_ec2_vpc.example.id)
+  vpc_arn         = format("arn:aws:ec2:%s:%s:vpc/%s", local.region, local.account_id, awscc_ec2_vpc.example.id)
   subnet_arns = [
-    format("arn:aws:ec2:%s:%s:subnet/%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, awscc_ec2_subnet.example_subnet1.id),
-    format("arn:aws:ec2:%s:%s:subnet/%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, awscc_ec2_subnet.example_subnet2.id)
+    format("arn:aws:ec2:%s:%s:subnet/%s", local.region, local.account_id, awscc_ec2_subnet.example_subnet1.id),
+    format("arn:aws:ec2:%s:%s:subnet/%s", local.region, local.account_id, awscc_ec2_subnet.example_subnet2.id)
   ]
   options = {
     appliance_mode_support = false

--- a/examples/resources/awscc_networkmanager_vpc_attachment/main.tf
+++ b/examples/resources/awscc_networkmanager_vpc_attachment/main.tf
@@ -1,7 +1,46 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-# Create VPC and subnets
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.name
+}
+
+resource "awscc_networkmanager_global_network" "example" {
+  description = "Example Global Network"
+  tags = [{
+    key   = "Modified By"
+    value = "AWSCC"
+  }]
+}
+
+# Core Network - segment-actions cannot reference attachment IDs during creation
+# as attachments don't exist yet. This creates circular dependencies on both
+# create and destroy operations. Use blackhole or add segment-actions later.
+resource "awscc_networkmanager_core_network" "example" {
+  description       = "Example Core Network"
+  global_network_id = awscc_networkmanager_global_network.example.id
+  policy_document = jsonencode({
+    "version" : "2021.12",
+    "core-network-configuration" : {
+      "vpn-ecmp-support" : true,
+      "asn-ranges" : ["64512-65534"],
+      "edge-locations" : [{
+        "location" : local.region
+      }]
+    },
+    "segments" : [{
+      "name" : "shared",
+      "description" : "Segment for shared services",
+      "require-attachment-acceptance" : false
+    }]
+  })
+  tags = [{
+    key   = "Modified By"
+    value = "AWSCC"
+  }]
+}
+
 resource "awscc_ec2_vpc" "example" {
   cidr_block = "10.0.0.0/16"
   tags = [{
@@ -13,7 +52,7 @@ resource "awscc_ec2_vpc" "example" {
 resource "awscc_ec2_subnet" "example_subnet1" {
   vpc_id            = awscc_ec2_vpc.example.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "${data.aws_region.current.name}a"
+  availability_zone = "${local.region}a"
   tags = [{
     key   = "Name"
     value = "example-subnet-1"
@@ -23,71 +62,19 @@ resource "awscc_ec2_subnet" "example_subnet1" {
 resource "awscc_ec2_subnet" "example_subnet2" {
   vpc_id            = awscc_ec2_vpc.example.id
   cidr_block        = "10.0.2.0/24"
-  availability_zone = "${data.aws_region.current.name}b"
+  availability_zone = "${local.region}b"
   tags = [{
     key   = "Name"
     value = "example-subnet-2"
   }]
 }
 
-# Create Network Manager resources
-resource "awscc_networkmanager_global_network" "example" {
-  description = "Example Global Network"
-  tags = [{
-    key   = "Modified By"
-    value = "AWSCC"
-  }]
-}
-
-resource "awscc_networkmanager_core_network" "example" {
-  description       = "Example Core Network"
-  global_network_id = awscc_networkmanager_global_network.example.id
-  policy_document = jsonencode({
-    "version" : "2021.12",
-    "core-network-configuration" : {
-      "vpn-ecmp-support" : true,
-      "asn-ranges" : [
-        "64512-65534"
-      ],
-      "edge-locations" : [
-        {
-          "location" : data.aws_region.current.name
-        }
-      ]
-    },
-    "segments" : [
-      {
-        "name" : "shared",
-        "description" : "Segment for shared services",
-        "require-attachment-acceptance" : false
-      }
-    ],
-    "segment-actions" : [
-      {
-        "action" : "create-route",
-        "destination-cidr-blocks" : [
-          "0.0.0.0/0"
-        ],
-        "destinations" : [
-          "attachment"
-        ],
-        "segment" : "shared"
-      }
-    ]
-  })
-  tags = [{
-    key   = "Modified By"
-    value = "AWSCC"
-  }]
-}
-
-# Create VPC Attachment
 resource "awscc_networkmanager_vpc_attachment" "example" {
   core_network_id = awscc_networkmanager_core_network.example.id
-  vpc_arn         = format("arn:aws:ec2:%s:%s:vpc/%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, awscc_ec2_vpc.example.id)
+  vpc_arn         = format("arn:aws:ec2:%s:%s:vpc/%s", local.region, local.account_id, awscc_ec2_vpc.example.id)
   subnet_arns = [
-    format("arn:aws:ec2:%s:%s:subnet/%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, awscc_ec2_subnet.example_subnet1.id),
-    format("arn:aws:ec2:%s:%s:subnet/%s", data.aws_region.current.name, data.aws_caller_identity.current.account_id, awscc_ec2_subnet.example_subnet2.id)
+    format("arn:aws:ec2:%s:%s:subnet/%s", local.region, local.account_id, awscc_ec2_subnet.example_subnet1.id),
+    format("arn:aws:ec2:%s:%s:subnet/%s", local.region, local.account_id, awscc_ec2_subnet.example_subnet2.id)
   ]
   options = {
     appliance_mode_support = false


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2785 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

Updated examples for the resource where the core network cannot have segment actions to the attachment id or a static string.