### PR TITLE
write startup errors to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ last_resource.txt
 .make-resources.log
 .make-schemas.log
 .make-singular-data-sources.log
+.make-startup-errors.log
 
 *_test.json

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -212,6 +212,23 @@ update: prereq-go ## Update Schema
 	echo "==> Updating Schema..."
 	$(GO_VER) run $$(find internal/update -name "*.go" -not -name "*_test.go")
 
+check-startup-error: prereq-go ## Build with writeerrors tag and run terraform plan against a minimal data source config
+	@echo "==> Installing provider with writeerrors tag..."
+	$(GO_VER) install -tags writeerrors .
+	@GOBIN="$$($(GO_VER) env GOPATH)/bin"; \
+	REPO_ROOT="$$(pwd)"; \
+	LOG_FILE="$$REPO_ROOT/.startup-errors.log"; \
+	WORK_DIR=$$(mktemp -d); \
+	trap 'rm -rf "$$WORK_DIR"' EXIT; \
+	echo "==> Writing Terraform config to $$WORK_DIR"; \
+	printf 'terraform {\n  required_providers {\n    awscc = {\n      source = "hashicorp/awscc"\n    }\n  }\n}\n\nprovider "awscc" {\n  region = "us-east-1"\n}\n\ndata "awscc_s3_bucket" "example" {\n  id = "my-example-bucket"\n}\n' > "$$WORK_DIR/main.tf"; \
+	printf 'provider_installation {\n  dev_overrides {\n    "hashicorp/awscc" = "%s"\n  }\n  direct {}\n}\n' "$$GOBIN" > "$$WORK_DIR/terraform.rc"; \
+	echo "==> Running terraform plan (errors logged to $$LOG_FILE)..."; \
+	: > "$$LOG_FILE"; \
+	cd "$$WORK_DIR" && RESOURCE_ERROR_LOG="$$LOG_FILE" TF_CLI_CONFIG_FILE="$$WORK_DIR/terraform.rc" terraform plan; \
+	echo "==> resource_errors.log (if any):"; \
+	cat "$$LOG_FILE" 2>/dev/null || echo "(no errors logged)"
+
 smoke: prereq-go ## Run smoke tests
 	@echo "make: Running smoke tests..."
 	@echo "make: NOTE: All tests should pass. Error output for sdk.proto, \"Response contains error diagnostic\" can be ignored."
@@ -287,6 +304,7 @@ biglister: prereq-go ## List all resources and data sources
 .PHONY: bigdiffer
 .PHONY: biglister
 .PHONY: build
+.PHONY: check-startup-error
 .PHONY: cleanschemas
 .PHONY: commitdatas
 .PHONY: commitdocs

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -217,7 +217,7 @@ check-startup-errors: prereq-go ## Build with writeerrors tag and run terraform 
 	$(GO_VER) install -tags writeerrors .
 	@GOBIN="$$($(GO_VER) env GOPATH)/bin"; \
 	REPO_ROOT="$$(pwd)"; \
-	LOG_FILE="$$REPO_ROOT/.startup-errors.log"; \
+	LOG_FILE="$$REPO_ROOT/.make-startup-errors.log"; \
 	WORK_DIR=$$(mktemp -d); \
 	trap 'rm -rf "$$WORK_DIR"' EXIT; \
 	echo "==> Writing Terraform config to $$WORK_DIR"; \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -212,7 +212,7 @@ update: prereq-go ## Update Schema
 	echo "==> Updating Schema..."
 	$(GO_VER) run $$(find internal/update -name "*.go" -not -name "*_test.go")
 
-check-startup-error: prereq-go ## Build with writeerrors tag and run terraform plan against a minimal data source config
+check-startup-errors: prereq-go ## Build with writeerrors tag and run terraform plan against a minimal data source config
 	@echo "==> Installing provider with writeerrors tag..."
 	$(GO_VER) install -tags writeerrors .
 	@GOBIN="$$($(GO_VER) env GOPATH)/bin"; \

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -445,7 +445,7 @@ func (p *ccProvider) Resources(ctx context.Context) []func() resource.Resource {
 				fmt.Sprintf("Error getting the %s Resource, this is an error in the provider.\n%s\n", name, err),
 			)
 
-			writeResourceError(name, err)
+			writeProviderError("resource", name, err)
 
 			continue
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -445,6 +445,8 @@ func (p *ccProvider) Resources(ctx context.Context) []func() resource.Resource {
 				fmt.Sprintf("Error getting the %s Resource, this is an error in the provider.\n%s\n", name, err),
 			)
 
+			writeResourceError(name, err)
+
 			continue
 		}
 

