### PR TITLE
generator: deduplicate emitted schema attributes

### DIFF
--- a/internal/provider/generators/resource/schema.tmpl
+++ b/internal/provider/generators/resource/schema.tmpl
@@ -50,6 +50,7 @@ import (
 	"github.com/hashicorp/terraform-provider-awscc/internal/registry"
 )
 
+{{ .AttributeFunctions }}
 func init() {
 	registry.AddResourceFactory("{{ .TerraformTypeName }}", {{ .FactoryFunctionName }})
 	{{- if .GenerateListResource }}

--- a/internal/provider/generators/shared/codegen/emitter.go
+++ b/internal/provider/generators/shared/codegen/emitter.go
@@ -4,6 +4,7 @@
 package codegen
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"regexp"
@@ -68,11 +69,14 @@ var (
 	}
 )
 
+const attributeFunctionHashBytes = 12
+
 type Emitter struct {
-	CfResource   *cfschema.Resource
-	IsDataSource bool
-	Ui           cli.Ui
-	Writer       io.Writer
+	CfResource         *cfschema.Resource
+	IsDataSource       bool
+	Ui                 cli.Ui
+	Writer             io.Writer
+	attributeFunctions *attributeFunctionRegistry
 }
 
 type parent struct {
@@ -84,23 +88,87 @@ type parent struct {
 	}
 }
 
+type attributeFunction struct {
+	body string
+	name string
+}
+
+type attributeFunctionRegistry struct {
+	functionsByBody map[string]attributeFunction
+	functionsByName map[string]attributeFunction
+	scope           string
+}
+
+func newAttributeFunctionRegistry(tfType string, isDataSource bool) *attributeFunctionRegistry {
+	scope := tfType + "\x00resource"
+	if isDataSource {
+		scope = tfType + "\x00data-source"
+	}
+
+	return &attributeFunctionRegistry{
+		functionsByBody: make(map[string]attributeFunction),
+		functionsByName: make(map[string]attributeFunction),
+		scope:           scope,
+	}
+}
+
+func (r *attributeFunctionRegistry) register(body string) (string, error) {
+	if function, ok := r.functionsByBody[body]; ok {
+		return function.name, nil
+	}
+
+	hash := sha256.Sum256([]byte(r.scope + "\x00" + body))
+	// Keep generated call sites compact. The registry still rejects a collision.
+	name := fmt.Sprintf("schemaAttribute%x", hash[:attributeFunctionHashBytes])
+	if function, ok := r.functionsByName[name]; ok {
+		return "", fmt.Errorf("schema attribute function hash collision between %q and %q", function.body, body)
+	}
+
+	function := attributeFunction{
+		body: body,
+		name: name,
+	}
+	r.functionsByBody[body] = function
+	r.functionsByName[name] = function
+
+	return name, nil
+}
+
+func (r *attributeFunctionRegistry) render() string {
+	names := tfmaps.Keys(r.functionsByName)
+	sort.Strings(names)
+
+	var w strings.Builder
+	for _, name := range names {
+		function := r.functionsByName[name]
+		fprintf(&w, "func %s() schema.Attribute {\n", function.name)
+		fprintf(&w, "return (\n%s)\n", function.body)
+		fprintf(&w, "}\n\n")
+	}
+
+	return w.String()
+}
+
 // EmitRootPropertiesSchema generates the Terraform Plugin SDK code for a CloudFormation root schema
-// and emits the generated code to the emitter's Writer. Code features are returned.
+// and emits the generated code to the emitter's Writer. Code features and the deduplicated
+// top-level attribute function declarations are returned.
 // The root schema is the map of root property names to Attributes.
