### PR TITLE
generic: drop derived members of mutually exclusive property pairs from patch documents

### DIFF
--- a/internal/generic/patch.go
+++ b/internal/generic/patch.go
@@ -25,6 +25,8 @@ func patchDocument(old, new string) (string, error) {
 
 	patch = replaceKeyValueArrayPatchesWithFullReplace(patch, new)
 
+	patch = resolveMutuallyExclusiveProperties(patch, old)
+
 	// Sort the patch operations to ensure remove operations are applied in reverse order
 	sortedPatch := sortPatchOperations(patch)
 
@@ -45,6 +47,72 @@ func patchDocument(old, new string) (string, error) {
 	}
 
 	return result, nil
+}
+
+// mutuallyExclusivePropertyPairs lists property pairs that Cloud Control API returns
+// together in a resource model but that the underlying service rejects when both are
+// present in an update ("You must only specify exactly one of ..."). The first member
+// of each pair is the derived/decoded form and is the one dropped when both are present.
+var mutuallyExclusivePropertyPairs = [][2]string{
+	{"SearchString", "SearchStringBase64"}, // AWS::WAFv2::WebACL / RuleGroup ByteMatchStatement
+}
+
+// resolveMutuallyExclusiveProperties appends remove operations for known mutually
+// exclusive property pairs when the current resource model contains both members of a
+// pair in the same object. Cloud Control API's GetResource can return both (e.g. a WAFv2
+// ByteMatchStatement created with SearchStringBase64 is returned with SearchString too),
+// and the service then fails ANY update whose resulting model still carries both — even
+// an update that doesn't touch them. If the patch already modifies one member of the
+// pair, the other member is the one removed.
+func resolveMutuallyExclusiveProperties(patch []jsonpatch.JsonPatchOperation, oldState string) []jsonpatch.JsonPatchOperation {
+	var oldDoc map[string]any
+	if err := json.Unmarshal([]byte(oldState), &oldDoc); err != nil {
+		return patch
+	}
+
+	patchedPaths := make(map[string]bool, len(patch))
+	for _, op := range patch {
+		patchedPaths[op.Path] = true
+	}
+
+	var walk func(node any, path string)
+	walk = func(node any, path string) {
+		switch v := node.(type) {
+		case map[string]any:
+			for _, pair := range mutuallyExclusivePropertyPairs {
+				derived, canonical := pair[0], pair[1]
+				if v[derived] == nil || v[canonical] == nil {
+					continue
+				}
+				derivedPath := path + "/" + derived
+				canonicalPath := path + "/" + canonical
+				switch {
+				case patchedPaths[derivedPath] && patchedPaths[canonicalPath]:
+					// Both explicitly changed; leave the conflict to the service.
+				case patchedPaths[derivedPath]:
+					patch = append(patch, jsonpatch.NewPatch("remove", canonicalPath, nil))
+				default:
+					patch = append(patch, jsonpatch.NewPatch("remove", derivedPath, nil))
+				}
+			}
+			for key, val := range v {
+				walk(val, path+"/"+escapeJSONPointerToken(key))
+			}
+		case []any:
+			for idx, val := range v {
+				walk(val, path+"/"+strconv.Itoa(idx))
+			}
+		}
+	}
+	walk(oldDoc, "")
+
+	return patch
+}
+
+// escapeJSONPointerToken escapes a single JSON Pointer reference token (RFC 6901).
+func escapeJSONPointerToken(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	return strings.ReplaceAll(s, "/", "~1")
 }
 
 // replaceKeyValueArrayPatchesWithFullReplace replaces index-based patch operations targeting

--- a/internal/generic/patch_test.go
+++ b/internal/generic/patch_test.go
@@ -226,3 +226,103 @@ func Test_replaceKeyValueArrayPatchesWithFullReplace(t *testing.T) {
 		})
 	}
 }