--- a/internal/provider/write_resource_error.go
+++ b/internal/provider/write_resource_error.go
@@ -1,0 +1,9 @@
+//go:build !writeerrors
+
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+// writeResourceError is a no-op in normal builds.
+func writeResourceError(_ string, _ error) {}

--- a/internal/provider/write_resource_error.go
+++ b/internal/provider/write_resource_error.go
@@ -5,5 +5,6 @@
 
 package provider
 
-// writeResourceError is a no-op in normal builds.
-func writeResourceError(_ string, _ error) {}
+// writeProviderError writes a factory error to the log file.
+// kind should be "resource", "data source", or "list resource".
+func writeProviderError(_ string, _ string, _ error) {}

--- a/internal/provider/write_resource_error_file.go
+++ b/internal/provider/write_resource_error_file.go
@@ -13,20 +13,29 @@ import (
 // resourceErrorLog holds the log file opened at program startup.
 var resourceErrorLog *os.File
 
-// init opens and truncates resource_errors.log when the provider binary starts.
+// init opens the resource error log when the provider binary starts.
+// The log path is read from $RESOURCE_ERROR_LOG; defaults to resource_errors.log
+// in the current working directory. Uses O_APPEND because terraform invokes the
+// provider binary multiple times per plan — O_TRUNC would wipe earlier entries.
+// Truncate the file once before running terraform (e.g. in the make target).
 // Enabled via the `writeerrors` build tag.
 func init() {
-	f, err := os.OpenFile("resource_errors.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	path := os.Getenv("RESOURCE_ERROR_LOG")
+	if path == "" {
+		path = ".startup_errors.log"
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return
 	}
 	resourceErrorLog = f
 }
 
-// writeResourceError writes a resource factory error to the log file.
-func writeResourceError(name string, err error) {
+// writeProviderError writes a factory error to the log file.
+// kind should be "resource", "data source", or "list resource".
+func writeProviderError(kind string, name string, err error) {
 	if resourceErrorLog == nil {
 		return
 	}
-	fmt.Fprintf(resourceErrorLog, "resource=%s error=%s\n", name, err)
+	fmt.Fprintf(resourceErrorLog, "kind=%s name=%s error=%s\n", kind, name, err)
 }

--- a/internal/provider/write_resource_error_file.go
+++ b/internal/provider/write_resource_error_file.go
@@ -20,7 +20,7 @@ var resourceErrorLog *os.File
 // Truncate the file once before running terraform (e.g. in the make target).
 // Enabled via the `writeerrors` build tag.
 func init() {
-	path := os.Getenv("RESOURCE_ERROR_LOG")
+	path := os.Getenv("STARTUP_ERROR_LOG")
 	if path == "" {
 		path = ".startup_errors.log"
 	}

--- a/internal/provider/write_resource_error_file.go
+++ b/internal/provider/write_resource_error_file.go
@@ -1,0 +1,32 @@
+//go:build writeerrors
+
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"os"
+)
+
+// resourceErrorLog holds the log file opened at program startup.
+var resourceErrorLog *os.File
+
+// init opens and truncates resource_errors.log when the provider binary starts.
+// Enabled via the `writeerrors` build tag.
+func init() {
+	f, err := os.OpenFile("resource_errors.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return
+	}
+	resourceErrorLog = f
+}
+
+// writeResourceError writes a resource factory error to the log file.
+func writeResourceError(name string, err error) {
+	if resourceErrorLog == nil {
+		return
+	}
+	fmt.Fprintf(resourceErrorLog, "resource=%s error=%s\n", name, err)
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2021, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

make target `check-startup-errors` runs the provider with specific build tags.

Tags set provider to write startup errors to file in the root of repo.

### output

```console
kind=resource name=awscc_mediapackage_origin_endpoint error=duplicate attribute name mapping for CloudFormation property Id
kind=resource name=awscc_mediapackage_channel error=duplicate attribute name mapping for CloudFormation property Id
kind=resource name=awscc_emrcontainers_security_configuration error=duplicate attribute name mapping for CloudFormation property Id
kind=resource name=awscc_vpclattice_target_group error=duplicate attribute name mapping for CloudFormation property Id
kind=resource name=awscc_emrcontainers_virtual_cluster error=duplicate attribute name mapping for CloudFormation property Id
kind=resource name=awscc_cloudfront_anycast_ip_list error=duplicate attribute name mapping for CloudFormation property Id
kind=resource name=awscc_eks_nodegroup error=duplicate attribute name mapping for CloudFormation property Id
kind=resource name=awscc_cloudfront_distribution error=duplicate attribute name mapping for CloudFormation property Id
kind=resource name=awscc_amazonmq_broker error=duplicate attribute name mapping for CloudFormation property Id
```