### PR TITLE
fix: add pre-delete hook for cleanrooms membership to remove analysis templates

### DIFF
--- a/internal/aws/cleanrooms/membership_resource_gen.go
+++ b/internal/aws/cleanrooms/membership_resource_gen.go
@@ -735,6 +735,10 @@ func membershipResource(ctx context.Context) (resource.Resource, error) {
 
 	opts = opts.WithUpdateTimeoutInMinutes(0)
 
+	// Pre-delete hook: clean up analysis templates before membership deletion.
+	// Without this, Cloud Control API returns 409 if analysis templates exist.
+	opts = opts.WithPreDeleteFunc(preDeleteMembership)
+
 	v, err := generic.NewResource(ctx, opts...)
 
 	if err != nil {

--- a/internal/aws/cleanrooms/membership_resource_hooks.go
+++ b/internal/aws/cleanrooms/membership_resource_hooks.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package cleanrooms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	tfcloudcontrol "github.com/hashicorp/terraform-provider-awscc/internal/service/cloudcontrol"
+)
+
+const (
+	analysisTemplateCfTypeName = "AWS::CleanRooms::AnalysisTemplate"
+	templateDeleteTimeout      = 10 * time.Minute
+)
+
+// preDeleteMembership deletes all analysis templates on a membership before
+// the membership itself is deleted via Cloud Control API. Without this, the
+// DeleteMembership call returns a 409 Conflict if any analysis templates exist.
+//
+// This uses only the Cloud Control API client — no native service SDK needed.
+// Analysis template identifiers have the format "MembershipId|AnalysisTemplateId",
+// so we list all analysis templates and filter by the membership ID prefix.
+func preDeleteMembership(ctx context.Context, provider tfcloudcontrol.Provider, membershipID string) error {
+	conn := provider.CloudControlAPIClient(ctx)
+	roleARN := provider.RoleARN(ctx)
+
+	resources, err := tfcloudcontrol.ListResourcesByTypeName(ctx, conn, roleARN, analysisTemplateCfTypeName)
+	if err != nil {
+		// If no analysis templates exist at all, that's fine — nothing to clean up.
+		if isNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("listing analysis templates: %w", err)
+	}
+
+	for _, resource := range resources {
+		if resource.Identifier == nil {
+			continue
+		}
+
+		identifier := *resource.Identifier
+
+		// Analysis template identifiers are "MembershipId|AnalysisTemplateId".
+		// Only delete templates belonging to this membership.
+		if !strings.HasPrefix(identifier, membershipID+"|") {
+			continue
+		}
+
+		tflog.Info(ctx, "Deleting analysis template before membership deletion", map[string]any{
+			"membership_id":              membershipID,
+			"analysis_template_identifier": identifier,
+		})
+
+		err := tfcloudcontrol.DeleteResource(
+			ctx, conn, roleARN,
+			analysisTemplateCfTypeName, identifier,
+			templateDeleteTimeout,
+		)
+		if err != nil {
+			return fmt.Errorf("deleting analysis template %s: %w", identifier, err)
+		}
+	}
+
+	return nil
+}
+
+// isNotFoundError checks if the error is a "not found" error from the
+// Cloud Control list operation (empty results).
+func isNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), "Empty result")
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2021, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

Closes #3000 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. The pre-delete hook uses the same Cloud Control API client and credentials already available to the provider. No new SDK dependencies or IAM permissions are introduced. The hook calls Cloud Control API `ListResources` and `DeleteResource` for `AWS::CleanRooms::AnalysisTemplate`, which require the same permissions the user would need to manage these resources directly.

## Description

This PR addresses two related 409 Conflict errors in Clean Rooms resources caused by the generic CRUD framework's lack of resource-type-specific lifecycle hooks.

**Bug 1: `awscc_cleanrooms_membership` deletion fails when analysis templates exist.** The Cloud Control API returns 409 because the CleanRooms service requires all child analysis templates to be removed first.

**Bug 2: `awscc_cleanrooms_configured_table_association` creation fails with `AlreadyExists`.** The Cloud Control API returns 409 when a configured table association for the same configured table already exists in the collaboration/membership (e.g., from a previous failed apply, out-of-band creation, or incomplete `RequiresReplace` cycle).

Both bugs share the same root cause: the generic CRUD framework has no mechanism for resource-type-specific pre-delete or pre-create cleanup.

This PR adds a `PreDeleteFunc` hook to the generic resource framework and implements it for the Clean Rooms membership resource using only the existing Cloud Control API client — no new SDK dependencies. The same pattern can be extended with a `PreCreateFunc` or `AlreadyExistsHandler` to address the configured table association creation issue.

### Framework changes (`internal/generic/resource.go`)

- Added `PreDeleteFunc` type: `func(ctx context.Context, provider Provider, id string) error`
- Added `preDeleteFunc` field to `genericResource` struct
- Added `WithPreDeleteFunc()` builder method on `ResourceOptions`
- Modified `Delete()` handler to call the hook before `DeleteResource` if one is registered

### Clean Rooms membership hook (`internal/aws/cleanrooms/`)

- New file `membership_resource_hooks.go`: `preDeleteMembership()` uses Cloud Control API `ListResources` for `AWS::CleanRooms::AnalysisTemplate`, filters results by membership ID prefix (identifiers are `MembershipId|AnalysisTemplateId`), and deletes matching templates via Cloud Control API `DeleteResource`
- Wired into the membership resource via `opts.WithPreDeleteFunc(preDeleteMembership)` in the generated resource file

### Design decisions

- **No new dependencies**: Uses only the existing Cloud Control API client. No native service SDK (e.g., `cleanrooms`) is added, keeping the provider's generic architecture intact.
- **Always-on**: The hook runs on every delete, not behind a `force_destroy` flag. Without it the delete simply fails — there's no valid use case for keeping orphaned analysis templates on a membership being destroyed.
- **Reusable pattern**: Other resources with similar parent-child deletion constraints can add their own `PreDeleteFunc` the same way.

### Testing

- Full `go build ./internal/...` passes with no errors
- Existing `internal/generic/` tests pass
- No new dependencies to resolve
