### PR TITLE
Fix awscc_s3_storage_lens resource primary identifier path

### DIFF
--- a/internal/aws/s3/storage_lens_resource_gen.go
+++ b/internal/aws/s3/storage_lens_resource_gen.go
@@ -1527,7 +1527,7 @@ func storageLensResource(ctx context.Context) (resource.Resource, error) {
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithPrimaryIdentifier(
 		identity.Identifier{
-			Name:              "storage_lens_configuration_id",
+			Name:              "id",
 			RequiredForImport: true,
 		})
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2021, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3051 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

## Description

Fixes a State Read Error when performing terraform plan or terraform apply on awscc_s3_storage_lens resource.

```log
Error: State Read Error
│ 
│   with awscc_s3_storage_lens.example,
│   on main.tf line 29, in resource "awscc_s3_storage_lens" "example":
│   29: resource "awscc_s3_storage_lens" "example" {
│ 
│ An unexpected error was encountered trying to retrieve type information at a given path. This is always an error in the provider. Please report the following to the provider developer:
│ 
│ Error: AttributeName("storage_lens_configuration_id") still remains in the path: could not find attribute or block "storage_lens_configuration_id" in schema
```
Root cause: The primary identifier was set to `storage_lens_configuration_id`, which doesn't exist as a top-level attribute in the Terraform schema. The identity system resolves identifiers via `path.Root(Name)` so it tried to read a non-existent attribute from state.

The CloudFormation primary identifier for this resource is `/properties/StorageLensConfiguration/Id` (nested), but the Cloud Control API returns the configuration ID as the resource identifier, which the generic resource already stores in the top-level `id` attribute via `setId`.

Fix: Changed the identifier `Name` from `storage_lens_configuration_id` to `id`, matching the existing top-level `id` attribute — consistent with the pattern used by other resources in the provider.
