### PR TITLE
generic: add WithUpdateIgnorePropertyPaths to fix awscc_bedrockagentcore_gateway update failures

### DIFF
--- a/internal/aws/bedrockagentcore/gateway_resource_gen.go
+++ b/internal/aws/bedrockagentcore/gateway_resource_gen.go
@@ -1023,6 +1023,15 @@ func gatewayResource(ctx context.Context) (resource.Resource, error) {
 
 	opts = opts.WithUpdateTimeoutInMinutes(0)
 
+	// The CloudControl handler for AWS::BedrockAgentCore::Gateway persists AllowedClients
+	// and AllowedScopes as [] when not set at creation time. UpdateResource re-validates the
+	// full stored model on every call, and [] fails minItems:1, blocking all updates.
+	// Excluding authorizer_configuration from the Update patch diff prevents this.
+	// Tracked upstream: https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/2528
+	opts = opts.WithUpdateIgnorePropertyPaths([]string{
+		"/properties/AuthorizerConfiguration",
+	})
+
 	v, err := generic.NewResource(ctx, opts...)
 
 	if err != nil {

--- a/internal/generic/resource.go
+++ b/internal/generic/resource.go
@@ -125,6 +125,34 @@ func resourceIsImmutableType(v bool) ResourceOptionsFunc {
 
 // resourceWithWriteOnlyPropertyPaths is a helper function to construct functional options
 // that set a resource type's write-only property paths (JSON Pointer).
+// resourceWithUpdateIgnorePropertyPaths is a helper function to construct functional options
+// that set paths to be excluded from both sides of the Update patch diff.
+// Use for Optional+Computed attributes where the CloudControl handler persists a value
+// that violates its own schema constraints (e.g. empty arrays for minItems>0 fields),
+// causing UpdateResource to fail with a ValidationException on any subsequent update
+// even when the patch does not touch those fields.
+// If multiple resourceWithUpdateIgnorePropertyPaths calls are made, the last call overrides
+// the previous calls' values.
+func resourceWithUpdateIgnorePropertyPaths(v []string) ResourceOptionsFunc {
+	return func(o *genericResource) error {
+		updateIgnoreAttributePaths := make([]*path.Path, 0)
+
+		for _, propertyPath := range v {
+			attributePath, err := o.propertyPathToAttributePath(propertyPath)
+
+			if err != nil {
+				continue
+			}
+
+			updateIgnoreAttributePaths = append(updateIgnoreAttributePaths, attributePath)
+		}
+
+		o.updateIgnoreAttributePaths = updateIgnoreAttributePaths
+
+		return nil
+	}
+}
+
 // If multiple resourceWithWriteOnlyPropertyPaths calls are made, the last call overrides
 // the previous calls' values.
 func resourceWithWriteOnlyPropertyPaths(v []string) ResourceOptionsFunc {
@@ -281,6 +309,13 @@ func (opts ResourceOptions) WithWriteOnlyPropertyPaths(v []string) ResourceOptio
 	return append(opts, resourceWithWriteOnlyPropertyPaths(v))
 }
 
+// WithUpdateIgnorePropertyPaths is a helper function to construct functional options
+// that exclude specified paths from both sides of the Update patch diff.
+// It is intended to be chained with other similar helper functions in a builder pattern.
+func (opts ResourceOptions) WithUpdateIgnorePropertyPaths(v []string) ResourceOptions {
+	return append(opts, resourceWithUpdateIgnorePropertyPaths(v))
+}
+
 // WithCreateTimeoutInMinutes is a helper function to construct functional options
 // that set a resource type's create timeout, append that function to the
 // current slice of functional options and return the new slice of options.
@@ -349,8 +384,9 @@ type genericResource struct {
 	tfTypeName              string                     // Terraform type name for resource type
 	tfToCfNameMap           map[string]string          // Map of Terraform attribute name to CloudFormation property name
 	cfToTfNameMap           map[string]string          // Map of CloudFormation property name to Terraform attribute name
-	isImmutableType         bool                       // Resources cannot be updated and must be recreated
-	writeOnlyAttributePaths []*path.Path               // Paths to any write-only attributes
+	isImmutableType            bool                       // Resources cannot be updated and must be recreated
+	writeOnlyAttributePaths    []*path.Path               // Paths to any write-only attributes
+	updateIgnoreAttributePaths []*path.Path               // Paths excluded from both sides of Update patch diff
 	createTimeout           time.Duration              // Maximum wait time for resource creation
 	updateTimeout           time.Duration              // Maximum wait time for resource update
 	deleteTimeout           time.Duration              // Maximum wait time for resource deletion
@@ -640,6 +676,39 @@ func (r *genericResource) Update(ctx context.Context, request resource.UpdateReq
 		if err != nil {
 			response.Diagnostics.Append(DesiredStateErrorDiag("Prior State", err))
 
+			return
+		}
+	}
+
+	// Clear paths that must be excluded from both sides of the Update patch diff.
+	// This prevents CloudControl from receiving patch operations for attributes whose
+	// stored values violate schema constraints (e.g. empty arrays for minItems>0 fields).
+	if len(r.updateIgnoreAttributePaths) > 0 {
+		nullifyPaths := func(raw tftypes.Value, s typeAtTerraformPather) (tftypes.Value, error) {
+			return tftypes.Transform(raw, func(tfPath *tftypes.AttributePath, val tftypes.Value) (tftypes.Value, error) {
+				if len(tfPath.Steps()) < 1 {
+					return val, nil
+				}
+				attrPath, diags := attributePath(ctx, tfPath, s)
+				if diags.HasError() {
+					return val, ccdiag.DiagnosticsError(diags)
+				}
+				for _, ignorePath := range r.updateIgnoreAttributePaths {
+					if ignorePath.Equal(attrPath) {
+						return tftypes.NewValue(val.Type(), nil), nil
+					}
+				}
+				return val, nil
+			})
+		}
+		currentStateRaw, err = nullifyPaths(currentStateRaw, currentState.Schema)
+		if err != nil {
+			response.Diagnostics.Append(DesiredStateErrorDiag("Prior State", err))
+			return
+		}
+		request.Plan.Raw, err = nullifyPaths(request.Plan.Raw, request.Plan.Schema)
+		if err != nil {
+			response.Diagnostics.Append(DesiredStateErrorDiag("Plan", err))
 			return
 		}
 	}

--- a/internal/generic/resource_test.go
+++ b/internal/generic/resource_test.go
@@ -7,7 +7,52 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
+
+func TestResourceWithUpdateIgnorePropertyPaths(t *testing.T) {
+	// Verify that resourceWithUpdateIgnorePropertyPaths correctly populates
+	// updateIgnoreAttributePaths, mirroring the writeOnlyPropertyPaths mechanism.
+	// The Update path uses these to zero out both sides of the patch diff so that
+	// CloudControl never receives patch operations for the affected attributes.
+	rt := genericResource{
+		cfToTfNameMap: map[string]string{
+			"AuthorizerConfiguration": "authorizer_configuration",
+			"Name":                    "name",
+		},
+	}
+
+	_ = schema.Schema{} // ensure schema import is used
+
+	opt := resourceWithUpdateIgnorePropertyPaths([]string{
+		"/properties/AuthorizerConfiguration",
+	})
+
+	if err := opt(&rt); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if len(rt.updateIgnoreAttributePaths) != 1 {
+		t.Fatalf("expected 1 updateIgnoreAttributePath, got %d", len(rt.updateIgnoreAttributePaths))
+	}
+
+	expected := path.Root("authorizer_configuration")
+	if !rt.updateIgnoreAttributePaths[0].Equal(expected) {
+		t.Errorf("got: %s, expected: %s", rt.updateIgnoreAttributePaths[0], expected)
+	}
+
+	// Invalid path should be silently skipped (mirrors writeOnlyPropertyPaths behaviour).
+	opt2 := resourceWithUpdateIgnorePropertyPaths([]string{
+		"/definitions/ShouldBeSkipped",
+	})
+	if err := opt2(&rt); err != nil {
+		t.Fatalf("unexpected error for invalid path: %s", err)
+	}
+	// rt still has the previous paths overwritten with zero because opt2 replaces the slice.
+	if len(rt.updateIgnoreAttributePaths) != 0 {
+		t.Errorf("expected invalid path to be skipped, got %d paths", len(rt.updateIgnoreAttributePaths))
+	}
+}
 
 func TestPropertyPathToAttributePath(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Description

Fixes #3186.

Some CloudControl handlers persist empty arrays (`[]`) for `Optional+Computed` list fields that have `minItems>0` in the CloudFormation schema, when those fields are not provided at resource creation time. `UpdateResource` re-validates the **full stored resource model** on every call — not just the patch delta — so `[]` fails `minItems:1` and blocks all subsequent updates, even those that do not touch the affected fields at all.

Example error from `AWS::BedrockAgentCore::Gateway`:
```
ValidationException: AllowedClients minimum 1, found 0
AllowedScopes minimum 1, found 0
```

This is a CloudControl API contract bug (tracked upstream at https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/2528), but the provider can work around it by ensuring those paths never appear in the patch document sent to `UpdateResource`.

## Changes

### `internal/generic/resource.go`

Adds `ResourceOptions.WithUpdateIgnorePropertyPaths([]string)` — a new option that zeroes out the specified attribute paths from **both** `currentStateRaw` and `request.Plan.Raw` before `patchDocument` is computed. When both sides of the diff are identical (both null/absent), no patch operation is generated for those paths, so `UpdateResource` never sees them and does not re-validate the stored empty arrays.

This mirrors the existing `WithWriteOnlyPropertyPaths` mechanism but applies symmetrically to both sides of the diff rather than only the prior-state side.

### `internal/aws/bedrockagentcore/gateway_resource_gen.go`

Wires `WithUpdateIgnorePropertyPaths` for `AuthorizerConfiguration` on the gateway resource, which exhibits this behaviour for `AllowedClients` and `AllowedScopes`.

### `internal/generic/resource_test.go`

Adds a unit test for `resourceWithUpdateIgnorePropertyPaths` covering correct path registration and silent skip of invalid paths.

## Testing

```
go test ./internal/generic/...   # all existing tests pass
```

Acceptance tests for `awscc_bedrockagentcore_gateway` would require a real AWS environment with a gateway created without `AllowedClients`/`AllowedScopes` — the fix prevents `ValidationException` on any subsequent `terraform apply`.

## Notes

- The `gateway_resource_gen.go` file is generated, but the contributing guide states that fixes to generation bugs in generated resources are acceptable. This change adds a call to a new `ResourceOptions` method and a comment explaining why — it does not modify the schema or any generated attribute.
- The underlying AWS bug means that any user who created a gateway without `AllowedClients`/`AllowedScopes` and then tries to update it via Terraform, CDK, or CloudFormation directly will hit the same `ValidationException` until AWS fixes the CloudControl handler.