+
+func Test_resolveMutuallyExclusiveProperties(t *testing.T) {
+	oldState := `{
+		"Description": "old",
+		"Rules": [
+			{
+				"Name": "r1",
+				"Statement": {
+					"ByteMatchStatement": {
+						"SearchString": "marker",
+						"SearchStringBase64": "bWFya2Vy",
+						"PositionalConstraint": "CONTAINS"
+					}
+				}
+			}
+		]
+	}`
+	oldStateSingle := `{
+		"Rules": [
+			{
+				"Statement": {
+					"ByteMatchStatement": {
+						"SearchStringBase64": "bWFya2Vy"
+					}
+				}
+			}
+		]
+	}`
+
+	tests := []struct {
+		name     string
+		oldState string
+		patch    []jsonpatch.JsonPatchOperation
+		want     []jsonpatch.JsonPatchOperation
+	}{
+		{
+			name:     "unrelated change drops derived member",
+			oldState: oldState,
+			patch: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "new"},
+			},
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "new"},
+				{Operation: "remove", Path: "/Rules/0/Statement/ByteMatchStatement/SearchString"},
+			},
+		},
+		{
+			name:     "changing derived member drops the other",
+			oldState: oldState,
+			patch: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Rules/0/Statement/ByteMatchStatement/SearchString", Value: "changed"},
+			},
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Rules/0/Statement/ByteMatchStatement/SearchString", Value: "changed"},
+				{Operation: "remove", Path: "/Rules/0/Statement/ByteMatchStatement/SearchStringBase64"},
+			},
+		},
+		{
+			name:     "both changed is left alone",
+			oldState: oldState,
+			patch: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Rules/0/Statement/ByteMatchStatement/SearchString", Value: "a"},
+				{Operation: "replace", Path: "/Rules/0/Statement/ByteMatchStatement/SearchStringBase64", Value: "YQ=="},
+			},
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Rules/0/Statement/ByteMatchStatement/SearchString", Value: "a"},
+				{Operation: "replace", Path: "/Rules/0/Statement/ByteMatchStatement/SearchStringBase64", Value: "YQ=="},
+			},
+		},
+		{
+			name:     "single member present is untouched",
+			oldState: oldStateSingle,
+			patch: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "new"},
+			},
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "new"},
+			},
+		},
+		{
+			name:     "invalid old state is a no-op",
+			oldState: "not json",
+			patch: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "new"},
+			},
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "new"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveMutuallyExclusiveProperties(tt.patch, tt.oldState)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resolveMutuallyExclusiveProperties() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #3243

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

## Description

Fixes updates failing with `You must only specify exactly one of SearchString and SearchStringBase64` on any `awscc_wafv2_web_acl` (or other resource) whose model contains a `ByteMatchStatement`.

### Root cause

Cloud Control API's `GetResource` returns **both** members of the pair — a byte-match statement created with `SearchStringBase64` comes back with a decoded `SearchString` as well. The service then rejects **any** subsequent `UpdateResource` whose resulting model still carries both, even when the patch doesn't touch them (e.g. a `description`-only edit). Verified with a raw `aws cloudcontrol update-resource` carrying only a `/Description` replace: same failure.

### Fix

`patchDocument` now consults a small table of known mutually exclusive property pairs (`SearchString`/`SearchStringBase64`). When the *current* resource model contains both members of a pair in the same object, it appends a `remove` for the derived member — or for the other member if the patch itself modifies the derived one — so the resulting model carries exactly one. If a patch explicitly modifies both members, it is left untouched and the conflict surfaces from the service.

Verified at the API level that a patch of `remove /.../SearchString` + the intended change succeeds where the same change alone fails.

### Verification

* Unit tests for the new behavior (unrelated change, derived-member change, both-changed, single-member, invalid state).
* Live end-to-end on a REGIONAL web ACL created with `SearchStringBase64` via `aws wafv2 create-web-acl`, imported, then `description` edited:
  * before the fix: `apply` fails with the error above (reproduced on current `main`);
  * with the fix: `apply` succeeds and `aws wafv2 get-web-acl` confirms the byte-match rule is unchanged.
* `go build ./...`, `gofmt -l`, `go vet`, `go test ./internal/generic/` all pass.