-func (e Emitter) EmitRootPropertiesSchema(tfType string, attributeNameMap map[string]string) (Features, error) {
+func (e Emitter) EmitRootPropertiesSchema(tfType string, attributeNameMap map[string]string) (Features, string, error) {
 	var features Features
+
+	e.attributeFunctions = newAttributeFunctionRegistry(tfType, e.IsDataSource)
 
 	cfResource := e.CfResource
 	features, err := e.emitSchema(tfType, attributeNameMap, parent{reqd: cfResource}, cfResource.Properties)
 
 	if err != nil {
-		return features, err
+		return features, "", err
 	}
 
 	for name := range cfResource.Properties {
 		for _, tfMetaArgument := range tfMetaArguments {
 			if naming.CloudFormationPropertyToTerraformAttribute(name) == tfMetaArgument {
-				return features, fmt.Errorf("top-level property %s conflicts with Terraform meta-argument: %s", name, tfMetaArgument)
+				return features, "", fmt.Errorf("top-level property %s conflicts with Terraform meta-argument: %s", name, tfMetaArgument)
 			}
 		}
 
@@ -109,7 +177,7 @@ func (e Emitter) EmitRootPropertiesSchema(tfType string, attributeNameMap map[st
 		}
 	}
 
-	return features, nil
+	return features, e.attributeFunctions.render(), nil
 }
 
 // emitAttribute generates the Terraform Plugin SDK code for a CloudFormation property's Attributes
@@ -1034,9 +1102,11 @@ func (e Emitter) emitSchema(tfType string, attributeNameMap map[string]string, p
 			e.printf("%s\n", regexp.MustCompile(`(?m)^`).ReplaceAllString(fmt.Sprintf("%v", properties[name]), "// "))
 		}
 
-		e.printf("%q:", tfAttributeName)
+		var attributeBody strings.Builder
+		attributeEmitter := e
+		attributeEmitter.Writer = &attributeBody
 
-		f, err := e.emitAttribute(
+		f, err := attributeEmitter.emitAttribute(
 			tfType,
 			attributeNameMap,
 			append(parent.path, name),
@@ -1053,7 +1123,12 @@ func (e Emitter) emitSchema(tfType string, attributeNameMap map[string]string, p
 
 		features = features.LogicalOr(f)
 
-		e.printf(",\n")
+		functionName, err := e.attributeFunctions.register(attributeBody.String())
+		if err != nil {
+			return features, err
+		}
+
+		e.printf("%q:%s(),\n", tfAttributeName, functionName)
 	}
 	e.printf("}/*END SCHEMA*/")
 

--- a/internal/provider/generators/shared/codegen/emitter_test.go
+++ b/internal/provider/generators/shared/codegen/emitter_test.go
@@ -1,0 +1,166 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package codegen
+
+import (
+	"go/format"
+	"regexp"
+	"strings"
+	"testing"
+
+	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
+	"github.com/hashicorp/cli"
+)
+
+func TestEmitterAttributeFunctionDeduplication(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		createOnlyProperties cfschema.PropertyJsonPointers
+		expectedFunctions    int
+		expectedSameRootCall bool
+	}{
+		"identical rendered attributes": {
+			expectedFunctions:    2,
+			expectedSameRootCall: true,
+		},
+		"path-specific attributes": {
+			createOnlyProperties: cfschema.PropertyJsonPointers{
+				cfschema.PropertyJsonPointer("/properties/First"),
+			},
+			expectedFunctions:    3,
+			expectedSameRootCall: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resource := testNestedResource()
+			resource.CreateOnlyProperties = testCase.createOnlyProperties
+
+			rootSchema, attributeFunctions := emitTestResource(t, resource, false)
+			rootCalls := regexp.MustCompile(`"(?:first|second)":(schemaAttribute[0-9a-f]+)\(\)`).FindAllStringSubmatch(rootSchema, -1)
+			if got, want := len(rootCalls), 2; got != want {
+				t.Fatalf("root attribute call count = %d, want %d\n%s", got, want, rootSchema)
+			}
+
+			callsSameFunction := rootCalls[0][1] == rootCalls[1][1]
+			if got, want := callsSameFunction, testCase.expectedSameRootCall; got != want {
+				t.Fatalf("root attributes call same function = %t, want %t\n%s", got, want, rootSchema)
+			}
+
+			if got, want := strings.Count(attributeFunctions, "func schemaAttribute"), testCase.expectedFunctions; got != want {
+				t.Fatalf("attribute function count = %d, want %d\n%s", got, want, attributeFunctions)
+			}
+
+			source := "package generated\n\n" + attributeFunctions + "\nvar _ = " + rootSchema
+			if _, err := format.Source([]byte(source)); err != nil {
+				t.Fatalf("generated code is not valid Go: %s\n%s", err, source)
+			}
+		})
+	}
+}
+
+func TestEmitterAttributeFunctionsAreDeterministic(t *testing.T) {
+	t.Parallel()
+
+	firstRootSchema, firstAttributeFunctions := emitTestResource(t, testNestedResource(), false)
+	secondRootSchema, secondAttributeFunctions := emitTestResource(t, testNestedResource(), false)
+
+	if firstRootSchema != secondRootSchema {
+		t.Fatalf("root schema changed between runs:\nfirst:\n%s\nsecond:\n%s", firstRootSchema, secondRootSchema)
+	}
+	if firstAttributeFunctions != secondAttributeFunctions {
+		t.Fatalf("attribute functions changed between runs:\nfirst:\n%s\nsecond:\n%s", firstAttributeFunctions, secondAttributeFunctions)
+	}
+}
+
+func TestAttributeFunctionNamesAreScoped(t *testing.T) {
+	t.Parallel()
+
+	body := "schema.StringAttribute{}"
+	resourceRegistry := newAttributeFunctionRegistry("awscc_test_thing", false)
+	dataSourceRegistry := newAttributeFunctionRegistry("awscc_test_thing", true)
+	otherResourceRegistry := newAttributeFunctionRegistry("awscc_test_other", false)
+
+	resourceName, err := resourceRegistry.register(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataSourceName, err := dataSourceRegistry.register(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherResourceName, err := otherResourceRegistry.register(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resourceName == dataSourceName || resourceName == otherResourceName || dataSourceName == otherResourceName {
+		t.Fatalf("attribute function names are not scoped: resource=%q data_source=%q other_resource=%q", resourceName, dataSourceName, otherResourceName)
+	}
+}
+
+func TestAttributeFunctionRenderHandlesLeadingComment(t *testing.T) {
+	t.Parallel()
+
+	registry := newAttributeFunctionRegistry("awscc_test_thing", false)
+	body := "// Pattern: \"\"\nschema.MapAttribute{}"
+	if _, err := registry.register(body); err != nil {
+		t.Fatal(err)
+	}
+
+	rendered := registry.render()
+	if want := "return (\n" + body + ")"; !strings.Contains(rendered, want) {
+		t.Fatalf("attribute function does not parenthesize its body:\n%s", rendered)
+	}
+
+	source := "package generated\n\n" + rendered
+	if _, err := format.Source([]byte(source)); err != nil {
+		t.Fatalf("generated code is not valid Go: %s\n%s", err, source)
+	}
+}
+
+func emitTestResource(t *testing.T, resource *cfschema.Resource, isDataSource bool) (string, string) {
+	t.Helper()
+
+	var rootSchema strings.Builder
+	emitter := Emitter{
+		CfResource:   resource,
+		IsDataSource: isDataSource,
+		Ui:           cli.NewMockUi(),
+		Writer:       &rootSchema,
+	}
+
+	_, attributeFunctions, err := emitter.EmitRootPropertiesSchema("awscc_test_thing", make(map[string]string))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return rootSchema.String(), attributeFunctions
+}
+
+func testNestedResource() *cfschema.Resource {
+	stringType := cfschema.Type(cfschema.PropertyTypeString)
+	objectType := cfschema.Type(cfschema.PropertyTypeObject)
+	nestedProperty := func() *cfschema.Property {
+		return &cfschema.Property{
+			Type: &objectType,
+			Properties: map[string]*cfschema.Property{
+				"Value": {
+					Type: &stringType,
+				},
+			},
+		}
+	}
+
+	return &cfschema.Resource{
+		Properties: map[string]*cfschema.Property{
+			"First":  nestedProperty(),
+			"Second": nestedProperty(),
+		},
+	}
+}

--- a/internal/provider/generators/shared/template_data.go
+++ b/internal/provider/generators/shared/template_data.go
@@ -67,7 +67,7 @@ func GenerateTemplateData(ui cli.Ui, cfTypeSchemaFile, resType, tfResourceType, 
 
 	// Generate code for the CloudFormation root properties schema.
 	attributeNameMap := make(map[string]string) // Terraform attribute name to CloudFormation property name.
-	codeFeatures, err := codeEmitter.EmitRootPropertiesSchema(resource.TfType, attributeNameMap)
+	codeFeatures, attributeFunctions, err := codeEmitter.EmitRootPropertiesSchema(resource.TfType, attributeNameMap)
 
 	if err != nil {
 		return nil, fmt.Errorf("emitting schema code: %w", err)
@@ -78,6 +78,7 @@ func GenerateTemplateData(ui cli.Ui, cfTypeSchemaFile, resType, tfResourceType, 
 
 	templateData := &TemplateData{
 		AcceptanceTestFunctionPrefix: acceptanceTestFunctionPrefix,
+		AttributeFunctions:           attributeFunctions,
 		AttributeNameMap:             attributeNameMap,
 		CloudFormationTypeName:       cfTypeName,
 		FactoryFunctionName:          factoryFunctionName,
@@ -209,6 +210,7 @@ func GenerateTemplateData(ui cli.Ui, cfTypeSchemaFile, resType, tfResourceType, 
 
 type TemplateData struct {
 	AcceptanceTestFunctionPrefix  string
+	AttributeFunctions            string
 	AttributeNameMap              map[string]string
 	CloudFormationTypeName        string
 	CreateTimeoutInMinutes        int

--- a/internal/provider/generators/singular-data-source/schema.tmpl
+++ b/internal/provider/generators/singular-data-source/schema.tmpl
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-awscc/internal/registry"
 )
 
+{{ .AttributeFunctions }}
 func init() {
 	registry.AddDataSourceFactory("{{ .TerraformTypeName }}", {{ .FactoryFunctionName }})
 }


### PR DESCRIPTION
## Summary

- render each generated schema attribute into a private buffer and intern exact rendered bodies
- emit deterministic package-level helper functions, with names scoped by Terraform type and resource/data-source kind
- keep path-sensitive variants distinct while reusing byte-identical nested attributes

The helpers construct fresh schema values at every call site, so runtime behavior is unchanged. This unblocks the deeper WAFv2 schema work in #3227 without stacking the two changes.

## Results

- resource generation output: 34.78 MB to 32.90 MB across 1,443 generated resource source files (5.4% smaller)
- two complete resource/data-source generations produced byte-identical SHA-256 manifests for all 5,774 generated files
- docs regeneration produced no tracked changes
- depth-4 WAFv2 WebACL: 49,763,591 bytes and 213 unique attribute helpers
- depth-4 WAFv2 RuleGroup: 19,005,869 bytes and 157 unique attribute helpers
- both depth-4 resources compile successfully; the previous `NewBulk too big` compiler failure is eliminated

## Validation

- `go test ./...`
- `go vet ./internal/provider/generators/shared/...`
- `make resources singular-data-sources` (two full passes)
- `make docs`
- `go test ./internal/aws/wafv2` with depth-4 schemas generated by #3227's de-recursion tool
- full provider build with both depth-4 WAFv2 schemas
- live create, zero-diff refresh, import, zero-diff refresh, update, zero-diff refresh, destroy, and service-level deletion verification for depth-4 WAFv2 WebACL/RuleGroup plus S3 Bucket and CloudFront Function

Closes #3242
