### PR TITLE
list of object as list of map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 1.90.0 (Unreleased)
 
+BREAKING CHANGES:
+
+* data-source/awscc_omics_annotation_store: The attribute `store_options.tsv_store_options.schema` now returns a list of key-value pairs instead of a list of strings. ([#30207](https://github.com/hashicorp/terraform-provider-awscc/pull/3207))
+* data-source/awscc_scheduler_schedule: The attribute `target.ecs_parameters.tags` now returns a list of key-value pairs instead of a list of strings. ([#30207](https://github.com/hashicorp/terraform-provider-awscc/pull/3207))
+* resource/awscc_omics_annotation_store: The argument `store_options.tsv_store_options.schema` now expects a list of key-value pairs instead of a list of strings. ([#30207](https://github.com/hashicorp/terraform-provider-awscc/pull/3207))
+* resource/awscc_scheduler_schedule: The argument `target.ecs_parameters.tags` now expects a list of key-value pairs instead of a list of strings. ([#30207](https://github.com/hashicorp/terraform-provider-awscc/pull/3207))
+
 ## 1.89.0 (June 17, 2026)
 
 FEATURES:

--- a/docs/data-sources/omics_annotation_store.md
+++ b/docs/data-sources/omics_annotation_store.md
@@ -67,4 +67,4 @@ Read-Only:
 
 - `annotation_type` (String)
 - `format_to_header` (Map of String)
-- `schema` (List of List of String)
+- `schema` (List of Map of String)

--- a/docs/data-sources/scheduler_schedule.md
+++ b/docs/data-sources/scheduler_schedule.md
@@ -83,7 +83,7 @@ Read-Only:
 - `platform_version` (String) Specifies the platform version for the task. Specify only the numeric portion of the platform version, such as 1.1.0.
 - `propagate_tags` (String) Specifies whether to propagate the tags from the task definition to the task. If no value is specified, the tags are not propagated. Tags can only be propagated to the task during task creation. To add tags to a task after task creation, use the TagResource API action.
 - `reference_id` (String) The reference ID to use for the task.
-- `tags` (List of List of String) The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. To learn more, see RunTask in the Amazon ECS API Reference.
+- `tags` (List of Map of String) The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. To learn more, see RunTask in the Amazon ECS API Reference.
 - `task_count` (Number) The number of tasks to create based on TaskDefinition. The default is 1.
 - `task_definition_arn` (String) The ARN of the task definition to use if the event target is an Amazon ECS task.
 

--- a/docs/resources/omics_annotation_store.md
+++ b/docs/resources/omics_annotation_store.md
@@ -108,7 +108,7 @@ Optional:
 
 - `annotation_type` (String)
 - `format_to_header` (Map of String)
-- `schema` (List of List of String)
+- `schema` (List of Map of String)
 
 ## Import
 

--- a/docs/resources/scheduler_schedule.md
+++ b/docs/resources/scheduler_schedule.md
@@ -197,7 +197,7 @@ Optional:
 - `platform_version` (String) Specifies the platform version for the task. Specify only the numeric portion of the platform version, such as 1.1.0.
 - `propagate_tags` (String) Specifies whether to propagate the tags from the task definition to the task. If no value is specified, the tags are not propagated. Tags can only be propagated to the task during task creation. To add tags to a task after task creation, use the TagResource API action.
 - `reference_id` (String) The reference ID to use for the task.
-- `tags` (List of List of String) The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. To learn more, see RunTask in the Amazon ECS API Reference.
+- `tags` (List of Map of String) The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. To learn more, see RunTask in the Amazon ECS API Reference.
 - `task_count` (Number) The number of tasks to create based on TaskDefinition. The default is 1.
 - `task_definition_arn` (String) The ARN of the task definition to use if the event target is an Amazon ECS task.
 

--- a/internal/aws/omics/annotation_store_resource_gen.go
+++ b/internal/aws/omics/annotation_store_resource_gen.go
@@ -367,7 +367,7 @@ func annotationStoreResource(ctx context.Context) (resource.Resource, error) {
 						}, /*END ATTRIBUTE*/
 						// Property: Schema
 						"schema": schema.ListAttribute{ /*START ATTRIBUTE*/
-							ElementType: types.ListType{ElemType: types.StringType},
+							ElementType: types.MapType{ElemType: types.StringType},
 							Optional:    true,
 							Computed:    true,
 							Validators: []validator.List{ /*START VALIDATORS*/

--- a/internal/aws/omics/annotation_store_singular_data_source_gen.go
+++ b/internal/aws/omics/annotation_store_singular_data_source_gen.go
@@ -260,7 +260,7 @@ func annotationStoreDataSource(ctx context.Context) (datasource.DataSource, erro
 						}, /*END ATTRIBUTE*/
 						// Property: Schema
 						"schema": schema.ListAttribute{ /*START ATTRIBUTE*/
-							ElementType: types.ListType{ElemType: types.StringType},
+							ElementType: types.MapType{ElemType: types.StringType},
 							Computed:    true,
 						}, /*END ATTRIBUTE*/
 					}, /*END SCHEMA*/

--- a/internal/aws/scheduler/schedule_resource_gen.go
+++ b/internal/aws/scheduler/schedule_resource_gen.go
@@ -1009,7 +1009,7 @@ func scheduleResource(ctx context.Context) (resource.Resource, error) {
 						}, /*END ATTRIBUTE*/
 						// Property: Tags
 						"tags": schema.ListAttribute{ /*START ATTRIBUTE*/
-							ElementType: types.ListType{ElemType: types.StringType},
+							ElementType: types.MapType{ElemType: types.StringType},
 							Description: "The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. To learn more, see RunTask in the Amazon ECS API Reference.",
 							Optional:    true,
 							Computed:    true,

--- a/internal/aws/scheduler/schedule_resource_test.go
+++ b/internal/aws/scheduler/schedule_resource_test.go
@@ -1,0 +1,286 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package scheduler_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-awscc/internal/acctest"
+)
+
+func TestAccAWSSchedulerSchedule_ecsParameters_tags(t *testing.T) {
+	td := acctest.NewTestData(t, "AWS::Scheduler::Schedule", "awscc_scheduler_schedule", "test")
+	rName := td.RandomName()
+
+	td.ResourceTestWithTestCase(t, resource.TestCase{
+		PreCheck: func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"awscc": {
+						Source:            "hashicorp/awscc",
+						VersionConstraint: "1.89.0",
+					},
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "6.51.0",
+					},
+				},
+				Config: acctest.ConfigCompose(
+					testAccAWSScheduleConfig_base(&td, rName),
+					testAccAWSScheduleConfig_old(&td, rName),
+				),
+				// error is returned from CloudControl API.
+				// object is serialized as incorrect type.
+				ExpectError: regexache.MustCompile(`(?s)Model validation failed.*expected type: JSONObject, found: JSONArray`),
+			},
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+				"aws": {
+					Source:            "hashicorp/aws",
+					VersionConstraint: "6.51.0",
+				},
+			},
+				Config: acctest.ConfigCompose(
+					testAccAWSScheduleConfig_base(&td, rName),
+					testAccAWSScheduleConfig_new(&td, rName),
+				),
+				ProtoV6ProviderFactories: td.ProviderFactories(),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(td.ResourceName, tfjsonpath.New("target").AtMapKey("ecs_parameters").AtMapKey("tags").AtSliceIndex(0).AtMapKey("key"), knownvalue.StringExact("environment")),
+					statecheck.ExpectKnownValue(td.ResourceName, tfjsonpath.New("target").AtMapKey("ecs_parameters").AtMapKey("tags").AtSliceIndex(0).AtMapKey("value"), knownvalue.StringExact("Prod")),
+				},
+			},
+		},
+	})
+}
+
+func testAccAWSScheduleConfig_base(td *acctest.TestData, rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "scheduler_role" {
+  name = "%[3]s-scheduler"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Principal = {
+          Service = "scheduler.amazonaws.com"
+        },
+        Effect = "Allow",
+        Sid    = ""
+      }
+    ]
+  })
+}
+
+# IAM role for the ECS task
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "%[3]s-ecs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        },
+        Effect = "Allow",
+        Sid    = ""
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_ecs_cluster" "test" {
+  name = %[3]q
+}
+
+# VPC and networking
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-west-2b"
+}
+
+resource "aws_security_group" "ecs_task" {
+  name        = %[3]q
+  description = "Security group for ECS Fargate tasks"
+  vpc_id      = aws_vpc.test.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family                   = %[3]q
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = %[3]q
+      image     = "public.ecr.aws/amazonlinux/amazonlinux:latest"
+      essential = true
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/test-task"
+          "awslogs-region"        = "us-west-2"
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_iam_role_policy" "ecs_execution" {
+  name = %[3]q
+  role = aws_iam_role.scheduler_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action   = ["ecs:RunTask"],
+        Resource = aws_ecs_task_definition.test.arn,
+        Effect   = "Allow"
+      },
+      {
+        Action   = ["iam:PassRole"],
+        Resource = aws_iam_role.ecs_task_execution_role.arn,
+        Effect   = "Allow"
+      }
+    ]
+  })
+}
+`, td.TerraformResourceType, td.ResourceLabel, rName)
+}
+
+func testAccAWSScheduleConfig_old(td *acctest.TestData, rName string) string {
+	return fmt.Sprintf(`
+# EventBridge Scheduler Schedule using the AWSCC provider
+resource %[1]q %[2]q {
+  name                         = %[3]q
+  description                  = "Test schedule created with Terraform"
+  schedule_expression          = "cron(0 12 * * ? *)" # Daily at 12:00 PM
+  schedule_expression_timezone = "America/Los_Angeles"
+
+  flexible_time_window = {
+    mode                      = "FLEXIBLE"
+    maximum_window_in_minutes = 30 # Allow 30-minute execution window
+  }
+
+  target = {
+    arn      = aws_ecs_cluster.test.arn
+    role_arn = aws_iam_role.scheduler_role.arn
+
+    ecs_parameters = {
+      task_definition_arn    = aws_ecs_task_definition.test.arn
+      launch_type            = "FARGATE"
+      task_count             = 1
+      network_configuration = {
+        awsvpc_configuration = {
+          assign_public_ip = "DISABLED"
+          subnets          = [aws_subnet.test1.id, aws_subnet.test2.id]
+          security_groups  = [aws_security_group.ecs_task.id]
+        }
+      }
+
+      tags = [
+        ["this"]
+      ]
+    }
+
+    retry_policy = {
+      maximum_retry_attempts       = 3
+      maximum_event_age_in_seconds = 3600
+    }
+  }
+
+  state = "ENABLED" # Schedule is active
+}
+`, td.TerraformResourceType, td.ResourceLabel, rName)
+}
+
+func testAccAWSScheduleConfig_new(td *acctest.TestData, rName string) string {
+	return fmt.Sprintf(`
+# EventBridge Scheduler Schedule using the AWSCC provider
+resource %[1]q %[2]q {
+  name                         = %[3]q
+  description                  = "Test schedule created with Terraform"
+  schedule_expression          = "cron(0 12 * * ? *)" # Daily at 12:00 PM
+  schedule_expression_timezone = "America/Los_Angeles"
+
+  flexible_time_window = {
+    mode                      = "FLEXIBLE"
+    maximum_window_in_minutes = 30 # Allow 30-minute execution window
+  }
+
+  target = {
+    arn      = aws_ecs_cluster.test.arn
+    role_arn = aws_iam_role.scheduler_role.arn
+
+    ecs_parameters = {
+      task_definition_arn    = aws_ecs_task_definition.test.arn
+      launch_type            = "FARGATE"
+      task_count             = 1
+      network_configuration = {
+        awsvpc_configuration = {
+          assign_public_ip = "DISABLED"
+          subnets          = [aws_subnet.test1.id, aws_subnet.test2.id]
+          security_groups  = [aws_security_group.ecs_task.id]
+        }
+      }
+
+      tags = [
+        {
+          key   = "environment"
+          value = "Prod"
+        }
+      ]
+    }
+
+    retry_policy = {
+      maximum_retry_attempts       = 3
+      maximum_event_age_in_seconds = 3600
+    }
+  }
+
+  state = "ENABLED" # Schedule is active
+}
+`, td.TerraformResourceType, td.ResourceLabel, rName)
+}

--- a/internal/aws/scheduler/schedule_singular_data_source_gen.go
+++ b/internal/aws/scheduler/schedule_singular_data_source_gen.go
@@ -730,7 +730,7 @@ func scheduleDataSource(ctx context.Context) (datasource.DataSource, error) {
 						}, /*END ATTRIBUTE*/
 						// Property: Tags
 						"tags": schema.ListAttribute{ /*START ATTRIBUTE*/
-							ElementType: types.ListType{ElemType: types.StringType},
+							ElementType: types.MapType{ElemType: types.StringType},
 							Description: "The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. To learn more, see RunTask in the Amazon ECS API Reference.",
 							Computed:    true,
 						}, /*END ATTRIBUTE*/

--- a/internal/provider/generators/shared/codegen/emitter.go
+++ b/internal/provider/generators/shared/codegen/emitter.go
@@ -458,13 +458,13 @@ func (e Emitter) emitAttribute(tfType string, attributeNameMap map[string]string
 					}
 					switch nestedPatternProperty.Type.String() {
 					case cfschema.PropertyTypeBoolean:
-						elementType = "types.ListType{ElemType: types.BoolType}"
+						elementType = "types.MapType{ElemType: types.BoolType}"
 					case cfschema.PropertyTypeInteger:
-						elementType = "types.ListType{ElemType: types.Int64Type}"
+						elementType = "types.MapType{ElemType: types.Int64Type}"
 					case cfschema.PropertyTypeNumber:
-						elementType = "types.ListType{ElemType: types.Float64Type}"
+						elementType = "types.MapType{ElemType: types.Float64Type}"
 					case cfschema.PropertyTypeString:
-						elementType = "types.ListType{ElemType: types.StringType}"
+						elementType = "types.MapType{ElemType: types.StringType}"
 					default:
 						return features, unsupportedTypeError(path, fmt.Sprintf("list of key-value map of %s", nestedPatternProperty.Type.String()))
 					}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2021, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2731

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

The emitter currently generates a list of objects as a list of list. This should be a list of a map.

```console
make testacc PKG_NAME=internal/aws/scheduler TESTARGS='-run=TestAccAWSSchedulerSchedule_ecsParameters_tags'
TF_ACC=1 go test ./internal/aws/scheduler -v -count 1 -parallel 20 -run=TestAccAWSSchedulerSchedule_ecsParameters_tags -timeout 180m
=== RUN   TestAccAWSSchedulerSchedule_ecsParameters_tags
=== PAUSE TestAccAWSSchedulerSchedule_ecsParameters_tags
=== CONT  TestAccAWSSchedulerSchedule_ecsParameters_tags
--- PASS: TestAccAWSSchedulerSchedule_ecsParameters_tags (96.17s)
PASS
ok      github.com/hashicorp/terraform-provider-awscc/internal/aws/scheduler    97.370s
```