### PR TITLE
ci: declare permissions on the 7 remaining workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ on: [workflow_dispatch, push]
 env:
   PKG_NAME: "terraform-provider-awscc"
 
+permissions:
+  contents: read
+
 jobs:
   # Detects the Go toolchain version to use for product builds.
   #

--- a/.github/workflows/documentation-linters.yml
+++ b/.github/workflows/documentation-linters.yml
@@ -17,6 +17,9 @@ on:
       - tools/go.mod
       # - website/**
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,6 +18,9 @@ on:
       - main.go
       - tools/**
 
+permissions:
+  contents: read
+
 jobs:
   go_mod_download:
     name: go mod download

--- a/.github/workflows/provider-release.yml
+++ b/.github/workflows/provider-release.yml
@@ -42,6 +42,10 @@ env:
   repo_name: "terraform-provider-awscc"
   deployment_environment_name: "tf-provider-awscc-oss"
 
+# bob trigger-promotion uses BOB_GITHUB_TOKEN; the default GITHUB_TOKEN is
+# unused.
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -6,6 +6,9 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+# Only posts to FEED_SLACK_WEBHOOK_URL; no GitHub API calls.
+permissions: {}
+
 jobs:
   tag-created:
     runs-on: ubuntu-latest

--- a/.github/workflows/tfplugindocs-check.yml
+++ b/.github/workflows/tfplugindocs-check.yml
@@ -20,6 +20,9 @@ on:
       - docs/**
       - examples/**
 
+permissions:
+  contents: read
+
 jobs:
   tfplugindocs_check:
     name: tfplugindocs check

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -11,6 +11,12 @@ on:
         required: true
         type: string
 
+# Creates a new branch and opens the changelog PR via gh CLI using
+# secrets.GITHUB_TOKEN.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for each workflow that was still inheriting org defaults:

| Workflow | Scope | What needs it |
|----------|-------|---------------|
| `build.yml` | `contents: read` | go build + metadata artifact upload |
| `documentation-linters.yml` | `contents: read` | markdown link check |
| `linters.yml` | `contents: read` | golangci-lint |
| `tfplugindocs-check.yml` | `contents: read` | regenerates docs to verify they match |
| `provider-release.yml` | `permissions: {}` | `bob trigger-promotion` uses `BOB_GITHUB_TOKEN`; default token is unused |
| `release-tag.yml` | `permissions: {}` | only POSTs to `FEED_SLACK_WEBHOOK_URL` |
| `update-changelog.yml` | `contents: write` + `pull-requests: write` | creates a branch via the default token and opens the changelog PR with `gh pr create` |

YAML validated with `yaml.safe_load` for each file.