### PR TITLE
Fix #3019: service/sagemaker: sync AWS::SageMaker::Cluster schema (excluding FsxLustreConfig)

### DIFF
--- a/docs/data-sources/sagemaker_cluster.md
+++ b/docs/data-sources/sagemaker_cluster.md
@@ -31,8 +31,9 @@ Data Source schema for AWS::SageMaker::Cluster
 - `instance_groups` (Attributes List) The instance groups of the SageMaker HyperPod cluster. (see [below for nested schema](#nestedatt--instance_groups))
 - `node_provisioning_mode` (String) Determines the scaling strategy for the SageMaker HyperPod cluster. When set to 'Continuous', enables continuous scaling which dynamically manages node provisioning. If the parameter is omitted, uses the standard scaling approach in previous release.
 - `node_recovery` (String) If node auto-recovery is set to true, faulty nodes will be replaced or rebooted when a failure is detected. If set to false, nodes will be labelled when a fault is detected.
-- `orchestrator` (Attributes) Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster. (see [below for nested schema](#nestedatt--orchestrator))
+- `orchestrator` (Attributes) Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster or Slurm configuration. (see [below for nested schema](#nestedatt--orchestrator))
 - `restricted_instance_groups` (Attributes List) The restricted instance groups of the SageMaker HyperPod cluster. (see [below for nested schema](#nestedatt--restricted_instance_groups))
+- `restricted_instance_groups_config` (Attributes) The cluster-level configuration for restricted instance groups, including shared environment settings for inter-RIG communication and FSx Lustre sharing. (see [below for nested schema](#nestedatt--restricted_instance_groups_config))
 - `tags` (Attributes Set) Custom tags for managing the SageMaker HyperPod cluster as an AWS resource. You can add tags to your cluster in the same way you add them in other AWS services that support tagging. (see [below for nested schema](#nestedatt--tags))
 - `tiered_storage_config` (Attributes) Configuration for tiered storage in the SageMaker HyperPod cluster. (see [below for nested schema](#nestedatt--tiered_storage_config))
 - `vpc_config` (Attributes) Specifies an Amazon Virtual Private Cloud (VPC) that your SageMaker jobs, hosted models, and compute resources have access to. You can control access to and from your resources by configuring a VPC. (see [below for nested schema](#nestedatt--vpc_config))
@@ -51,22 +52,89 @@ Read-Only:
 
 Read-Only:
 
+- `auto_patch_config` (Attributes) The configuration for automatic patching of the instance group. Enables workload-aware, patch-level AMI updates. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config))
 - `capacity_requirements` (Attributes) Specifies the capacity requirements configuration for an instance group (see [below for nested schema](#nestedatt--instance_groups--capacity_requirements))
 - `current_count` (Number) The number of instances that are currently in the instance group of a SageMaker HyperPod cluster.
 - `execution_role` (String) The execution role for the instance group to assume.
 - `image_id` (String) AMI Id to be used for launching EC2 instances - HyperPodPublicAmiId or CustomAmiId
 - `instance_count` (Number) The number of instances you specified to add to the instance group of a SageMaker HyperPod cluster.
 - `instance_group_name` (String) The name of the instance group of a SageMaker HyperPod cluster.
+- `instance_requirements` (Attributes) The instance requirements for the instance group. Specifies a list of instance types that can be used. (see [below for nested schema](#nestedatt--instance_groups--instance_requirements))
 - `instance_storage_configs` (Attributes List) The instance storage configuration for the instance group. (see [below for nested schema](#nestedatt--instance_groups--instance_storage_configs))
 - `instance_type` (String) The instance type of the instance group of a SageMaker HyperPod cluster.
 - `kubernetes_config` (Attributes) Kubernetes configuration for cluster nodes including labels and taints. (see [below for nested schema](#nestedatt--instance_groups--kubernetes_config))
-- `life_cycle_config` (Attributes) The lifecycle configuration for a SageMaker HyperPod cluster. (see [below for nested schema](#nestedatt--instance_groups--life_cycle_config))
+- `life_cycle_config` (Attributes) The lifecycle configuration for a SageMaker HyperPod cluster. When omitted, the instance group uses Bootstrap mode. When provided with SourceS3Uri and OnCreate, uses Customer Managed mode. When provided with SourceS3Uri and OnInitComplete, uses Extended mode. (see [below for nested schema](#nestedatt--instance_groups--life_cycle_config))
 - `min_instance_count` (Number) The minimum number of instances required for the instance group to be InService. MinInstanceCount must be less than or equal to InstanceCount.
+- `network_interface` (Attributes) Specifies the network interface configuration for the instance group. (see [below for nested schema](#nestedatt--instance_groups--network_interface))
 - `on_start_deep_health_checks` (List of String) Nodes will undergo advanced stress test to detect and replace faulty instances, based on the type of deep health check(s) passed in.
 - `override_vpc_config` (Attributes) Specifies an Amazon Virtual Private Cloud (VPC) that your SageMaker jobs, hosted models, and compute resources have access to. You can control access to and from your resources by configuring a VPC. (see [below for nested schema](#nestedatt--instance_groups--override_vpc_config))
 - `scheduled_update_config` (Attributes) The configuration object of the schedule that SageMaker follows when updating the AMI. (see [below for nested schema](#nestedatt--instance_groups--scheduled_update_config))
+- `slurm_config` (Attributes) Slurm configuration for the instance group. (see [below for nested schema](#nestedatt--instance_groups--slurm_config))
 - `threads_per_core` (Number) The number you specified to TreadsPerCore in CreateCluster for enabling or disabling multithreading. For instance types that support multithreading, you can specify 1 for disabling multithreading and 2 for enabling multithreading.
 - `training_plan_arn` (String) The Amazon Resource Name (ARN) of the training plan to use for this cluster instance group. For more information about how to reserve GPU capacity for your SageMaker HyperPod clusters using Amazon SageMaker Training Plan, see CreateTrainingPlan.
+
+<a id="nestedatt--instance_groups--auto_patch_config"></a>
+### Nested Schema for `instance_groups.auto_patch_config`
+
+Read-Only:
+
+- `deployment_config` (Attributes) The configuration to use when updating the AMI versions. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config))
+- `patch_schedule` (Attributes) The schedule configuration for automatic patching. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--patch_schedule))
+- `patching_strategy` (String) The patching strategy that determines when and how instances are patched. WhenIdle patches instances as they become idle. WhenAllIdle patches all instances when they are all idle.
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config`
+
+Read-Only:
+
+- `auto_rollback_configuration` (Attributes List) An array that contains the alarms that SageMaker monitors to know whether to roll back the AMI update. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config--auto_rollback_configuration))
+- `rolling_update_policy` (Attributes) The policy that SageMaker uses when updating the AMI versions of the cluster. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy))
+- `wait_interval_in_seconds` (Number) The duration in seconds that SageMaker waits before updating more instances in the cluster.
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config--auto_rollback_configuration"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config.auto_rollback_configuration`
+
+Read-Only:
+
+- `alarm_name` (String) The name of the alarm.
+
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config.rolling_update_policy`
+
+Read-Only:
+
+- `maximum_batch_size` (Attributes) The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy--maximum_batch_size))
+- `rollback_maximum_batch_size` (Attributes) The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy--rollback_maximum_batch_size))
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy--maximum_batch_size"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config.rolling_update_policy.maximum_batch_size`
+
+Read-Only:
+
+- `type` (String) Specifies whether SageMaker should process the update by amount or percentage of instances.
+- `value` (Number) Specifies the amount or percentage of instances SageMaker updates at a time.
+
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy--rollback_maximum_batch_size"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config.rolling_update_policy.rollback_maximum_batch_size`
+
+Read-Only:
+
+- `type` (String) Specifies whether SageMaker should process the update by amount or percentage of instances.
+- `value` (Number) Specifies the amount or percentage of instances SageMaker updates at a time.
+
+
+
+
+<a id="nestedatt--instance_groups--auto_patch_config--patch_schedule"></a>
+### Nested Schema for `instance_groups.auto_patch_config.patch_schedule`
+
+Read-Only:
+
+- `next_patch_date` (String) The date and time of the next scheduled patch, set by the system when a patch AMI is detected.
+
+
 
 <a id="nestedatt--instance_groups--capacity_requirements"></a>
 ### Nested Schema for `instance_groups.capacity_requirements`
@@ -77,12 +145,21 @@ Read-Only:
 - `spot` (String) Options for Spot capacity
 
 
+<a id="nestedatt--instance_groups--instance_requirements"></a>
+### Nested Schema for `instance_groups.instance_requirements`
+
+Read-Only:
+
+- `instance_types` (List of String) A list of instance types that can be used for this instance group.
+
+
 <a id="nestedatt--instance_groups--instance_storage_configs"></a>
 ### Nested Schema for `instance_groups.instance_storage_configs`
 
 Read-Only:
 
 - `ebs_volume_config` (Attributes) Defines the configuration for attaching additional Amazon Elastic Block Store (EBS) volumes to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker. (see [below for nested schema](#nestedatt--instance_groups--instance_storage_configs--ebs_volume_config))
+- `fsx_open_zfs_config` (Attributes) Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group. (see [below for nested schema](#nestedatt--instance_groups--instance_storage_configs--fsx_open_zfs_config))
 
 <a id="nestedatt--instance_groups--instance_storage_configs--ebs_volume_config"></a>
 ### Nested Schema for `instance_groups.instance_storage_configs.ebs_volume_config`
@@ -92,6 +169,15 @@ Read-Only:
 - `root_volume` (Boolean)
 - `volume_kms_key_id` (String)
 - `volume_size_in_gb` (Number) The size in gigabytes (GB) of the additional EBS volume to be attached to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker.
+
+
+<a id="nestedatt--instance_groups--instance_storage_configs--fsx_open_zfs_config"></a>
+### Nested Schema for `instance_groups.instance_storage_configs.fsx_open_zfs_config`
+
+Read-Only:
+
+- `dns_name` (String) The DNS name of the FSx for OpenZFS file system.
+- `mount_path` (String) The mount path for the FSx for OpenZFS file system.
 
 
 
@@ -119,8 +205,17 @@ Read-Only:
 
 Read-Only:
 
-- `on_create` (String) The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation.
+- `on_create` (String) The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation. Mutually exclusive with OnInitComplete.
+- `on_init_complete` (String) The file name of the extension script under SourceS3Uri. This script runs after HyperPod configures the default software on the instance. Mutually exclusive with OnCreate.
 - `source_s3_uri` (String) An Amazon S3 bucket path where your lifecycle scripts are stored.
+
+
+<a id="nestedatt--instance_groups--network_interface"></a>
+### Nested Schema for `instance_groups.network_interface`
+
+Read-Only:
+
+- `interface_type` (String) The type of network interface.
 
 
 <a id="nestedatt--instance_groups--override_vpc_config"></a>
@@ -186,6 +281,15 @@ Read-Only:
 
 
 
+<a id="nestedatt--instance_groups--slurm_config"></a>
+### Nested Schema for `instance_groups.slurm_config`
+
+Read-Only:
+
+- `node_type` (String) The type of Slurm node for this instance group.
+- `partition_names` (List of String) The Slurm partitions that this instance group belongs to. Maximum of 1 partition.
+
+
 
 <a id="nestedatt--orchestrator"></a>
 ### Nested Schema for `orchestrator`
@@ -193,6 +297,7 @@ Read-Only:
 Read-Only:
 
 - `eks` (Attributes) Specifies parameter(s) related to EKS as orchestrator, e.g. the EKS cluster nodes will attach to, (see [below for nested schema](#nestedatt--orchestrator--eks))
+- `slurm` (Attributes) Specifies parameter(s) related to Slurm as orchestrator. (see [below for nested schema](#nestedatt--orchestrator--slurm))
 
 <a id="nestedatt--orchestrator--eks"></a>
 ### Nested Schema for `orchestrator.eks`
@@ -200,6 +305,14 @@ Read-Only:
 Read-Only:
 
 - `cluster_arn` (String) The ARN of the EKS cluster, such as arn:aws:eks:us-west-2:123456789012:cluster/my-eks-cluster
+
+
+<a id="nestedatt--orchestrator--slurm"></a>
+### Nested Schema for `orchestrator.slurm`
+
+Read-Only:
+
+- `slurm_config_strategy` (String) The strategy for managing Slurm configuration on the cluster.
 
 
 
@@ -243,6 +356,7 @@ Read-Only:
 Read-Only:
 
 - `ebs_volume_config` (Attributes) Defines the configuration for attaching additional Amazon Elastic Block Store (EBS) volumes to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker. (see [below for nested schema](#nestedatt--restricted_instance_groups--instance_storage_configs--ebs_volume_config))
+- `fsx_open_zfs_config` (Attributes) Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group. (see [below for nested schema](#nestedatt--restricted_instance_groups--instance_storage_configs--fsx_open_zfs_config))
 
 <a id="nestedatt--restricted_instance_groups--instance_storage_configs--ebs_volume_config"></a>
 ### Nested Schema for `restricted_instance_groups.instance_storage_configs.ebs_volume_config`
@@ -254,6 +368,15 @@ Read-Only:
 - `volume_size_in_gb` (Number) The size in gigabytes (GB) of the additional EBS volume to be attached to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker.
 
 
+<a id="nestedatt--restricted_instance_groups--instance_storage_configs--fsx_open_zfs_config"></a>
+### Nested Schema for `restricted_instance_groups.instance_storage_configs.fsx_open_zfs_config`
+
+Read-Only:
+
+- `dns_name` (String) The DNS name of the FSx for OpenZFS file system.
+- `mount_path` (String) The mount path for the FSx for OpenZFS file system.
+
+
 
 <a id="nestedatt--restricted_instance_groups--override_vpc_config"></a>
 ### Nested Schema for `restricted_instance_groups.override_vpc_config`
@@ -262,6 +385,32 @@ Read-Only:
 
 - `security_group_ids` (List of String) The VPC security group IDs, in the form sg-xxxxxxxx. Specify the security groups for the VPC that is specified in the Subnets field.
 - `subnets` (List of String) The ID of the subnets in the VPC to which you want to connect your training job or model.
+
+
+
+<a id="nestedatt--restricted_instance_groups_config"></a>
+### Nested Schema for `restricted_instance_groups_config`
+
+Read-Only:
+
+- `shared_environment_config` (Attributes) The shared environment configuration for restricted instance groups that use cluster-level shared FSx Lustre storage. (see [below for nested schema](#nestedatt--restricted_instance_groups_config--shared_environment_config))
+
+<a id="nestedatt--restricted_instance_groups_config--shared_environment_config"></a>
+### Nested Schema for `restricted_instance_groups_config.shared_environment_config`
+
+Read-Only:
+
+- `fsx_lustre_config` (Attributes) Configuration settings for an Amazon FSx for Lustre file system to be used with the cluster. (see [below for nested schema](#nestedatt--restricted_instance_groups_config--shared_environment_config--fsx_lustre_config))
+- `fsx_lustre_deletion_policy` (String) The deletion policy for the shared FSx Lustre file system. Keep retains the FSx when RIGs are deleted. DeleteIfNotUsed deletes the FSx when no RIGs reference it.
+
+<a id="nestedatt--restricted_instance_groups_config--shared_environment_config--fsx_lustre_config"></a>
+### Nested Schema for `restricted_instance_groups_config.shared_environment_config.fsx_lustre_config`
+
+Read-Only:
+
+- `per_unit_storage_throughput` (Number) The throughput capacity of the FSx for Lustre file system, measured in MB/s per TiB of storage.
+- `size_in_gi_b` (Number) The storage capacity of the FSx for Lustre file system, specified in gibibytes (GiB).
+
 
 
 

--- a/docs/resources/sagemaker_cluster.md
+++ b/docs/resources/sagemaker_cluster.md
@@ -322,8 +322,9 @@ variable "subnet_2" {
 - `instance_groups` (Attributes List) The instance groups of the SageMaker HyperPod cluster. (see [below for nested schema](#nestedatt--instance_groups))
 - `node_provisioning_mode` (String) Determines the scaling strategy for the SageMaker HyperPod cluster. When set to 'Continuous', enables continuous scaling which dynamically manages node provisioning. If the parameter is omitted, uses the standard scaling approach in previous release.
 - `node_recovery` (String) If node auto-recovery is set to true, faulty nodes will be replaced or rebooted when a failure is detected. If set to false, nodes will be labelled when a fault is detected.
-- `orchestrator` (Attributes) Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster. (see [below for nested schema](#nestedatt--orchestrator))
+- `orchestrator` (Attributes) Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster or Slurm configuration. (see [below for nested schema](#nestedatt--orchestrator))
 - `restricted_instance_groups` (Attributes List) The restricted instance groups of the SageMaker HyperPod cluster. (see [below for nested schema](#nestedatt--restricted_instance_groups))
+- `restricted_instance_groups_config` (Attributes) The cluster-level configuration for restricted instance groups, including shared environment settings for inter-RIG communication and FSx Lustre sharing. (see [below for nested schema](#nestedatt--restricted_instance_groups_config))
 - `tags` (Attributes Set) Custom tags for managing the SageMaker HyperPod cluster as an AWS resource. You can add tags to your cluster in the same way you add them in other AWS services that support tagging. (see [below for nested schema](#nestedatt--tags))
 - `tiered_storage_config` (Attributes) Configuration for tiered storage in the SageMaker HyperPod cluster. (see [below for nested schema](#nestedatt--tiered_storage_config))
 - `vpc_config` (Attributes) Specifies an Amazon Virtual Private Cloud (VPC) that your SageMaker jobs, hosted models, and compute resources have access to. You can control access to and from your resources by configuring a VPC. (see [below for nested schema](#nestedatt--vpc_config))
@@ -350,22 +351,89 @@ Optional:
 
 Optional:
 
+- `auto_patch_config` (Attributes) The configuration for automatic patching of the instance group. Enables workload-aware, patch-level AMI updates. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config))
 - `capacity_requirements` (Attributes) Specifies the capacity requirements configuration for an instance group (see [below for nested schema](#nestedatt--instance_groups--capacity_requirements))
 - `current_count` (Number) The number of instances that are currently in the instance group of a SageMaker HyperPod cluster.
 - `execution_role` (String) The execution role for the instance group to assume.
 - `image_id` (String) AMI Id to be used for launching EC2 instances - HyperPodPublicAmiId or CustomAmiId
 - `instance_count` (Number) The number of instances you specified to add to the instance group of a SageMaker HyperPod cluster.
 - `instance_group_name` (String) The name of the instance group of a SageMaker HyperPod cluster.
+- `instance_requirements` (Attributes) The instance requirements for the instance group. Specifies a list of instance types that can be used. (see [below for nested schema](#nestedatt--instance_groups--instance_requirements))
 - `instance_storage_configs` (Attributes List) The instance storage configuration for the instance group. (see [below for nested schema](#nestedatt--instance_groups--instance_storage_configs))
 - `instance_type` (String) The instance type of the instance group of a SageMaker HyperPod cluster.
 - `kubernetes_config` (Attributes) Kubernetes configuration for cluster nodes including labels and taints. (see [below for nested schema](#nestedatt--instance_groups--kubernetes_config))
-- `life_cycle_config` (Attributes) The lifecycle configuration for a SageMaker HyperPod cluster. (see [below for nested schema](#nestedatt--instance_groups--life_cycle_config))
+- `life_cycle_config` (Attributes) The lifecycle configuration for a SageMaker HyperPod cluster. When omitted, the instance group uses Bootstrap mode. When provided with SourceS3Uri and OnCreate, uses Customer Managed mode. When provided with SourceS3Uri and OnInitComplete, uses Extended mode. (see [below for nested schema](#nestedatt--instance_groups--life_cycle_config))
 - `min_instance_count` (Number) The minimum number of instances required for the instance group to be InService. MinInstanceCount must be less than or equal to InstanceCount.
+- `network_interface` (Attributes) Specifies the network interface configuration for the instance group. (see [below for nested schema](#nestedatt--instance_groups--network_interface))
 - `on_start_deep_health_checks` (List of String) Nodes will undergo advanced stress test to detect and replace faulty instances, based on the type of deep health check(s) passed in.
 - `override_vpc_config` (Attributes) Specifies an Amazon Virtual Private Cloud (VPC) that your SageMaker jobs, hosted models, and compute resources have access to. You can control access to and from your resources by configuring a VPC. (see [below for nested schema](#nestedatt--instance_groups--override_vpc_config))
 - `scheduled_update_config` (Attributes) The configuration object of the schedule that SageMaker follows when updating the AMI. (see [below for nested schema](#nestedatt--instance_groups--scheduled_update_config))
+- `slurm_config` (Attributes) Slurm configuration for the instance group. (see [below for nested schema](#nestedatt--instance_groups--slurm_config))
 - `threads_per_core` (Number) The number you specified to TreadsPerCore in CreateCluster for enabling or disabling multithreading. For instance types that support multithreading, you can specify 1 for disabling multithreading and 2 for enabling multithreading.
 - `training_plan_arn` (String) The Amazon Resource Name (ARN) of the training plan to use for this cluster instance group. For more information about how to reserve GPU capacity for your SageMaker HyperPod clusters using Amazon SageMaker Training Plan, see CreateTrainingPlan.
+
+<a id="nestedatt--instance_groups--auto_patch_config"></a>
+### Nested Schema for `instance_groups.auto_patch_config`
+
+Optional:
+
+- `deployment_config` (Attributes) The configuration to use when updating the AMI versions. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config))
+- `patch_schedule` (Attributes) The schedule configuration for automatic patching. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--patch_schedule))
+- `patching_strategy` (String) The patching strategy that determines when and how instances are patched. WhenIdle patches instances as they become idle. WhenAllIdle patches all instances when they are all idle.
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config`
+
+Optional:
+
+- `auto_rollback_configuration` (Attributes List) An array that contains the alarms that SageMaker monitors to know whether to roll back the AMI update. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config--auto_rollback_configuration))
+- `rolling_update_policy` (Attributes) The policy that SageMaker uses when updating the AMI versions of the cluster. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy))
+- `wait_interval_in_seconds` (Number) The duration in seconds that SageMaker waits before updating more instances in the cluster.
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config--auto_rollback_configuration"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config.auto_rollback_configuration`
+
+Optional:
+
+- `alarm_name` (String) The name of the alarm.
+
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config.rolling_update_policy`
+
+Optional:
+
+- `maximum_batch_size` (Attributes) The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy--maximum_batch_size))
+- `rollback_maximum_batch_size` (Attributes) The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances. (see [below for nested schema](#nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy--rollback_maximum_batch_size))
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy--maximum_batch_size"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config.rolling_update_policy.maximum_batch_size`
+
+Optional:
+
+- `type` (String) Specifies whether SageMaker should process the update by amount or percentage of instances.
+- `value` (Number) Specifies the amount or percentage of instances SageMaker updates at a time.
+
+
+<a id="nestedatt--instance_groups--auto_patch_config--deployment_config--rolling_update_policy--rollback_maximum_batch_size"></a>
+### Nested Schema for `instance_groups.auto_patch_config.deployment_config.rolling_update_policy.rollback_maximum_batch_size`
+
+Optional:
+
+- `type` (String) Specifies whether SageMaker should process the update by amount or percentage of instances.
+- `value` (Number) Specifies the amount or percentage of instances SageMaker updates at a time.
+
+
+
+
+<a id="nestedatt--instance_groups--auto_patch_config--patch_schedule"></a>
+### Nested Schema for `instance_groups.auto_patch_config.patch_schedule`
+
+Optional:
+
+- `next_patch_date` (String) The date and time of the next scheduled patch, set by the system when a patch AMI is detected.
+
+
 
 <a id="nestedatt--instance_groups--capacity_requirements"></a>
 ### Nested Schema for `instance_groups.capacity_requirements`
@@ -376,12 +444,21 @@ Optional:
 - `spot` (String) Options for Spot capacity
 
 
+<a id="nestedatt--instance_groups--instance_requirements"></a>
+### Nested Schema for `instance_groups.instance_requirements`
+
+Optional:
+
+- `instance_types` (List of String) A list of instance types that can be used for this instance group.
+
+
 <a id="nestedatt--instance_groups--instance_storage_configs"></a>
 ### Nested Schema for `instance_groups.instance_storage_configs`
 
 Optional:
 
 - `ebs_volume_config` (Attributes) Defines the configuration for attaching additional Amazon Elastic Block Store (EBS) volumes to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker. (see [below for nested schema](#nestedatt--instance_groups--instance_storage_configs--ebs_volume_config))
+- `fsx_open_zfs_config` (Attributes) Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group. (see [below for nested schema](#nestedatt--instance_groups--instance_storage_configs--fsx_open_zfs_config))
 
 <a id="nestedatt--instance_groups--instance_storage_configs--ebs_volume_config"></a>
 ### Nested Schema for `instance_groups.instance_storage_configs.ebs_volume_config`
@@ -391,6 +468,15 @@ Optional:
 - `root_volume` (Boolean)
 - `volume_kms_key_id` (String)
 - `volume_size_in_gb` (Number) The size in gigabytes (GB) of the additional EBS volume to be attached to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker.
+
+
+<a id="nestedatt--instance_groups--instance_storage_configs--fsx_open_zfs_config"></a>
+### Nested Schema for `instance_groups.instance_storage_configs.fsx_open_zfs_config`
+
+Optional:
+
+- `dns_name` (String) The DNS name of the FSx for OpenZFS file system.
+- `mount_path` (String) The mount path for the FSx for OpenZFS file system.
 
 
 
@@ -418,8 +504,17 @@ Optional:
 
 Optional:
 
-- `on_create` (String) The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation.
+- `on_create` (String) The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation. Mutually exclusive with OnInitComplete.
+- `on_init_complete` (String) The file name of the extension script under SourceS3Uri. This script runs after HyperPod configures the default software on the instance. Mutually exclusive with OnCreate.
 - `source_s3_uri` (String) An Amazon S3 bucket path where your lifecycle scripts are stored.
+
+
+<a id="nestedatt--instance_groups--network_interface"></a>
+### Nested Schema for `instance_groups.network_interface`
+
+Optional:
+
+- `interface_type` (String) The type of network interface.
 
 
 <a id="nestedatt--instance_groups--override_vpc_config"></a>
@@ -485,6 +580,15 @@ Optional:
 
 
 
+<a id="nestedatt--instance_groups--slurm_config"></a>
+### Nested Schema for `instance_groups.slurm_config`
+
+Optional:
+
+- `node_type` (String) The type of Slurm node for this instance group.
+- `partition_names` (List of String) The Slurm partitions that this instance group belongs to. Maximum of 1 partition.
+
+
 
 <a id="nestedatt--orchestrator"></a>
 ### Nested Schema for `orchestrator`
@@ -492,6 +596,7 @@ Optional:
 Optional:
 
 - `eks` (Attributes) Specifies parameter(s) related to EKS as orchestrator, e.g. the EKS cluster nodes will attach to, (see [below for nested schema](#nestedatt--orchestrator--eks))
+- `slurm` (Attributes) Specifies parameter(s) related to Slurm as orchestrator. (see [below for nested schema](#nestedatt--orchestrator--slurm))
 
 <a id="nestedatt--orchestrator--eks"></a>
 ### Nested Schema for `orchestrator.eks`
@@ -499,6 +604,14 @@ Optional:
 Optional:
 
 - `cluster_arn` (String) The ARN of the EKS cluster, such as arn:aws:eks:us-west-2:123456789012:cluster/my-eks-cluster
+
+
+<a id="nestedatt--orchestrator--slurm"></a>
+### Nested Schema for `orchestrator.slurm`
+
+Optional:
+
+- `slurm_config_strategy` (String) The strategy for managing Slurm configuration on the cluster.
 
 
 
@@ -542,6 +655,7 @@ Optional:
 Optional:
 
 - `ebs_volume_config` (Attributes) Defines the configuration for attaching additional Amazon Elastic Block Store (EBS) volumes to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker. (see [below for nested schema](#nestedatt--restricted_instance_groups--instance_storage_configs--ebs_volume_config))
+- `fsx_open_zfs_config` (Attributes) Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group. (see [below for nested schema](#nestedatt--restricted_instance_groups--instance_storage_configs--fsx_open_zfs_config))
 
 <a id="nestedatt--restricted_instance_groups--instance_storage_configs--ebs_volume_config"></a>
 ### Nested Schema for `restricted_instance_groups.instance_storage_configs.ebs_volume_config`
@@ -553,6 +667,15 @@ Optional:
 - `volume_size_in_gb` (Number) The size in gigabytes (GB) of the additional EBS volume to be attached to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker.
 
 
+<a id="nestedatt--restricted_instance_groups--instance_storage_configs--fsx_open_zfs_config"></a>
+### Nested Schema for `restricted_instance_groups.instance_storage_configs.fsx_open_zfs_config`
+
+Optional:
+
+- `dns_name` (String) The DNS name of the FSx for OpenZFS file system.
+- `mount_path` (String) The mount path for the FSx for OpenZFS file system.
+
+
 
 <a id="nestedatt--restricted_instance_groups--override_vpc_config"></a>
 ### Nested Schema for `restricted_instance_groups.override_vpc_config`
@@ -561,6 +684,32 @@ Optional:
 
 - `security_group_ids` (List of String) The VPC security group IDs, in the form sg-xxxxxxxx. Specify the security groups for the VPC that is specified in the Subnets field.
 - `subnets` (List of String) The ID of the subnets in the VPC to which you want to connect your training job or model.
+
+
+
+<a id="nestedatt--restricted_instance_groups_config"></a>
+### Nested Schema for `restricted_instance_groups_config`
+
+Optional:
+
+- `shared_environment_config` (Attributes) The shared environment configuration for restricted instance groups that use cluster-level shared FSx Lustre storage. (see [below for nested schema](#nestedatt--restricted_instance_groups_config--shared_environment_config))
+
+<a id="nestedatt--restricted_instance_groups_config--shared_environment_config"></a>
+### Nested Schema for `restricted_instance_groups_config.shared_environment_config`
+
+Optional:
+
+- `fsx_lustre_config` (Attributes) Configuration settings for an Amazon FSx for Lustre file system to be used with the cluster. (see [below for nested schema](#nestedatt--restricted_instance_groups_config--shared_environment_config--fsx_lustre_config))
+- `fsx_lustre_deletion_policy` (String) The deletion policy for the shared FSx Lustre file system. Keep retains the FSx when RIGs are deleted. DeleteIfNotUsed deletes the FSx when no RIGs reference it.
+
+<a id="nestedatt--restricted_instance_groups_config--shared_environment_config--fsx_lustre_config"></a>
+### Nested Schema for `restricted_instance_groups_config.shared_environment_config.fsx_lustre_config`
+
+Optional:
+
+- `per_unit_storage_throughput` (Number) The throughput capacity of the FSx for Lustre file system, measured in MB/s per TiB of storage.
+- `size_in_gi_b` (Number) The storage capacity of the FSx for Lustre file system, specified in gibibytes (GiB).
+
 
 
 

--- a/internal/aws/sagemaker/cluster_resource_gen.go
+++ b/internal/aws/sagemaker/cluster_resource_gen.go
@@ -234,6 +234,122 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	    "additionalProperties": false,
 		//	    "description": "Details of an instance group in a SageMaker HyperPod cluster.",
 		//	    "properties": {
+		//	      "AutoPatchConfig": {
+		//	        "additionalProperties": false,
+		//	        "description": "The configuration for automatic patching of the instance group. Enables workload-aware, patch-level AMI updates.",
+		//	        "properties": {
+		//	          "DeploymentConfig": {
+		//	            "additionalProperties": false,
+		//	            "description": "The configuration to use when updating the AMI versions.",
+		//	            "properties": {
+		//	              "AutoRollbackConfiguration": {
+		//	                "description": "An array that contains the alarms that SageMaker monitors to know whether to roll back the AMI update.",
+		//	                "insertionOrder": false,
+		//	                "items": {
+		//	                  "additionalProperties": false,
+		//	                  "description": "The details of the alarm to monitor during the AMI update.",
+		//	                  "properties": {
+		//	                    "AlarmName": {
+		//	                      "description": "The name of the alarm.",
+		//	                      "maxLength": 256,
+		//	                      "minLength": 1,
+		//	                      "pattern": "",
+		//	                      "type": "string"
+		//	                    }
+		//	                  },
+		//	                  "required": [
+		//	                    "AlarmName"
+		//	                  ],
+		//	                  "type": "object"
+		//	                },
+		//	                "type": "array"
+		//	              },
+		//	              "RollingUpdatePolicy": {
+		//	                "additionalProperties": false,
+		//	                "description": "The policy that SageMaker uses when updating the AMI versions of the cluster.",
+		//	                "properties": {
+		//	                  "MaximumBatchSize": {
+		//	                    "additionalProperties": false,
+		//	                    "description": "The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances.",
+		//	                    "properties": {
+		//	                      "Type": {
+		//	                        "description": "Specifies whether SageMaker should process the update by amount or percentage of instances.",
+		//	                        "pattern": "INSTANCE_COUNT|CAPACITY_PERCENTAGE",
+		//	                        "type": "string"
+		//	                      },
+		//	                      "Value": {
+		//	                        "description": "Specifies the amount or percentage of instances SageMaker updates at a time.",
+		//	                        "minimum": 1,
+		//	                        "type": "integer"
+		//	                      }
+		//	                    },
+		//	                    "required": [
+		//	                      "Type",
+		//	                      "Value"
+		//	                    ],
+		//	                    "type": "object"
+		//	                  },
+		//	                  "RollbackMaximumBatchSize": {
+		//	                    "additionalProperties": false,
+		//	                    "description": "The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances.",
+		//	                    "properties": {
+		//	                      "Type": {
+		//	                        "description": "Specifies whether SageMaker should process the update by amount or percentage of instances.",
+		//	                        "pattern": "INSTANCE_COUNT|CAPACITY_PERCENTAGE",
+		//	                        "type": "string"
+		//	                      },
+		//	                      "Value": {
+		//	                        "description": "Specifies the amount or percentage of instances SageMaker updates at a time.",
+		//	                        "minimum": 1,
+		//	                        "type": "integer"
+		//	                      }
+		//	                    },
+		//	                    "required": [
+		//	                      "Type",
+		//	                      "Value"
+		//	                    ],
+		//	                    "type": "object"
+		//	                  }
+		//	                },
+		//	                "required": [
+		//	                  "MaximumBatchSize"
+		//	                ],
+		//	                "type": "object"
+		//	              },
+		//	              "WaitIntervalInSeconds": {
+		//	                "description": "The duration in seconds that SageMaker waits before updating more instances in the cluster.",
+		//	                "maximum": 3600,
+		//	                "minimum": 0,
+		//	                "type": "integer"
+		//	              }
+		//	            },
+		//	            "type": "object"
+		//	          },
+		//	          "PatchSchedule": {
+		//	            "additionalProperties": false,
+		//	            "description": "The schedule configuration for automatic patching.",
+		//	            "properties": {
+		//	              "NextPatchDate": {
+		//	                "description": "The date and time of the next scheduled patch, set by the system when a patch AMI is detected.",
+		//	                "type": "string"
+		//	              }
+		//	            },
+		//	            "type": "object"
+		//	          },
+		//	          "PatchingStrategy": {
+		//	            "description": "The patching strategy that determines when and how instances are patched. WhenIdle patches instances as they become idle. WhenAllIdle patches all instances when they are all idle.",
+		//	            "enum": [
+		//	              "WhenIdle",
+		//	              "WhenAllIdle"
+		//	            ],
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "PatchingStrategy"
+		//	        ],
+		//	        "type": "object"
+		//	      },
 		//	      "CapacityRequirements": {
 		//	        "additionalProperties": false,
 		//	        "description": "Specifies the capacity requirements configuration for an instance group",
@@ -282,6 +398,27 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	        "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$",
 		//	        "type": "string"
 		//	      },
+		//	      "InstanceRequirements": {
+		//	        "additionalProperties": false,
+		//	        "description": "The instance requirements for the instance group. Specifies a list of instance types that can be used.",
+		//	        "properties": {
+		//	          "InstanceTypes": {
+		//	            "description": "A list of instance types that can be used for this instance group.",
+		//	            "insertionOrder": true,
+		//	            "items": {
+		//	              "description": "The instance type of the instance group of a SageMaker HyperPod cluster.",
+		//	              "type": "string"
+		//	            },
+		//	            "maxItems": 20,
+		//	            "minItems": 1,
+		//	            "type": "array"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "InstanceTypes"
+		//	        ],
+		//	        "type": "object"
+		//	      },
 		//	      "InstanceStorageConfigs": {
 		//	        "description": "The instance storage configuration for the instance group.",
 		//	        "insertionOrder": false,
@@ -309,11 +446,35 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	                }
 		//	              },
 		//	              "type": "object"
+		//	            },
+		//	            "FsxOpenZfsConfig": {
+		//	              "additionalProperties": false,
+		//	              "description": "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
+		//	              "properties": {
+		//	                "DnsName": {
+		//	                  "description": "The DNS name of the FSx for OpenZFS file system.",
+		//	                  "maxLength": 275,
+		//	                  "minLength": 16,
+		//	                  "pattern": "^((fs|fc)i?-[0-9a-f]{8,}\\..{4,253})$",
+		//	                  "type": "string"
+		//	                },
+		//	                "MountPath": {
+		//	                  "description": "The mount path for the FSx for OpenZFS file system.",
+		//	                  "maxLength": 1024,
+		//	                  "minLength": 1,
+		//	                  "pattern": "",
+		//	                  "type": "string"
+		//	                }
+		//	              },
+		//	              "required": [
+		//	                "DnsName"
+		//	              ],
+		//	              "type": "object"
 		//	            }
 		//	          },
 		//	          "type": "object"
 		//	        },
-		//	        "maxItems": 1,
+		//	        "maxItems": 4,
 		//	        "type": "array"
 		//	      },
 		//	      "InstanceType": {
@@ -373,10 +534,17 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	      },
 		//	      "LifeCycleConfig": {
 		//	        "additionalProperties": false,
-		//	        "description": "The lifecycle configuration for a SageMaker HyperPod cluster.",
+		//	        "description": "The lifecycle configuration for a SageMaker HyperPod cluster. When omitted, the instance group uses Bootstrap mode. When provided with SourceS3Uri and OnCreate, uses Customer Managed mode. When provided with SourceS3Uri and OnInitComplete, uses Extended mode.",
 		//	        "properties": {
 		//	          "OnCreate": {
-		//	            "description": "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation.",
+		//	            "description": "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation. Mutually exclusive with OnInitComplete.",
+		//	            "maxLength": 128,
+		//	            "minLength": 1,
+		//	            "pattern": "^[\\S\\s]+$",
+		//	            "type": "string"
+		//	          },
+		//	          "OnInitComplete": {
+		//	            "description": "The file name of the extension script under SourceS3Uri. This script runs after HyperPod configures the default software on the instance. Mutually exclusive with OnCreate.",
 		//	            "maxLength": 128,
 		//	            "minLength": 1,
 		//	            "pattern": "^[\\S\\s]+$",
@@ -389,16 +557,30 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	            "type": "string"
 		//	          }
 		//	        },
-		//	        "required": [
-		//	          "OnCreate",
-		//	          "SourceS3Uri"
-		//	        ],
 		//	        "type": "object"
 		//	      },
 		//	      "MinInstanceCount": {
 		//	        "description": "The minimum number of instances required for the instance group to be InService. MinInstanceCount must be less than or equal to InstanceCount.",
 		//	        "minimum": 0,
 		//	        "type": "integer"
+		//	      },
+		//	      "NetworkInterface": {
+		//	        "additionalProperties": false,
+		//	        "description": "Specifies the network interface configuration for the instance group.",
+		//	        "properties": {
+		//	          "InterfaceType": {
+		//	            "description": "The type of network interface.",
+		//	            "enum": [
+		//	              "efa",
+		//	              "efa-only"
+		//	            ],
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "InterfaceType"
+		//	        ],
+		//	        "type": "object"
 		//	      },
 		//	      "OnStartDeepHealthChecks": {
 		//	        "description": "Nodes will undergo advanced stress test to detect and replace faulty instances, based on the type of deep health check(s) passed in.",
@@ -552,6 +734,39 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	        ],
 		//	        "type": "object"
 		//	      },
+		//	      "SlurmConfig": {
+		//	        "additionalProperties": false,
+		//	        "description": "Slurm configuration for the instance group.",
+		//	        "properties": {
+		//	          "NodeType": {
+		//	            "description": "The type of Slurm node for this instance group.",
+		//	            "enum": [
+		//	              "Controller",
+		//	              "Login",
+		//	              "Compute"
+		//	            ],
+		//	            "type": "string"
+		//	          },
+		//	          "PartitionNames": {
+		//	            "description": "The Slurm partitions that this instance group belongs to. Maximum of 1 partition.",
+		//	            "insertionOrder": false,
+		//	            "items": {
+		//	              "description": "The name of a Slurm partition.",
+		//	              "maxLength": 1024,
+		//	              "minLength": 0,
+		//	              "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$",
+		//	              "type": "string"
+		//	            },
+		//	            "maxItems": 1,
+		//	            "minItems": 0,
+		//	            "type": "array"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "NodeType"
+		//	        ],
+		//	        "type": "object"
+		//	      },
 		//	      "ThreadsPerCore": {
 		//	        "description": "The number you specified to TreadsPerCore in CreateCluster for enabling or disabling multithreading. For instance types that support multithreading, you can specify 1 for disabling multithreading and 2 for enabling multithreading.",
 		//	        "maximum": 2,
@@ -569,9 +784,7 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	    "required": [
 		//	      "ExecutionRole",
 		//	      "InstanceCount",
-		//	      "InstanceGroupName",
-		//	      "InstanceType",
-		//	      "LifeCycleConfig"
+		//	      "InstanceGroupName"
 		//	    ],
 		//	    "type": "object"
 		//	  },
@@ -581,6 +794,191 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		"instance_groups": schema.ListNestedAttribute{ /*START ATTRIBUTE*/
 			NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
 				Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+					// Property: AutoPatchConfig
+					"auto_patch_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: DeploymentConfig
+							"deployment_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+								Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+									// Property: AutoRollbackConfiguration
+									"auto_rollback_configuration": schema.ListNestedAttribute{ /*START ATTRIBUTE*/
+										NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+											Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+												// Property: AlarmName
+												"alarm_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+													Description: "The name of the alarm.",
+													Optional:    true,
+													Computed:    true,
+													Validators: []validator.String{ /*START VALIDATORS*/
+														stringvalidator.LengthBetween(1, 256),
+														fwvalidators.NotNullString(),
+													}, /*END VALIDATORS*/
+													PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+														stringplanmodifier.UseStateForUnknown(),
+													}, /*END PLAN MODIFIERS*/
+												}, /*END ATTRIBUTE*/
+											}, /*END SCHEMA*/
+										}, /*END NESTED OBJECT*/
+										Description: "An array that contains the alarms that SageMaker monitors to know whether to roll back the AMI update.",
+										Optional:    true,
+										Computed:    true,
+										PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
+											generic.Multiset(),
+											listplanmodifier.UseStateForUnknown(),
+										}, /*END PLAN MODIFIERS*/
+									}, /*END ATTRIBUTE*/
+									// Property: RollingUpdatePolicy
+									"rolling_update_policy": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+										Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+											// Property: MaximumBatchSize
+											"maximum_batch_size": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+												Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+													// Property: Type
+													"type": schema.StringAttribute{ /*START ATTRIBUTE*/
+														Description: "Specifies whether SageMaker should process the update by amount or percentage of instances.",
+														Optional:    true,
+														Computed:    true,
+														Validators: []validator.String{ /*START VALIDATORS*/
+															stringvalidator.RegexMatches(regexp.MustCompile("INSTANCE_COUNT|CAPACITY_PERCENTAGE"), ""),
+															fwvalidators.NotNullString(),
+														}, /*END VALIDATORS*/
+														PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+															stringplanmodifier.UseStateForUnknown(),
+														}, /*END PLAN MODIFIERS*/
+													}, /*END ATTRIBUTE*/
+													// Property: Value
+													"value": schema.Int64Attribute{ /*START ATTRIBUTE*/
+														Description: "Specifies the amount or percentage of instances SageMaker updates at a time.",
+														Optional:    true,
+														Computed:    true,
+														Validators: []validator.Int64{ /*START VALIDATORS*/
+															int64validator.AtLeast(1),
+															fwvalidators.NotNullInt64(),
+														}, /*END VALIDATORS*/
+														PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+															int64planmodifier.UseStateForUnknown(),
+														}, /*END PLAN MODIFIERS*/
+													}, /*END ATTRIBUTE*/
+												}, /*END SCHEMA*/
+												Description: "The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances.",
+												Optional:    true,
+												Computed:    true,
+												Validators: []validator.Object{ /*START VALIDATORS*/
+													fwvalidators.NotNullObject(),
+												}, /*END VALIDATORS*/
+												PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+													objectplanmodifier.UseStateForUnknown(),
+												}, /*END PLAN MODIFIERS*/
+											}, /*END ATTRIBUTE*/
+											// Property: RollbackMaximumBatchSize
+											"rollback_maximum_batch_size": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+												Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+													// Property: Type
+													"type": schema.StringAttribute{ /*START ATTRIBUTE*/
+														Description: "Specifies whether SageMaker should process the update by amount or percentage of instances.",
+														Optional:    true,
+														Computed:    true,
+														Validators: []validator.String{ /*START VALIDATORS*/
+															stringvalidator.RegexMatches(regexp.MustCompile("INSTANCE_COUNT|CAPACITY_PERCENTAGE"), ""),
+															fwvalidators.NotNullString(),
+														}, /*END VALIDATORS*/
+														PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+															stringplanmodifier.UseStateForUnknown(),
+														}, /*END PLAN MODIFIERS*/
+													}, /*END ATTRIBUTE*/
+													// Property: Value
+													"value": schema.Int64Attribute{ /*START ATTRIBUTE*/
+														Description: "Specifies the amount or percentage of instances SageMaker updates at a time.",
+														Optional:    true,
+														Computed:    true,
+														Validators: []validator.Int64{ /*START VALIDATORS*/
+															int64validator.AtLeast(1),
+															fwvalidators.NotNullInt64(),
+														}, /*END VALIDATORS*/
+														PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+															int64planmodifier.UseStateForUnknown(),
+														}, /*END PLAN MODIFIERS*/
+													}, /*END ATTRIBUTE*/
+												}, /*END SCHEMA*/
+												Description: "The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances.",
+												Optional:    true,
+												Computed:    true,
+												PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+													objectplanmodifier.UseStateForUnknown(),
+												}, /*END PLAN MODIFIERS*/
+											}, /*END ATTRIBUTE*/
+										}, /*END SCHEMA*/
+										Description: "The policy that SageMaker uses when updating the AMI versions of the cluster.",
+										Optional:    true,
+										Computed:    true,
+										PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+											objectplanmodifier.UseStateForUnknown(),
+										}, /*END PLAN MODIFIERS*/
+									}, /*END ATTRIBUTE*/
+									// Property: WaitIntervalInSeconds
+									"wait_interval_in_seconds": schema.Int64Attribute{ /*START ATTRIBUTE*/
+										Description: "The duration in seconds that SageMaker waits before updating more instances in the cluster.",
+										Optional:    true,
+										Computed:    true,
+										Validators: []validator.Int64{ /*START VALIDATORS*/
+											int64validator.Between(0, 3600),
+										}, /*END VALIDATORS*/
+										PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+											int64planmodifier.UseStateForUnknown(),
+										}, /*END PLAN MODIFIERS*/
+									}, /*END ATTRIBUTE*/
+								}, /*END SCHEMA*/
+								Description: "The configuration to use when updating the AMI versions.",
+								Optional:    true,
+								Computed:    true,
+								PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+									objectplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+							// Property: PatchSchedule
+							"patch_schedule": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+								Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+									// Property: NextPatchDate
+									"next_patch_date": schema.StringAttribute{ /*START ATTRIBUTE*/
+										Description: "The date and time of the next scheduled patch, set by the system when a patch AMI is detected.",
+										Optional:    true,
+										Computed:    true,
+										PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+											stringplanmodifier.UseStateForUnknown(),
+										}, /*END PLAN MODIFIERS*/
+									}, /*END ATTRIBUTE*/
+								}, /*END SCHEMA*/
+								Description: "The schedule configuration for automatic patching.",
+								Optional:    true,
+								Computed:    true,
+								PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+									objectplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+							// Property: PatchingStrategy
+							"patching_strategy": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The patching strategy that determines when and how instances are patched. WhenIdle patches instances as they become idle. WhenAllIdle patches all instances when they are all idle.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.OneOf(
+										"WhenIdle",
+										"WhenAllIdle",
+									),
+									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+						Description: "The configuration for automatic patching of the instance group. Enables workload-aware, patch-level AMI updates.",
+						Optional:    true,
+						Computed:    true,
+						PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+							objectplanmodifier.UseStateForUnknown(),
+						}, /*END PLAN MODIFIERS*/
+					}, /*END ATTRIBUTE*/
 					// Property: CapacityRequirements
 					"capacity_requirements": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
 						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
@@ -678,6 +1076,31 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 							stringplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
+					// Property: InstanceRequirements
+					"instance_requirements": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: InstanceTypes
+							"instance_types": schema.ListAttribute{ /*START ATTRIBUTE*/
+								ElementType: types.StringType,
+								Description: "A list of instance types that can be used for this instance group.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.List{ /*START VALIDATORS*/
+									listvalidator.SizeBetween(1, 20),
+									fwvalidators.NotNullList(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
+									listplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+						Description: "The instance requirements for the instance group. Specifies a list of instance types that can be used.",
+						Optional:    true,
+						Computed:    true,
+						PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+							objectplanmodifier.UseStateForUnknown(),
+						}, /*END PLAN MODIFIERS*/
+					}, /*END ATTRIBUTE*/
 					// Property: InstanceStorageConfigs
 					"instance_storage_configs": schema.ListNestedAttribute{ /*START ATTRIBUTE*/
 						NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
@@ -725,13 +1148,50 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 										objectplanmodifier.UseStateForUnknown(),
 									}, /*END PLAN MODIFIERS*/
 								}, /*END ATTRIBUTE*/
+								// Property: FsxOpenZfsConfig
+								"fsx_open_zfs_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+									Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+										// Property: DnsName
+										"dns_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+											Description: "The DNS name of the FSx for OpenZFS file system.",
+											Optional:    true,
+											Computed:    true,
+											Validators: []validator.String{ /*START VALIDATORS*/
+												stringvalidator.LengthBetween(16, 275),
+												stringvalidator.RegexMatches(regexp.MustCompile("^((fs|fc)i?-[0-9a-f]{8,}\\..{4,253})$"), ""),
+												fwvalidators.NotNullString(),
+											}, /*END VALIDATORS*/
+											PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+												stringplanmodifier.UseStateForUnknown(),
+											}, /*END PLAN MODIFIERS*/
+										}, /*END ATTRIBUTE*/
+										// Property: MountPath
+										"mount_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+											Description: "The mount path for the FSx for OpenZFS file system.",
+											Optional:    true,
+											Computed:    true,
+											Validators: []validator.String{ /*START VALIDATORS*/
+												stringvalidator.LengthBetween(1, 1024),
+											}, /*END VALIDATORS*/
+											PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+												stringplanmodifier.UseStateForUnknown(),
+											}, /*END PLAN MODIFIERS*/
+										}, /*END ATTRIBUTE*/
+									}, /*END SCHEMA*/
+									Description: "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
+									Optional:    true,
+									Computed:    true,
+									PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+										objectplanmodifier.UseStateForUnknown(),
+									}, /*END PLAN MODIFIERS*/
+								}, /*END ATTRIBUTE*/
 							}, /*END SCHEMA*/
 						}, /*END NESTED OBJECT*/
 						Description: "The instance storage configuration for the instance group.",
 						Optional:    true,
 						Computed:    true,
 						Validators: []validator.List{ /*START VALIDATORS*/
-							listvalidator.SizeAtMost(1),
+							listvalidator.SizeAtMost(4),
 						}, /*END VALIDATORS*/
 						PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
 							generic.Multiset(),
@@ -743,9 +1203,6 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 						Description: "The instance type of the instance group of a SageMaker HyperPod cluster.",
 						Optional:    true,
 						Computed:    true,
-						Validators: []validator.String{ /*START VALIDATORS*/
-							fwvalidators.NotNullString(),
-						}, /*END VALIDATORS*/
 						PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
 							stringplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
@@ -832,13 +1289,25 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
 							// Property: OnCreate
 							"on_create": schema.StringAttribute{ /*START ATTRIBUTE*/
-								Description: "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation.",
+								Description: "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation. Mutually exclusive with OnInitComplete.",
 								Optional:    true,
 								Computed:    true,
 								Validators: []validator.String{ /*START VALIDATORS*/
 									stringvalidator.LengthBetween(1, 128),
 									stringvalidator.RegexMatches(regexp.MustCompile("^[\\S\\s]+$"), ""),
-									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+							// Property: OnInitComplete
+							"on_init_complete": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The file name of the extension script under SourceS3Uri. This script runs after HyperPod configures the default software on the instance. Mutually exclusive with OnCreate.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.LengthBetween(1, 128),
+									stringvalidator.RegexMatches(regexp.MustCompile("^[\\S\\s]+$"), ""),
 								}, /*END VALIDATORS*/
 								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
 									stringplanmodifier.UseStateForUnknown(),
@@ -852,19 +1321,15 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 								Validators: []validator.String{ /*START VALIDATORS*/
 									stringvalidator.LengthAtMost(1024),
 									stringvalidator.RegexMatches(regexp.MustCompile("^(https|s3)://([^/]+)/?(.*)$"), ""),
-									fwvalidators.NotNullString(),
 								}, /*END VALIDATORS*/
 								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
 									stringplanmodifier.UseStateForUnknown(),
 								}, /*END PLAN MODIFIERS*/
 							}, /*END ATTRIBUTE*/
 						}, /*END SCHEMA*/
-						Description: "The lifecycle configuration for a SageMaker HyperPod cluster.",
+						Description: "The lifecycle configuration for a SageMaker HyperPod cluster. When omitted, the instance group uses Bootstrap mode. When provided with SourceS3Uri and OnCreate, uses Customer Managed mode. When provided with SourceS3Uri and OnInitComplete, uses Extended mode.",
 						Optional:    true,
 						Computed:    true,
-						Validators: []validator.Object{ /*START VALIDATORS*/
-							fwvalidators.NotNullObject(),
-						}, /*END VALIDATORS*/
 						PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
 							objectplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
@@ -879,6 +1344,33 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 						}, /*END VALIDATORS*/
 						PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
 							int64planmodifier.UseStateForUnknown(),
+						}, /*END PLAN MODIFIERS*/
+					}, /*END ATTRIBUTE*/
+					// Property: NetworkInterface
+					"network_interface": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: InterfaceType
+							"interface_type": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The type of network interface.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.OneOf(
+										"efa",
+										"efa-only",
+									),
+									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+						Description: "Specifies the network interface configuration for the instance group.",
+						Optional:    true,
+						Computed:    true,
+						PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+							objectplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
 					// Property: OnStartDeepHealthChecks
@@ -1112,6 +1604,52 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 							objectplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
 					}, /*END ATTRIBUTE*/
+					// Property: SlurmConfig
+					"slurm_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: NodeType
+							"node_type": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The type of Slurm node for this instance group.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.String{ /*START VALIDATORS*/
+									stringvalidator.OneOf(
+										"Controller",
+										"Login",
+										"Compute",
+									),
+									fwvalidators.NotNullString(),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+									stringplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+							// Property: PartitionNames
+							"partition_names": schema.ListAttribute{ /*START ATTRIBUTE*/
+								ElementType: types.StringType,
+								Description: "The Slurm partitions that this instance group belongs to. Maximum of 1 partition.",
+								Optional:    true,
+								Computed:    true,
+								Validators: []validator.List{ /*START VALIDATORS*/
+									listvalidator.SizeBetween(0, 1),
+									listvalidator.ValueStringsAre(
+										stringvalidator.LengthBetween(0, 1024),
+										stringvalidator.RegexMatches(regexp.MustCompile("^[a-zA-Z0-9](-*[a-zA-Z0-9])*$"), ""),
+									),
+								}, /*END VALIDATORS*/
+								PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
+									generic.Multiset(),
+									listplanmodifier.UseStateForUnknown(),
+								}, /*END PLAN MODIFIERS*/
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+						Description: "Slurm configuration for the instance group.",
+						Optional:    true,
+						Computed:    true,
+						PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+							objectplanmodifier.UseStateForUnknown(),
+						}, /*END PLAN MODIFIERS*/
+					}, /*END ATTRIBUTE*/
 					// Property: ThreadsPerCore
 					"threads_per_core": schema.Int64Attribute{ /*START ATTRIBUTE*/
 						Description: "The number you specified to TreadsPerCore in CreateCluster for enabling or disabling multithreading. For instance types that support multithreading, you can specify 1 for disabling multithreading and 2 for enabling multithreading.",
@@ -1202,8 +1740,7 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		// CloudFormation resource type schema:
 		//
 		//	{
-		//	  "additionalProperties": false,
-		//	  "description": "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster.",
+		//	  "description": "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster or Slurm configuration.",
 		//	  "properties": {
 		//	    "Eks": {
 		//	      "additionalProperties": false,
@@ -1218,11 +1755,24 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	        "ClusterArn"
 		//	      ],
 		//	      "type": "object"
+		//	    },
+		//	    "Slurm": {
+		//	      "additionalProperties": false,
+		//	      "description": "Specifies parameter(s) related to Slurm as orchestrator.",
+		//	      "properties": {
+		//	        "SlurmConfigStrategy": {
+		//	          "description": "The strategy for managing Slurm configuration on the cluster.",
+		//	          "enum": [
+		//	            "Overwrite",
+		//	            "Managed",
+		//	            "Merge"
+		//	          ],
+		//	          "type": "string"
+		//	        }
+		//	      },
+		//	      "type": "object"
 		//	    }
 		//	  },
-		//	  "required": [
-		//	    "Eks"
-		//	  ],
 		//	  "type": "object"
 		//	}
 		"orchestrator": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
@@ -1246,20 +1796,44 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 					Description: "Specifies parameter(s) related to EKS as orchestrator, e.g. the EKS cluster nodes will attach to,",
 					Optional:    true,
 					Computed:    true,
-					Validators: []validator.Object{ /*START VALIDATORS*/
-						fwvalidators.NotNullObject(),
-					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+						objectplanmodifier.UseStateForUnknown(),
+						objectplanmodifier.RequiresReplaceIfConfigured(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+				// Property: Slurm
+				"slurm": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+					Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+						// Property: SlurmConfigStrategy
+						"slurm_config_strategy": schema.StringAttribute{ /*START ATTRIBUTE*/
+							Description: "The strategy for managing Slurm configuration on the cluster.",
+							Optional:    true,
+							Computed:    true,
+							Validators: []validator.String{ /*START VALIDATORS*/
+								stringvalidator.OneOf(
+									"Overwrite",
+									"Managed",
+									"Merge",
+								),
+							}, /*END VALIDATORS*/
+							PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+								stringplanmodifier.UseStateForUnknown(),
+							}, /*END PLAN MODIFIERS*/
+						}, /*END ATTRIBUTE*/
+					}, /*END SCHEMA*/
+					Description: "Specifies parameter(s) related to Slurm as orchestrator.",
+					Optional:    true,
+					Computed:    true,
 					PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
 						objectplanmodifier.UseStateForUnknown(),
 					}, /*END PLAN MODIFIERS*/
 				}, /*END ATTRIBUTE*/
 			}, /*END SCHEMA*/
-			Description: "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster.",
+			Description: "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster or Slurm configuration.",
 			Optional:    true,
 			Computed:    true,
 			PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
 				objectplanmodifier.UseStateForUnknown(),
-				objectplanmodifier.RequiresReplaceIfConfigured(),
 			}, /*END PLAN MODIFIERS*/
 		}, /*END ATTRIBUTE*/
 		// Property: RestrictedInstanceGroups
@@ -1353,11 +1927,35 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	                }
 		//	              },
 		//	              "type": "object"
+		//	            },
+		//	            "FsxOpenZfsConfig": {
+		//	              "additionalProperties": false,
+		//	              "description": "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
+		//	              "properties": {
+		//	                "DnsName": {
+		//	                  "description": "The DNS name of the FSx for OpenZFS file system.",
+		//	                  "maxLength": 275,
+		//	                  "minLength": 16,
+		//	                  "pattern": "^((fs|fc)i?-[0-9a-f]{8,}\\..{4,253})$",
+		//	                  "type": "string"
+		//	                },
+		//	                "MountPath": {
+		//	                  "description": "The mount path for the FSx for OpenZFS file system.",
+		//	                  "maxLength": 1024,
+		//	                  "minLength": 1,
+		//	                  "pattern": "",
+		//	                  "type": "string"
+		//	                }
+		//	              },
+		//	              "required": [
+		//	                "DnsName"
+		//	              ],
+		//	              "type": "object"
 		//	            }
 		//	          },
 		//	          "type": "object"
 		//	        },
-		//	        "maxItems": 1,
+		//	        "maxItems": 4,
 		//	        "type": "array"
 		//	      },
 		//	      "InstanceType": {
@@ -1430,8 +2028,7 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		//	      "ExecutionRole",
 		//	      "InstanceCount",
 		//	      "InstanceGroupName",
-		//	      "InstanceType",
-		//	      "EnvironmentConfig"
+		//	      "InstanceType"
 		//	    ],
 		//	    "type": "object"
 		//	  },
@@ -1497,9 +2094,6 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 						Description: "The configuration for the restricted instance groups (RIG) environment.",
 						Optional:    true,
 						Computed:    true,
-						Validators: []validator.Object{ /*START VALIDATORS*/
-							fwvalidators.NotNullObject(),
-						}, /*END VALIDATORS*/
 						PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
 							objectplanmodifier.UseStateForUnknown(),
 						}, /*END PLAN MODIFIERS*/
@@ -1592,13 +2186,50 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 										objectplanmodifier.UseStateForUnknown(),
 									}, /*END PLAN MODIFIERS*/
 								}, /*END ATTRIBUTE*/
+								// Property: FsxOpenZfsConfig
+								"fsx_open_zfs_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+									Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+										// Property: DnsName
+										"dns_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+											Description: "The DNS name of the FSx for OpenZFS file system.",
+											Optional:    true,
+											Computed:    true,
+											Validators: []validator.String{ /*START VALIDATORS*/
+												stringvalidator.LengthBetween(16, 275),
+												stringvalidator.RegexMatches(regexp.MustCompile("^((fs|fc)i?-[0-9a-f]{8,}\\..{4,253})$"), ""),
+												fwvalidators.NotNullString(),
+											}, /*END VALIDATORS*/
+											PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+												stringplanmodifier.UseStateForUnknown(),
+											}, /*END PLAN MODIFIERS*/
+										}, /*END ATTRIBUTE*/
+										// Property: MountPath
+										"mount_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+											Description: "The mount path for the FSx for OpenZFS file system.",
+											Optional:    true,
+											Computed:    true,
+											Validators: []validator.String{ /*START VALIDATORS*/
+												stringvalidator.LengthBetween(1, 1024),
+											}, /*END VALIDATORS*/
+											PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+												stringplanmodifier.UseStateForUnknown(),
+											}, /*END PLAN MODIFIERS*/
+										}, /*END ATTRIBUTE*/
+									}, /*END SCHEMA*/
+									Description: "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
+									Optional:    true,
+									Computed:    true,
+									PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+										objectplanmodifier.UseStateForUnknown(),
+									}, /*END PLAN MODIFIERS*/
+								}, /*END ATTRIBUTE*/
 							}, /*END SCHEMA*/
 						}, /*END NESTED OBJECT*/
 						Description: "The instance storage configuration for the instance group.",
 						Optional:    true,
 						Computed:    true,
 						Validators: []validator.List{ /*START VALIDATORS*/
-							listvalidator.SizeAtMost(1),
+							listvalidator.SizeAtMost(4),
 						}, /*END VALIDATORS*/
 						PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
 							generic.Multiset(),
@@ -1721,6 +2352,137 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 			PlanModifiers: []planmodifier.List{ /*START PLAN MODIFIERS*/
 				generic.Multiset(),
 				listplanmodifier.UseStateForUnknown(),
+			}, /*END PLAN MODIFIERS*/
+		}, /*END ATTRIBUTE*/
+		// Property: RestrictedInstanceGroupsConfig
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "additionalProperties": false,
+		//	  "description": "The cluster-level configuration for restricted instance groups, including shared environment settings for inter-RIG communication and FSx Lustre sharing.",
+		//	  "properties": {
+		//	    "SharedEnvironmentConfig": {
+		//	      "additionalProperties": false,
+		//	      "description": "The shared environment configuration for restricted instance groups that use cluster-level shared FSx Lustre storage.",
+		//	      "properties": {
+		//	        "FSxLustreConfig": {
+		//	          "additionalProperties": false,
+		//	          "description": "Configuration settings for an Amazon FSx for Lustre file system to be used with the cluster.",
+		//	          "properties": {
+		//	            "PerUnitStorageThroughput": {
+		//	              "description": "The throughput capacity of the FSx for Lustre file system, measured in MB/s per TiB of storage.",
+		//	              "maximum": 1000,
+		//	              "minimum": 125,
+		//	              "type": "integer"
+		//	            },
+		//	            "SizeInGiB": {
+		//	              "description": "The storage capacity of the FSx for Lustre file system, specified in gibibytes (GiB).",
+		//	              "maximum": 100800,
+		//	              "minimum": 1200,
+		//	              "type": "integer"
+		//	            }
+		//	          },
+		//	          "required": [
+		//	            "SizeInGiB",
+		//	            "PerUnitStorageThroughput"
+		//	          ],
+		//	          "type": "object"
+		//	        },
+		//	        "FSxLustreDeletionPolicy": {
+		//	          "description": "The deletion policy for the shared FSx Lustre file system. Keep retains the FSx when RIGs are deleted. DeleteIfNotUsed deletes the FSx when no RIGs reference it.",
+		//	          "enum": [
+		//	            "Keep",
+		//	            "DeleteIfNotUsed"
+		//	          ],
+		//	          "type": "string"
+		//	        }
+		//	      },
+		//	      "required": [
+		//	        "FSxLustreDeletionPolicy"
+		//	      ],
+		//	      "type": "object"
+		//	    }
+		//	  },
+		//	  "required": [
+		//	    "SharedEnvironmentConfig"
+		//	  ],
+		//	  "type": "object"
+		//	}
+		"restricted_instance_groups_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+			Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+				// Property: SharedEnvironmentConfig
+				"shared_environment_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+					Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+						// Property: FSxLustreConfig
+						"fsx_lustre_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+							Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+								// Property: PerUnitStorageThroughput
+								"per_unit_storage_throughput": schema.Int64Attribute{ /*START ATTRIBUTE*/
+									Description: "The throughput capacity of the FSx for Lustre file system, measured in MB/s per TiB of storage.",
+									Optional:    true,
+									Computed:    true,
+									Validators: []validator.Int64{ /*START VALIDATORS*/
+										int64validator.Between(125, 1000),
+										fwvalidators.NotNullInt64(),
+									}, /*END VALIDATORS*/
+									PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+										int64planmodifier.UseStateForUnknown(),
+									}, /*END PLAN MODIFIERS*/
+								}, /*END ATTRIBUTE*/
+								// Property: SizeInGiB
+								"size_in_gi_b": schema.Int64Attribute{ /*START ATTRIBUTE*/
+									Description: "The storage capacity of the FSx for Lustre file system, specified in gibibytes (GiB).",
+									Optional:    true,
+									Computed:    true,
+									Validators: []validator.Int64{ /*START VALIDATORS*/
+										int64validator.Between(1200, 100800),
+										fwvalidators.NotNullInt64(),
+									}, /*END VALIDATORS*/
+									PlanModifiers: []planmodifier.Int64{ /*START PLAN MODIFIERS*/
+										int64planmodifier.UseStateForUnknown(),
+									}, /*END PLAN MODIFIERS*/
+								}, /*END ATTRIBUTE*/
+							}, /*END SCHEMA*/
+							Description: "Configuration settings for an Amazon FSx for Lustre file system to be used with the cluster.",
+							Optional:    true,
+							Computed:    true,
+							PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+								objectplanmodifier.UseStateForUnknown(),
+							}, /*END PLAN MODIFIERS*/
+						}, /*END ATTRIBUTE*/
+						// Property: FSxLustreDeletionPolicy
+						"fsx_lustre_deletion_policy": schema.StringAttribute{ /*START ATTRIBUTE*/
+							Description: "The deletion policy for the shared FSx Lustre file system. Keep retains the FSx when RIGs are deleted. DeleteIfNotUsed deletes the FSx when no RIGs reference it.",
+							Optional:    true,
+							Computed:    true,
+							Validators: []validator.String{ /*START VALIDATORS*/
+								stringvalidator.OneOf(
+									"Keep",
+									"DeleteIfNotUsed",
+								),
+								fwvalidators.NotNullString(),
+							}, /*END VALIDATORS*/
+							PlanModifiers: []planmodifier.String{ /*START PLAN MODIFIERS*/
+								stringplanmodifier.UseStateForUnknown(),
+							}, /*END PLAN MODIFIERS*/
+						}, /*END ATTRIBUTE*/
+					}, /*END SCHEMA*/
+					Description: "The shared environment configuration for restricted instance groups that use cluster-level shared FSx Lustre storage.",
+					Optional:    true,
+					Computed:    true,
+					Validators: []validator.Object{ /*START VALIDATORS*/
+						fwvalidators.NotNullObject(),
+					}, /*END VALIDATORS*/
+					PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+						objectplanmodifier.UseStateForUnknown(),
+					}, /*END PLAN MODIFIERS*/
+				}, /*END ATTRIBUTE*/
+			}, /*END SCHEMA*/
+			Description: "The cluster-level configuration for restricted instance groups, including shared environment settings for inter-RIG communication and FSx Lustre sharing.",
+			Optional:    true,
+			Computed:    true,
+			PlanModifiers: []planmodifier.Object{ /*START PLAN MODIFIERS*/
+				objectplanmodifier.UseStateForUnknown(),
 			}, /*END PLAN MODIFIERS*/
 		}, /*END ATTRIBUTE*/
 		// Property: Tags
@@ -1978,6 +2740,7 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"alarm_name":                            "AlarmName",
+		"auto_patch_config":                     "AutoPatchConfig",
 		"auto_rollback_configuration":           "AutoRollbackConfiguration",
 		"auto_scaler_type":                      "AutoScalerType",
 		"auto_scaling":                          "AutoScaling",
@@ -1989,6 +2752,7 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		"creation_time":                         "CreationTime",
 		"current_count":                         "CurrentCount",
 		"deployment_config":                     "DeploymentConfig",
+		"dns_name":                              "DnsName",
 		"ebs_volume_config":                     "EbsVolumeConfig",
 		"effect":                                "Effect",
 		"eks":                                   "Eks",
@@ -1996,13 +2760,18 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		"execution_role":                        "ExecutionRole",
 		"failure_message":                       "FailureMessage",
 		"fsx_lustre_config":                     "FSxLustreConfig",
+		"fsx_lustre_deletion_policy":            "FSxLustreDeletionPolicy",
+		"fsx_open_zfs_config":                   "FsxOpenZfsConfig",
 		"image_id":                              "ImageId",
 		"instance_count":                        "InstanceCount",
 		"instance_group_name":                   "InstanceGroupName",
 		"instance_groups":                       "InstanceGroups",
 		"instance_memory_allocation_percentage": "InstanceMemoryAllocationPercentage",
+		"instance_requirements":                 "InstanceRequirements",
 		"instance_storage_configs":              "InstanceStorageConfigs",
 		"instance_type":                         "InstanceType",
+		"instance_types":                        "InstanceTypes",
+		"interface_type":                        "InterfaceType",
 		"key":                                   "Key",
 		"kubernetes_config":                     "KubernetesConfig",
 		"labels":                                "Labels",
@@ -2010,22 +2779,35 @@ func clusterResource(ctx context.Context) (resource.Resource, error) {
 		"maximum_batch_size":                    "MaximumBatchSize",
 		"min_instance_count":                    "MinInstanceCount",
 		"mode":                                  "Mode",
+		"mount_path":                            "MountPath",
+		"network_interface":                     "NetworkInterface",
+		"next_patch_date":                       "NextPatchDate",
 		"node_provisioning_mode":                "NodeProvisioningMode",
 		"node_recovery":                         "NodeRecovery",
+		"node_type":                             "NodeType",
 		"on_create":                             "OnCreate",
 		"on_demand":                             "OnDemand",
+		"on_init_complete":                      "OnInitComplete",
 		"on_start_deep_health_checks":           "OnStartDeepHealthChecks",
 		"orchestrator":                          "Orchestrator",
 		"override_vpc_config":                   "OverrideVpcConfig",
+		"partition_names":                       "PartitionNames",
+		"patch_schedule":                        "PatchSchedule",
+		"patching_strategy":                     "PatchingStrategy",
 		"per_unit_storage_throughput":           "PerUnitStorageThroughput",
 		"restricted_instance_groups":            "RestrictedInstanceGroups",
+		"restricted_instance_groups_config":     "RestrictedInstanceGroupsConfig",
 		"rollback_maximum_batch_size":           "RollbackMaximumBatchSize",
 		"rolling_update_policy":                 "RollingUpdatePolicy",
 		"root_volume":                           "RootVolume",
 		"schedule_expression":                   "ScheduleExpression",
 		"scheduled_update_config":               "ScheduledUpdateConfig",
 		"security_group_ids":                    "SecurityGroupIds",
+		"shared_environment_config":             "SharedEnvironmentConfig",
 		"size_in_gi_b":                          "SizeInGiB",
+		"slurm":                                 "Slurm",
+		"slurm_config":                          "SlurmConfig",
+		"slurm_config_strategy":                 "SlurmConfigStrategy",
 		"source_s3_uri":                         "SourceS3Uri",
 		"spot":                                  "Spot",
 		"subnets":                               "Subnets",

--- a/internal/aws/sagemaker/cluster_singular_data_source_gen.go
+++ b/internal/aws/sagemaker/cluster_singular_data_source_gen.go
@@ -162,6 +162,122 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	    "additionalProperties": false,
 		//	    "description": "Details of an instance group in a SageMaker HyperPod cluster.",
 		//	    "properties": {
+		//	      "AutoPatchConfig": {
+		//	        "additionalProperties": false,
+		//	        "description": "The configuration for automatic patching of the instance group. Enables workload-aware, patch-level AMI updates.",
+		//	        "properties": {
+		//	          "DeploymentConfig": {
+		//	            "additionalProperties": false,
+		//	            "description": "The configuration to use when updating the AMI versions.",
+		//	            "properties": {
+		//	              "AutoRollbackConfiguration": {
+		//	                "description": "An array that contains the alarms that SageMaker monitors to know whether to roll back the AMI update.",
+		//	                "insertionOrder": false,
+		//	                "items": {
+		//	                  "additionalProperties": false,
+		//	                  "description": "The details of the alarm to monitor during the AMI update.",
+		//	                  "properties": {
+		//	                    "AlarmName": {
+		//	                      "description": "The name of the alarm.",
+		//	                      "maxLength": 256,
+		//	                      "minLength": 1,
+		//	                      "pattern": "",
+		//	                      "type": "string"
+		//	                    }
+		//	                  },
+		//	                  "required": [
+		//	                    "AlarmName"
+		//	                  ],
+		//	                  "type": "object"
+		//	                },
+		//	                "type": "array"
+		//	              },
+		//	              "RollingUpdatePolicy": {
+		//	                "additionalProperties": false,
+		//	                "description": "The policy that SageMaker uses when updating the AMI versions of the cluster.",
+		//	                "properties": {
+		//	                  "MaximumBatchSize": {
+		//	                    "additionalProperties": false,
+		//	                    "description": "The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances.",
+		//	                    "properties": {
+		//	                      "Type": {
+		//	                        "description": "Specifies whether SageMaker should process the update by amount or percentage of instances.",
+		//	                        "pattern": "INSTANCE_COUNT|CAPACITY_PERCENTAGE",
+		//	                        "type": "string"
+		//	                      },
+		//	                      "Value": {
+		//	                        "description": "Specifies the amount or percentage of instances SageMaker updates at a time.",
+		//	                        "minimum": 1,
+		//	                        "type": "integer"
+		//	                      }
+		//	                    },
+		//	                    "required": [
+		//	                      "Type",
+		//	                      "Value"
+		//	                    ],
+		//	                    "type": "object"
+		//	                  },
+		//	                  "RollbackMaximumBatchSize": {
+		//	                    "additionalProperties": false,
+		//	                    "description": "The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances.",
+		//	                    "properties": {
+		//	                      "Type": {
+		//	                        "description": "Specifies whether SageMaker should process the update by amount or percentage of instances.",
+		//	                        "pattern": "INSTANCE_COUNT|CAPACITY_PERCENTAGE",
+		//	                        "type": "string"
+		//	                      },
+		//	                      "Value": {
+		//	                        "description": "Specifies the amount or percentage of instances SageMaker updates at a time.",
+		//	                        "minimum": 1,
+		//	                        "type": "integer"
+		//	                      }
+		//	                    },
+		//	                    "required": [
+		//	                      "Type",
+		//	                      "Value"
+		//	                    ],
+		//	                    "type": "object"
+		//	                  }
+		//	                },
+		//	                "required": [
+		//	                  "MaximumBatchSize"
+		//	                ],
+		//	                "type": "object"
+		//	              },
+		//	              "WaitIntervalInSeconds": {
+		//	                "description": "The duration in seconds that SageMaker waits before updating more instances in the cluster.",
+		//	                "maximum": 3600,
+		//	                "minimum": 0,
+		//	                "type": "integer"
+		//	              }
+		//	            },
+		//	            "type": "object"
+		//	          },
+		//	          "PatchSchedule": {
+		//	            "additionalProperties": false,
+		//	            "description": "The schedule configuration for automatic patching.",
+		//	            "properties": {
+		//	              "NextPatchDate": {
+		//	                "description": "The date and time of the next scheduled patch, set by the system when a patch AMI is detected.",
+		//	                "type": "string"
+		//	              }
+		//	            },
+		//	            "type": "object"
+		//	          },
+		//	          "PatchingStrategy": {
+		//	            "description": "The patching strategy that determines when and how instances are patched. WhenIdle patches instances as they become idle. WhenAllIdle patches all instances when they are all idle.",
+		//	            "enum": [
+		//	              "WhenIdle",
+		//	              "WhenAllIdle"
+		//	            ],
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "PatchingStrategy"
+		//	        ],
+		//	        "type": "object"
+		//	      },
 		//	      "CapacityRequirements": {
 		//	        "additionalProperties": false,
 		//	        "description": "Specifies the capacity requirements configuration for an instance group",
@@ -210,6 +326,27 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	        "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$",
 		//	        "type": "string"
 		//	      },
+		//	      "InstanceRequirements": {
+		//	        "additionalProperties": false,
+		//	        "description": "The instance requirements for the instance group. Specifies a list of instance types that can be used.",
+		//	        "properties": {
+		//	          "InstanceTypes": {
+		//	            "description": "A list of instance types that can be used for this instance group.",
+		//	            "insertionOrder": true,
+		//	            "items": {
+		//	              "description": "The instance type of the instance group of a SageMaker HyperPod cluster.",
+		//	              "type": "string"
+		//	            },
+		//	            "maxItems": 20,
+		//	            "minItems": 1,
+		//	            "type": "array"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "InstanceTypes"
+		//	        ],
+		//	        "type": "object"
+		//	      },
 		//	      "InstanceStorageConfigs": {
 		//	        "description": "The instance storage configuration for the instance group.",
 		//	        "insertionOrder": false,
@@ -237,11 +374,35 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	                }
 		//	              },
 		//	              "type": "object"
+		//	            },
+		//	            "FsxOpenZfsConfig": {
+		//	              "additionalProperties": false,
+		//	              "description": "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
+		//	              "properties": {
+		//	                "DnsName": {
+		//	                  "description": "The DNS name of the FSx for OpenZFS file system.",
+		//	                  "maxLength": 275,
+		//	                  "minLength": 16,
+		//	                  "pattern": "^((fs|fc)i?-[0-9a-f]{8,}\\..{4,253})$",
+		//	                  "type": "string"
+		//	                },
+		//	                "MountPath": {
+		//	                  "description": "The mount path for the FSx for OpenZFS file system.",
+		//	                  "maxLength": 1024,
+		//	                  "minLength": 1,
+		//	                  "pattern": "",
+		//	                  "type": "string"
+		//	                }
+		//	              },
+		//	              "required": [
+		//	                "DnsName"
+		//	              ],
+		//	              "type": "object"
 		//	            }
 		//	          },
 		//	          "type": "object"
 		//	        },
-		//	        "maxItems": 1,
+		//	        "maxItems": 4,
 		//	        "type": "array"
 		//	      },
 		//	      "InstanceType": {
@@ -301,10 +462,17 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	      },
 		//	      "LifeCycleConfig": {
 		//	        "additionalProperties": false,
-		//	        "description": "The lifecycle configuration for a SageMaker HyperPod cluster.",
+		//	        "description": "The lifecycle configuration for a SageMaker HyperPod cluster. When omitted, the instance group uses Bootstrap mode. When provided with SourceS3Uri and OnCreate, uses Customer Managed mode. When provided with SourceS3Uri and OnInitComplete, uses Extended mode.",
 		//	        "properties": {
 		//	          "OnCreate": {
-		//	            "description": "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation.",
+		//	            "description": "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation. Mutually exclusive with OnInitComplete.",
+		//	            "maxLength": 128,
+		//	            "minLength": 1,
+		//	            "pattern": "^[\\S\\s]+$",
+		//	            "type": "string"
+		//	          },
+		//	          "OnInitComplete": {
+		//	            "description": "The file name of the extension script under SourceS3Uri. This script runs after HyperPod configures the default software on the instance. Mutually exclusive with OnCreate.",
 		//	            "maxLength": 128,
 		//	            "minLength": 1,
 		//	            "pattern": "^[\\S\\s]+$",
@@ -317,16 +485,30 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	            "type": "string"
 		//	          }
 		//	        },
-		//	        "required": [
-		//	          "OnCreate",
-		//	          "SourceS3Uri"
-		//	        ],
 		//	        "type": "object"
 		//	      },
 		//	      "MinInstanceCount": {
 		//	        "description": "The minimum number of instances required for the instance group to be InService. MinInstanceCount must be less than or equal to InstanceCount.",
 		//	        "minimum": 0,
 		//	        "type": "integer"
+		//	      },
+		//	      "NetworkInterface": {
+		//	        "additionalProperties": false,
+		//	        "description": "Specifies the network interface configuration for the instance group.",
+		//	        "properties": {
+		//	          "InterfaceType": {
+		//	            "description": "The type of network interface.",
+		//	            "enum": [
+		//	              "efa",
+		//	              "efa-only"
+		//	            ],
+		//	            "type": "string"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "InterfaceType"
+		//	        ],
+		//	        "type": "object"
 		//	      },
 		//	      "OnStartDeepHealthChecks": {
 		//	        "description": "Nodes will undergo advanced stress test to detect and replace faulty instances, based on the type of deep health check(s) passed in.",
@@ -480,6 +662,39 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	        ],
 		//	        "type": "object"
 		//	      },
+		//	      "SlurmConfig": {
+		//	        "additionalProperties": false,
+		//	        "description": "Slurm configuration for the instance group.",
+		//	        "properties": {
+		//	          "NodeType": {
+		//	            "description": "The type of Slurm node for this instance group.",
+		//	            "enum": [
+		//	              "Controller",
+		//	              "Login",
+		//	              "Compute"
+		//	            ],
+		//	            "type": "string"
+		//	          },
+		//	          "PartitionNames": {
+		//	            "description": "The Slurm partitions that this instance group belongs to. Maximum of 1 partition.",
+		//	            "insertionOrder": false,
+		//	            "items": {
+		//	              "description": "The name of a Slurm partition.",
+		//	              "maxLength": 1024,
+		//	              "minLength": 0,
+		//	              "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$",
+		//	              "type": "string"
+		//	            },
+		//	            "maxItems": 1,
+		//	            "minItems": 0,
+		//	            "type": "array"
+		//	          }
+		//	        },
+		//	        "required": [
+		//	          "NodeType"
+		//	        ],
+		//	        "type": "object"
+		//	      },
 		//	      "ThreadsPerCore": {
 		//	        "description": "The number you specified to TreadsPerCore in CreateCluster for enabling or disabling multithreading. For instance types that support multithreading, you can specify 1 for disabling multithreading and 2 for enabling multithreading.",
 		//	        "maximum": 2,
@@ -497,9 +712,7 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	    "required": [
 		//	      "ExecutionRole",
 		//	      "InstanceCount",
-		//	      "InstanceGroupName",
-		//	      "InstanceType",
-		//	      "LifeCycleConfig"
+		//	      "InstanceGroupName"
 		//	    ],
 		//	    "type": "object"
 		//	  },
@@ -509,6 +722,97 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"instance_groups": schema.ListNestedAttribute{ /*START ATTRIBUTE*/
 			NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
 				Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+					// Property: AutoPatchConfig
+					"auto_patch_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: DeploymentConfig
+							"deployment_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+								Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+									// Property: AutoRollbackConfiguration
+									"auto_rollback_configuration": schema.ListNestedAttribute{ /*START ATTRIBUTE*/
+										NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
+											Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+												// Property: AlarmName
+												"alarm_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+													Description: "The name of the alarm.",
+													Computed:    true,
+												}, /*END ATTRIBUTE*/
+											}, /*END SCHEMA*/
+										}, /*END NESTED OBJECT*/
+										Description: "An array that contains the alarms that SageMaker monitors to know whether to roll back the AMI update.",
+										Computed:    true,
+									}, /*END ATTRIBUTE*/
+									// Property: RollingUpdatePolicy
+									"rolling_update_policy": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+										Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+											// Property: MaximumBatchSize
+											"maximum_batch_size": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+												Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+													// Property: Type
+													"type": schema.StringAttribute{ /*START ATTRIBUTE*/
+														Description: "Specifies whether SageMaker should process the update by amount or percentage of instances.",
+														Computed:    true,
+													}, /*END ATTRIBUTE*/
+													// Property: Value
+													"value": schema.Int64Attribute{ /*START ATTRIBUTE*/
+														Description: "Specifies the amount or percentage of instances SageMaker updates at a time.",
+														Computed:    true,
+													}, /*END ATTRIBUTE*/
+												}, /*END SCHEMA*/
+												Description: "The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances.",
+												Computed:    true,
+											}, /*END ATTRIBUTE*/
+											// Property: RollbackMaximumBatchSize
+											"rollback_maximum_batch_size": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+												Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+													// Property: Type
+													"type": schema.StringAttribute{ /*START ATTRIBUTE*/
+														Description: "Specifies whether SageMaker should process the update by amount or percentage of instances.",
+														Computed:    true,
+													}, /*END ATTRIBUTE*/
+													// Property: Value
+													"value": schema.Int64Attribute{ /*START ATTRIBUTE*/
+														Description: "Specifies the amount or percentage of instances SageMaker updates at a time.",
+														Computed:    true,
+													}, /*END ATTRIBUTE*/
+												}, /*END SCHEMA*/
+												Description: "The configuration of the size measurements of the AMI update. Using this configuration, you can specify whether SageMaker should update your instance group by an amount or percentage of instances.",
+												Computed:    true,
+											}, /*END ATTRIBUTE*/
+										}, /*END SCHEMA*/
+										Description: "The policy that SageMaker uses when updating the AMI versions of the cluster.",
+										Computed:    true,
+									}, /*END ATTRIBUTE*/
+									// Property: WaitIntervalInSeconds
+									"wait_interval_in_seconds": schema.Int64Attribute{ /*START ATTRIBUTE*/
+										Description: "The duration in seconds that SageMaker waits before updating more instances in the cluster.",
+										Computed:    true,
+									}, /*END ATTRIBUTE*/
+								}, /*END SCHEMA*/
+								Description: "The configuration to use when updating the AMI versions.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+							// Property: PatchSchedule
+							"patch_schedule": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+								Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+									// Property: NextPatchDate
+									"next_patch_date": schema.StringAttribute{ /*START ATTRIBUTE*/
+										Description: "The date and time of the next scheduled patch, set by the system when a patch AMI is detected.",
+										Computed:    true,
+									}, /*END ATTRIBUTE*/
+								}, /*END SCHEMA*/
+								Description: "The schedule configuration for automatic patching.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+							// Property: PatchingStrategy
+							"patching_strategy": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The patching strategy that determines when and how instances are patched. WhenIdle patches instances as they become idle. WhenAllIdle patches all instances when they are all idle.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+						Description: "The configuration for automatic patching of the instance group. Enables workload-aware, patch-level AMI updates.",
+						Computed:    true,
+					}, /*END ATTRIBUTE*/
 					// Property: CapacityRequirements
 					"capacity_requirements": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
 						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
@@ -553,6 +857,19 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 						Description: "The name of the instance group of a SageMaker HyperPod cluster.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
+					// Property: InstanceRequirements
+					"instance_requirements": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: InstanceTypes
+							"instance_types": schema.ListAttribute{ /*START ATTRIBUTE*/
+								ElementType: types.StringType,
+								Description: "A list of instance types that can be used for this instance group.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+						Description: "The instance requirements for the instance group. Specifies a list of instance types that can be used.",
+						Computed:    true,
+					}, /*END ATTRIBUTE*/
 					// Property: InstanceStorageConfigs
 					"instance_storage_configs": schema.ListNestedAttribute{ /*START ATTRIBUTE*/
 						NestedObject: schema.NestedAttributeObject{ /*START NESTED OBJECT*/
@@ -575,6 +892,23 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 										}, /*END ATTRIBUTE*/
 									}, /*END SCHEMA*/
 									Description: "Defines the configuration for attaching additional Amazon Elastic Block Store (EBS) volumes to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker.",
+									Computed:    true,
+								}, /*END ATTRIBUTE*/
+								// Property: FsxOpenZfsConfig
+								"fsx_open_zfs_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+									Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+										// Property: DnsName
+										"dns_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+											Description: "The DNS name of the FSx for OpenZFS file system.",
+											Computed:    true,
+										}, /*END ATTRIBUTE*/
+										// Property: MountPath
+										"mount_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+											Description: "The mount path for the FSx for OpenZFS file system.",
+											Computed:    true,
+										}, /*END ATTRIBUTE*/
+									}, /*END SCHEMA*/
+									Description: "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
 									Computed:    true,
 								}, /*END ATTRIBUTE*/
 							}, /*END SCHEMA*/
@@ -630,7 +964,12 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
 							// Property: OnCreate
 							"on_create": schema.StringAttribute{ /*START ATTRIBUTE*/
-								Description: "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation.",
+								Description: "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation. Mutually exclusive with OnInitComplete.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+							// Property: OnInitComplete
+							"on_init_complete": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The file name of the extension script under SourceS3Uri. This script runs after HyperPod configures the default software on the instance. Mutually exclusive with OnCreate.",
 								Computed:    true,
 							}, /*END ATTRIBUTE*/
 							// Property: SourceS3Uri
@@ -639,12 +978,24 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 								Computed:    true,
 							}, /*END ATTRIBUTE*/
 						}, /*END SCHEMA*/
-						Description: "The lifecycle configuration for a SageMaker HyperPod cluster.",
+						Description: "The lifecycle configuration for a SageMaker HyperPod cluster. When omitted, the instance group uses Bootstrap mode. When provided with SourceS3Uri and OnCreate, uses Customer Managed mode. When provided with SourceS3Uri and OnInitComplete, uses Extended mode.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
 					// Property: MinInstanceCount
 					"min_instance_count": schema.Int64Attribute{ /*START ATTRIBUTE*/
 						Description: "The minimum number of instances required for the instance group to be InService. MinInstanceCount must be less than or equal to InstanceCount.",
+						Computed:    true,
+					}, /*END ATTRIBUTE*/
+					// Property: NetworkInterface
+					"network_interface": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: InterfaceType
+							"interface_type": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The type of network interface.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+						Description: "Specifies the network interface configuration for the instance group.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
 					// Property: OnStartDeepHealthChecks
@@ -751,6 +1102,24 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 						Description: "The configuration object of the schedule that SageMaker follows when updating the AMI.",
 						Computed:    true,
 					}, /*END ATTRIBUTE*/
+					// Property: SlurmConfig
+					"slurm_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+						Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+							// Property: NodeType
+							"node_type": schema.StringAttribute{ /*START ATTRIBUTE*/
+								Description: "The type of Slurm node for this instance group.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+							// Property: PartitionNames
+							"partition_names": schema.ListAttribute{ /*START ATTRIBUTE*/
+								ElementType: types.StringType,
+								Description: "The Slurm partitions that this instance group belongs to. Maximum of 1 partition.",
+								Computed:    true,
+							}, /*END ATTRIBUTE*/
+						}, /*END SCHEMA*/
+						Description: "Slurm configuration for the instance group.",
+						Computed:    true,
+					}, /*END ATTRIBUTE*/
 					// Property: ThreadsPerCore
 					"threads_per_core": schema.Int64Attribute{ /*START ATTRIBUTE*/
 						Description: "The number you specified to TreadsPerCore in CreateCluster for enabling or disabling multithreading. For instance types that support multithreading, you can specify 1 for disabling multithreading and 2 for enabling multithreading.",
@@ -799,8 +1168,7 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		// CloudFormation resource type schema:
 		//
 		//	{
-		//	  "additionalProperties": false,
-		//	  "description": "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster.",
+		//	  "description": "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster or Slurm configuration.",
 		//	  "properties": {
 		//	    "Eks": {
 		//	      "additionalProperties": false,
@@ -815,11 +1183,24 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	        "ClusterArn"
 		//	      ],
 		//	      "type": "object"
+		//	    },
+		//	    "Slurm": {
+		//	      "additionalProperties": false,
+		//	      "description": "Specifies parameter(s) related to Slurm as orchestrator.",
+		//	      "properties": {
+		//	        "SlurmConfigStrategy": {
+		//	          "description": "The strategy for managing Slurm configuration on the cluster.",
+		//	          "enum": [
+		//	            "Overwrite",
+		//	            "Managed",
+		//	            "Merge"
+		//	          ],
+		//	          "type": "string"
+		//	        }
+		//	      },
+		//	      "type": "object"
 		//	    }
 		//	  },
-		//	  "required": [
-		//	    "Eks"
-		//	  ],
 		//	  "type": "object"
 		//	}
 		"orchestrator": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
@@ -836,8 +1217,20 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 					Description: "Specifies parameter(s) related to EKS as orchestrator, e.g. the EKS cluster nodes will attach to,",
 					Computed:    true,
 				}, /*END ATTRIBUTE*/
+				// Property: Slurm
+				"slurm": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+					Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+						// Property: SlurmConfigStrategy
+						"slurm_config_strategy": schema.StringAttribute{ /*START ATTRIBUTE*/
+							Description: "The strategy for managing Slurm configuration on the cluster.",
+							Computed:    true,
+						}, /*END ATTRIBUTE*/
+					}, /*END SCHEMA*/
+					Description: "Specifies parameter(s) related to Slurm as orchestrator.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
 			}, /*END SCHEMA*/
-			Description: "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster.",
+			Description: "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster or Slurm configuration.",
 			Computed:    true,
 		}, /*END ATTRIBUTE*/
 		// Property: RestrictedInstanceGroups
@@ -931,11 +1324,35 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	                }
 		//	              },
 		//	              "type": "object"
+		//	            },
+		//	            "FsxOpenZfsConfig": {
+		//	              "additionalProperties": false,
+		//	              "description": "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
+		//	              "properties": {
+		//	                "DnsName": {
+		//	                  "description": "The DNS name of the FSx for OpenZFS file system.",
+		//	                  "maxLength": 275,
+		//	                  "minLength": 16,
+		//	                  "pattern": "^((fs|fc)i?-[0-9a-f]{8,}\\..{4,253})$",
+		//	                  "type": "string"
+		//	                },
+		//	                "MountPath": {
+		//	                  "description": "The mount path for the FSx for OpenZFS file system.",
+		//	                  "maxLength": 1024,
+		//	                  "minLength": 1,
+		//	                  "pattern": "",
+		//	                  "type": "string"
+		//	                }
+		//	              },
+		//	              "required": [
+		//	                "DnsName"
+		//	              ],
+		//	              "type": "object"
 		//	            }
 		//	          },
 		//	          "type": "object"
 		//	        },
-		//	        "maxItems": 1,
+		//	        "maxItems": 4,
 		//	        "type": "array"
 		//	      },
 		//	      "InstanceType": {
@@ -1008,8 +1425,7 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		//	      "ExecutionRole",
 		//	      "InstanceCount",
 		//	      "InstanceGroupName",
-		//	      "InstanceType",
-		//	      "EnvironmentConfig"
+		//	      "InstanceType"
 		//	    ],
 		//	    "type": "object"
 		//	  },
@@ -1087,6 +1503,23 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 									Description: "Defines the configuration for attaching additional Amazon Elastic Block Store (EBS) volumes to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker.",
 									Computed:    true,
 								}, /*END ATTRIBUTE*/
+								// Property: FsxOpenZfsConfig
+								"fsx_open_zfs_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+									Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+										// Property: DnsName
+										"dns_name": schema.StringAttribute{ /*START ATTRIBUTE*/
+											Description: "The DNS name of the FSx for OpenZFS file system.",
+											Computed:    true,
+										}, /*END ATTRIBUTE*/
+										// Property: MountPath
+										"mount_path": schema.StringAttribute{ /*START ATTRIBUTE*/
+											Description: "The mount path for the FSx for OpenZFS file system.",
+											Computed:    true,
+										}, /*END ATTRIBUTE*/
+									}, /*END SCHEMA*/
+									Description: "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
+									Computed:    true,
+								}, /*END ATTRIBUTE*/
 							}, /*END SCHEMA*/
 						}, /*END NESTED OBJECT*/
 						Description: "The instance storage configuration for the instance group.",
@@ -1135,6 +1568,95 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 				}, /*END SCHEMA*/
 			}, /*END NESTED OBJECT*/
 			Description: "The restricted instance groups of the SageMaker HyperPod cluster.",
+			Computed:    true,
+		}, /*END ATTRIBUTE*/
+		// Property: RestrictedInstanceGroupsConfig
+		// CloudFormation resource type schema:
+		//
+		//	{
+		//	  "additionalProperties": false,
+		//	  "description": "The cluster-level configuration for restricted instance groups, including shared environment settings for inter-RIG communication and FSx Lustre sharing.",
+		//	  "properties": {
+		//	    "SharedEnvironmentConfig": {
+		//	      "additionalProperties": false,
+		//	      "description": "The shared environment configuration for restricted instance groups that use cluster-level shared FSx Lustre storage.",
+		//	      "properties": {
+		//	        "FSxLustreConfig": {
+		//	          "additionalProperties": false,
+		//	          "description": "Configuration settings for an Amazon FSx for Lustre file system to be used with the cluster.",
+		//	          "properties": {
+		//	            "PerUnitStorageThroughput": {
+		//	              "description": "The throughput capacity of the FSx for Lustre file system, measured in MB/s per TiB of storage.",
+		//	              "maximum": 1000,
+		//	              "minimum": 125,
+		//	              "type": "integer"
+		//	            },
+		//	            "SizeInGiB": {
+		//	              "description": "The storage capacity of the FSx for Lustre file system, specified in gibibytes (GiB).",
+		//	              "maximum": 100800,
+		//	              "minimum": 1200,
+		//	              "type": "integer"
+		//	            }
+		//	          },
+		//	          "required": [
+		//	            "SizeInGiB",
+		//	            "PerUnitStorageThroughput"
+		//	          ],
+		//	          "type": "object"
+		//	        },
+		//	        "FSxLustreDeletionPolicy": {
+		//	          "description": "The deletion policy for the shared FSx Lustre file system. Keep retains the FSx when RIGs are deleted. DeleteIfNotUsed deletes the FSx when no RIGs reference it.",
+		//	          "enum": [
+		//	            "Keep",
+		//	            "DeleteIfNotUsed"
+		//	          ],
+		//	          "type": "string"
+		//	        }
+		//	      },
+		//	      "required": [
+		//	        "FSxLustreDeletionPolicy"
+		//	      ],
+		//	      "type": "object"
+		//	    }
+		//	  },
+		//	  "required": [
+		//	    "SharedEnvironmentConfig"
+		//	  ],
+		//	  "type": "object"
+		//	}
+		"restricted_instance_groups_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+			Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+				// Property: SharedEnvironmentConfig
+				"shared_environment_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+					Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+						// Property: FSxLustreConfig
+						"fsx_lustre_config": schema.SingleNestedAttribute{ /*START ATTRIBUTE*/
+							Attributes: map[string]schema.Attribute{ /*START SCHEMA*/
+								// Property: PerUnitStorageThroughput
+								"per_unit_storage_throughput": schema.Int64Attribute{ /*START ATTRIBUTE*/
+									Description: "The throughput capacity of the FSx for Lustre file system, measured in MB/s per TiB of storage.",
+									Computed:    true,
+								}, /*END ATTRIBUTE*/
+								// Property: SizeInGiB
+								"size_in_gi_b": schema.Int64Attribute{ /*START ATTRIBUTE*/
+									Description: "The storage capacity of the FSx for Lustre file system, specified in gibibytes (GiB).",
+									Computed:    true,
+								}, /*END ATTRIBUTE*/
+							}, /*END SCHEMA*/
+							Description: "Configuration settings for an Amazon FSx for Lustre file system to be used with the cluster.",
+							Computed:    true,
+						}, /*END ATTRIBUTE*/
+						// Property: FSxLustreDeletionPolicy
+						"fsx_lustre_deletion_policy": schema.StringAttribute{ /*START ATTRIBUTE*/
+							Description: "The deletion policy for the shared FSx Lustre file system. Keep retains the FSx when RIGs are deleted. DeleteIfNotUsed deletes the FSx when no RIGs reference it.",
+							Computed:    true,
+						}, /*END ATTRIBUTE*/
+					}, /*END SCHEMA*/
+					Description: "The shared environment configuration for restricted instance groups that use cluster-level shared FSx Lustre storage.",
+					Computed:    true,
+				}, /*END ATTRIBUTE*/
+			}, /*END SCHEMA*/
+			Description: "The cluster-level configuration for restricted instance groups, including shared environment settings for inter-RIG communication and FSx Lustre sharing.",
 			Computed:    true,
 		}, /*END ATTRIBUTE*/
 		// Property: Tags
@@ -1305,6 +1827,7 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 	opts = opts.WithTerraformSchema(schema)
 	opts = opts.WithAttributeNameMap(map[string]string{
 		"alarm_name":                            "AlarmName",
+		"auto_patch_config":                     "AutoPatchConfig",
 		"auto_rollback_configuration":           "AutoRollbackConfiguration",
 		"auto_scaler_type":                      "AutoScalerType",
 		"auto_scaling":                          "AutoScaling",
@@ -1316,6 +1839,7 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"creation_time":                         "CreationTime",
 		"current_count":                         "CurrentCount",
 		"deployment_config":                     "DeploymentConfig",
+		"dns_name":                              "DnsName",
 		"ebs_volume_config":                     "EbsVolumeConfig",
 		"effect":                                "Effect",
 		"eks":                                   "Eks",
@@ -1323,13 +1847,18 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"execution_role":                        "ExecutionRole",
 		"failure_message":                       "FailureMessage",
 		"fsx_lustre_config":                     "FSxLustreConfig",
+		"fsx_lustre_deletion_policy":            "FSxLustreDeletionPolicy",
+		"fsx_open_zfs_config":                   "FsxOpenZfsConfig",
 		"image_id":                              "ImageId",
 		"instance_count":                        "InstanceCount",
 		"instance_group_name":                   "InstanceGroupName",
 		"instance_groups":                       "InstanceGroups",
 		"instance_memory_allocation_percentage": "InstanceMemoryAllocationPercentage",
+		"instance_requirements":                 "InstanceRequirements",
 		"instance_storage_configs":              "InstanceStorageConfigs",
 		"instance_type":                         "InstanceType",
+		"instance_types":                        "InstanceTypes",
+		"interface_type":                        "InterfaceType",
 		"key":                                   "Key",
 		"kubernetes_config":                     "KubernetesConfig",
 		"labels":                                "Labels",
@@ -1337,22 +1866,35 @@ func clusterDataSource(ctx context.Context) (datasource.DataSource, error) {
 		"maximum_batch_size":                    "MaximumBatchSize",
 		"min_instance_count":                    "MinInstanceCount",
 		"mode":                                  "Mode",
+		"mount_path":                            "MountPath",
+		"network_interface":                     "NetworkInterface",
+		"next_patch_date":                       "NextPatchDate",
 		"node_provisioning_mode":                "NodeProvisioningMode",
 		"node_recovery":                         "NodeRecovery",
+		"node_type":                             "NodeType",
 		"on_create":                             "OnCreate",
 		"on_demand":                             "OnDemand",
+		"on_init_complete":                      "OnInitComplete",
 		"on_start_deep_health_checks":           "OnStartDeepHealthChecks",
 		"orchestrator":                          "Orchestrator",
 		"override_vpc_config":                   "OverrideVpcConfig",
+		"partition_names":                       "PartitionNames",
+		"patch_schedule":                        "PatchSchedule",
+		"patching_strategy":                     "PatchingStrategy",
 		"per_unit_storage_throughput":           "PerUnitStorageThroughput",
 		"restricted_instance_groups":            "RestrictedInstanceGroups",
+		"restricted_instance_groups_config":     "RestrictedInstanceGroupsConfig",
 		"rollback_maximum_batch_size":           "RollbackMaximumBatchSize",
 		"rolling_update_policy":                 "RollingUpdatePolicy",
 		"root_volume":                           "RootVolume",
 		"schedule_expression":                   "ScheduleExpression",
 		"scheduled_update_config":               "ScheduledUpdateConfig",
 		"security_group_ids":                    "SecurityGroupIds",
+		"shared_environment_config":             "SharedEnvironmentConfig",
 		"size_in_gi_b":                          "SizeInGiB",
+		"slurm":                                 "Slurm",
+		"slurm_config":                          "SlurmConfig",
+		"slurm_config_strategy":                 "SlurmConfigStrategy",
 		"source_s3_uri":                         "SourceS3Uri",
 		"spot":                                  "Spot",
 		"subnets":                               "Subnets",

--- a/internal/service/cloudformation/schemas/AWS_SageMaker_Cluster.json
+++ b/internal/service/cloudformation/schemas/AWS_SageMaker_Cluster.json
@@ -11,6 +11,30 @@
     "tagProperty": "/properties/Tags",
     "cloudFormationSystemTags": false
   },
+  "typeName": "AWS::SageMaker::Cluster",
+  "readOnlyProperties": [
+    "/properties/ClusterArn",
+    "/properties/CreationTime",
+    "/properties/ClusterStatus",
+    "/properties/FailureMessage",
+    "/properties/InstanceGroups/*/CurrentCount",
+    "/properties/RestrictedInstanceGroups/*/CurrentCount",
+    "/properties/InstanceGroups/*/AutoPatchConfig/PatchSchedule/NextPatchDate"
+  ],
+  "description": "Resource Type definition for AWS::SageMaker::Cluster",
+  "createOnlyProperties": [
+    "/properties/ClusterName",
+    "/properties/VpcConfig",
+    "/properties/Orchestrator/Eks"
+  ],
+  "primaryIdentifier": [
+    "/properties/ClusterArn"
+  ],
+  "required": [],
+  "conditionalCreateOnlyProperties": [
+    "/properties/InstanceGroups/*/CustomMetadata",
+    "/properties/RestrictedInstanceGroups/*/CustomMetadata"
+  ],
   "handlers": {
     "read": {
       "permissions": [
@@ -85,40 +109,12 @@
       "timeoutInMinutes": 720
     }
   },
-  "typeName": "AWS::SageMaker::Cluster",
-  "readOnlyProperties": [
-    "/properties/ClusterArn",
-    "/properties/CreationTime",
-    "/properties/ClusterStatus",
-    "/properties/FailureMessage",
-    "/properties/InstanceGroups/*/CurrentCount",
-    "/properties/RestrictedInstanceGroups/*/CurrentCount"
-  ],
-  "description": "Resource Type definition for AWS::SageMaker::Cluster",
   "additionalIdentifiers": [
     [
       "/properties/ClusterName"
     ]
   ],
-  "createOnlyProperties": [
-    "/properties/ClusterName",
-    "/properties/VpcConfig",
-    "/properties/Orchestrator",
-    "/properties/InstanceGroups/*/OverrideVpcConfig",
-    "/properties/InstanceGroups/*/ExecutionRole",
-    "/properties/InstanceGroups/*/InstanceGroupName",
-    "/properties/InstanceGroups/*/InstanceType",
-    "/properties/InstanceGroups/*/ThreadsPerCore",
-    "/properties/RestrictedInstanceGroups/*/OverrideVpcConfig",
-    "/properties/RestrictedInstanceGroups/*/ExecutionRole",
-    "/properties/RestrictedInstanceGroups/*/InstanceGroupName",
-    "/properties/RestrictedInstanceGroups/*/InstanceType",
-    "/properties/RestrictedInstanceGroups/*/ThreadsPerCore"
-  ],
   "additionalProperties": false,
-  "primaryIdentifier": [
-    "/properties/ClusterArn"
-  ],
   "definitions": {
     "ClusterOrchestratorEksConfig": {
       "description": "Specifies parameter(s) related to EKS as orchestrator, e.g. the EKS cluster nodes will attach to,",
@@ -177,6 +173,15 @@
               "$ref": "#/definitions/ClusterEbsVolumeConfig"
             }
           }
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "FsxOpenZfsConfig": {
+              "$ref": "#/definitions/ClusterFsxOpenZfsConfig"
+            }
+          }
         }
       ],
       "description": "Defines the configuration for attaching additional storage to the instances in the SageMaker HyperPod cluster instance group.",
@@ -226,6 +231,17 @@
         "SecurityGroupIds",
         "Subnets"
       ]
+    },
+    "PatchSchedule": {
+      "description": "The schedule configuration for automatic patching.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "NextPatchDate": {
+          "description": "The date and time of the next scheduled patch, set by the system when a patch AMI is detected.",
+          "type": "string"
+        }
+      }
     },
     "ClusterKubernetesTaint": {
       "description": "A Kubernetes taint to apply to cluster nodes.",
@@ -309,8 +325,7 @@
         "ExecutionRole",
         "InstanceCount",
         "InstanceGroupName",
-        "InstanceType",
-        "EnvironmentConfig"
+        "InstanceType"
       ]
     },
     "AutoRollbackConfiguration": {
@@ -320,6 +335,19 @@
       "items": {
         "$ref": "#/definitions/AlarmDetails"
       }
+    },
+    "RestrictedInstanceGroupsConfig": {
+      "description": "The cluster-level configuration for restricted instance groups, including shared environment settings for inter-RIG communication and FSx Lustre sharing.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "SharedEnvironmentConfig": {
+          "$ref": "#/definitions/SharedEnvironmentConfig"
+        }
+      },
+      "required": [
+        "SharedEnvironmentConfig"
+      ]
     },
     "ClusterCapacityRequirements": {
       "description": "Specifies the capacity requirements configuration for an instance group",
@@ -371,6 +399,46 @@
       "description": "The instance type of the instance group of a SageMaker HyperPod cluster.",
       "type": "string"
     },
+    "AutoPatchConfig": {
+      "description": "The configuration for automatic patching of the instance group. Enables workload-aware, patch-level AMI updates.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "PatchingStrategy": {
+          "description": "The patching strategy that determines when and how instances are patched. WhenIdle patches instances as they become idle. WhenAllIdle patches all instances when they are all idle.",
+          "type": "string",
+          "enum": [
+            "WhenIdle",
+            "WhenAllIdle"
+          ]
+        },
+        "PatchSchedule": {
+          "$ref": "#/definitions/PatchSchedule"
+        },
+        "DeploymentConfig": {
+          "$ref": "#/definitions/DeploymentConfig"
+        }
+      },
+      "required": [
+        "PatchingStrategy"
+      ]
+    },
+    "ClusterOrchestratorSlurmConfig": {
+      "description": "Specifies parameter(s) related to Slurm as orchestrator.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "SlurmConfigStrategy": {
+          "description": "The strategy for managing Slurm configuration on the cluster.",
+          "type": "string",
+          "enum": [
+            "Overwrite",
+            "Managed",
+            "Merge"
+          ]
+        }
+      }
+    },
     "ExecutionRole": {
       "minLength": 20,
       "pattern": "^arn:aws[a-z\\-]*:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$",
@@ -384,6 +452,60 @@
       "enum": [
         "InstanceStress",
         "InstanceConnectivity"
+      ]
+    },
+    "SharedEnvironmentConfig": {
+      "description": "The shared environment configuration for restricted instance groups that use cluster-level shared FSx Lustre storage.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "FSxLustreDeletionPolicy": {
+          "description": "The deletion policy for the shared FSx Lustre file system. Keep retains the FSx when RIGs are deleted. DeleteIfNotUsed deletes the FSx when no RIGs reference it.",
+          "type": "string",
+          "enum": [
+            "Keep",
+            "DeleteIfNotUsed"
+          ]
+        },
+        "FSxLustreConfig": {
+          "$ref": "#/definitions/FSxLustreConfig"
+        }
+      },
+      "required": [
+        "FSxLustreDeletionPolicy"
+      ]
+    },
+    "ClusterSlurmConfig": {
+      "description": "Slurm configuration for the instance group.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "PartitionNames": {
+          "minItems": 0,
+          "maxItems": 1,
+          "description": "The Slurm partitions that this instance group belongs to. Maximum of 1 partition.",
+          "insertionOrder": false,
+          "type": "array",
+          "items": {
+            "minLength": 0,
+            "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$",
+            "description": "The name of a Slurm partition.",
+            "type": "string",
+            "maxLength": 1024
+          }
+        },
+        "NodeType": {
+          "description": "The type of Slurm node for this instance group.",
+          "type": "string",
+          "enum": [
+            "Controller",
+            "Login",
+            "Compute"
+          ]
+        }
+      },
+      "required": [
+        "NodeType"
       ]
     },
     "EnvironmentConfig": {
@@ -440,17 +562,28 @@
       }
     },
     "Orchestrator": {
-      "description": "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster.",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "Eks": {
-          "$ref": "#/definitions/ClusterOrchestratorEksConfig"
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "Eks": {
+              "$ref": "#/definitions/ClusterOrchestratorEksConfig"
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "Slurm": {
+              "$ref": "#/definitions/ClusterOrchestratorSlurmConfig"
+            }
+          }
         }
-      },
-      "required": [
-        "Eks"
-      ]
+      ],
+      "description": "Specifies parameter(s) specific to the orchestrator, e.g. specify the EKS cluster or Slurm configuration.",
+      "type": "object"
     },
     "ClusterEbsVolumeConfig": {
       "description": "Defines the configuration for attaching additional Amazon Elastic Block Store (EBS) volumes to the instances in the SageMaker HyperPod cluster instance group. The additional EBS volume is attached to each instance within the SageMaker HyperPod cluster instance group and mounted to /opt/sagemaker.",
@@ -474,11 +607,36 @@
         }
       }
     },
-    "ClusterLifeCycleConfig": {
-      "description": "The lifecycle configuration for a SageMaker HyperPod cluster.",
+    "ClusterNetworkInterface": {
+      "description": "Specifies the network interface configuration for the instance group.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
+        "InterfaceType": {
+          "description": "The type of network interface.",
+          "type": "string",
+          "enum": [
+            "efa",
+            "efa-only"
+          ]
+        }
+      },
+      "required": [
+        "InterfaceType"
+      ]
+    },
+    "ClusterLifeCycleConfig": {
+      "description": "The lifecycle configuration for a SageMaker HyperPod cluster. When omitted, the instance group uses Bootstrap mode. When provided with SourceS3Uri and OnCreate, uses Customer Managed mode. When provided with SourceS3Uri and OnInitComplete, uses Extended mode.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "OnInitComplete": {
+          "minLength": 1,
+          "pattern": "^[\\S\\s]+$",
+          "description": "The file name of the extension script under SourceS3Uri. This script runs after HyperPod configures the default software on the instance. Mutually exclusive with OnCreate.",
+          "type": "string",
+          "maxLength": 128
+        },
         "SourceS3Uri": {
           "pattern": "^(https|s3)://([^/]+)/?(.*)$",
           "description": "An Amazon S3 bucket path where your lifecycle scripts are stored.",
@@ -488,15 +646,11 @@
         "OnCreate": {
           "minLength": 1,
           "pattern": "^[\\S\\s]+$",
-          "description": "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation.",
+          "description": "The file name of the entrypoint script of lifecycle scripts under SourceS3Uri. This entrypoint script runs during cluster creation. Mutually exclusive with OnInitComplete.",
           "type": "string",
           "maxLength": 128
         }
-      },
-      "required": [
-        "OnCreate",
-        "SourceS3Uri"
-      ]
+      }
     },
     "OnStartDeepHealthChecks": {
       "description": "Nodes will undergo advanced stress test to detect and replace faulty instances, based on the type of deep health check(s) passed in.",
@@ -505,6 +659,30 @@
       "items": {
         "$ref": "#/definitions/DeepHealthCheckType"
       }
+    },
+    "ClusterFsxOpenZfsConfig": {
+      "description": "Configuration for mounting an Amazon FSx OpenZFS file system to the instances in the SageMaker HyperPod cluster instance group.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "MountPath": {
+          "minLength": 1,
+          "pattern": "",
+          "description": "The mount path for the FSx for OpenZFS file system.",
+          "type": "string",
+          "maxLength": 1024
+        },
+        "DnsName": {
+          "minLength": 16,
+          "pattern": "^((fs|fc)i?-[0-9a-f]{8,}\\..{4,253})$",
+          "description": "The DNS name of the FSx for OpenZFS file system.",
+          "type": "string",
+          "maxLength": 275
+        }
+      },
+      "required": [
+        "DnsName"
+      ]
     },
     "ClusterKubernetesTaints": {
       "maxItems": 50,
@@ -520,6 +698,9 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
+        "SlurmConfig": {
+          "$ref": "#/definitions/ClusterSlurmConfig"
+        },
         "CapacityRequirements": {
           "$ref": "#/definitions/ClusterCapacityRequirements"
         },
@@ -531,6 +712,9 @@
         },
         "KubernetesConfig": {
           "$ref": "#/definitions/ClusterKubernetesConfig"
+        },
+        "NetworkInterface": {
+          "$ref": "#/definitions/ClusterNetworkInterface"
         },
         "LifeCycleConfig": {
           "$ref": "#/definitions/ClusterLifeCycleConfig"
@@ -570,8 +754,14 @@
         "ScheduledUpdateConfig": {
           "$ref": "#/definitions/ScheduledUpdateConfig"
         },
+        "InstanceRequirements": {
+          "$ref": "#/definitions/InstanceRequirements"
+        },
         "InstanceType": {
           "$ref": "#/definitions/InstanceType"
+        },
+        "AutoPatchConfig": {
+          "$ref": "#/definitions/AutoPatchConfig"
         },
         "ExecutionRole": {
           "$ref": "#/definitions/ExecutionRole"
@@ -585,9 +775,7 @@
       "required": [
         "ExecutionRole",
         "InstanceCount",
-        "InstanceGroupName",
-        "InstanceType",
-        "LifeCycleConfig"
+        "InstanceGroupName"
       ]
     },
     "ClusterAutoScalingConfig": {
@@ -637,13 +825,33 @@
       ]
     },
     "ClusterInstanceStorageConfigs": {
-      "maxItems": 1,
+      "maxItems": 4,
       "description": "The instance storage configuration for the instance group.",
       "insertionOrder": false,
       "type": "array",
       "items": {
         "$ref": "#/definitions/ClusterInstanceStorageConfig"
       }
+    },
+    "InstanceRequirements": {
+      "description": "The instance requirements for the instance group. Specifies a list of instance types that can be used.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "InstanceTypes": {
+          "minItems": 1,
+          "maxItems": 20,
+          "description": "A list of instance types that can be used for this instance group.",
+          "insertionOrder": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/InstanceType"
+          }
+        }
+      },
+      "required": [
+        "InstanceTypes"
+      ]
     },
     "Tag": {
       "description": "A key-value pair to associate with a resource.",
@@ -735,7 +943,6 @@
       ]
     }
   },
-  "required": [],
   "properties": {
     "ClusterArn": {
       "pattern": "^arn:aws[a-z\\-]*:sagemaker:[a-z0-9\\-]*:[0-9]{12}:cluster/[a-z0-9]{12}$",
@@ -769,6 +976,9 @@
       "description": "The cluster role for the autoscaler to assume.",
       "type": "string",
       "maxLength": 2048
+    },
+    "RestrictedInstanceGroupsConfig": {
+      "$ref": "#/definitions/RestrictedInstanceGroupsConfig"
     },
     "NodeProvisioningMode": {
       "description": "Determines the scaling strategy for the SageMaker HyperPod cluster. When set to 'Continuous', enables continuous scaling which dynamically manages node provisioning. If the parameter is omitted, uses the standard scaling approach in previous release.",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #3019

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This change only updates the vendored CloudFormation resource schema and the code/docs generated from it. There are no changes to access controls, encryption, or logging.

## Description

The vendored `AWS::SageMaker::Cluster` schema was pinned to a pre-collision version, so `awscc_sagemaker_cluster` could not track newer schema releases. The blocker is a case-only property-name collision:

| CFN property | Location | Purpose | `$ref` |
|---|---|---|---|
| `FsxLustreConfig` (lowercase `s`) | `ClusterInstanceStorageConfig` | Mount an **existing** FSx for Lustre file system | `ClusterFsxLustreConfig` |
| `FSxLustreConfig` (capital `S`) | `EnvironmentConfig` / `SharedEnvironmentConfig` | Provision a **new** RIG FSx file system | `FSxLustreConfig` |

Both normalize to the Terraform attribute `fsx_lustre_config` (the `FSx` → `Fsx` rewrite in `internal/naming` erases the only difference), so generation fails with:

```
FSxLustreConfig overwrites FsxLustreConfig for Terraform attribute fsx_lustre_config
```

This PR unblocks the remaining schema updates without waiting on a naming-collision fix, by syncing the schema to the current `us-east-1` registry version **with the single instance-storage `FsxLustreConfig` property omitted** (its `ClusterInstanceStorageConfig.oneOf` branch and the now-unused `ClusterFsxLustreConfig` definition are removed). The RIG `FSxLustreConfig` → `fsx_lustre_config` mapping is unchanged, so existing state is unaffected.

The updated `AWS_SageMaker_Cluster.json` was fetched from the public CloudFormation registry in `us-east-1` (via `aws cloudformation describe-type --type RESOURCE --type-name AWS::SageMaker::Cluster --region us-east-1`) and sanitized the same way the provider's schema-generation step does, before removing the `FsxLustreConfig` branch.

New capabilities now generated for `awscc_sagemaker_cluster`:
* `network_interface` — EFA-only network interfaces (`interface_type` = `efa` | `efa-only`)
* `restricted_instance_groups_config` / `shared_environment_config`
* `auto_patch_config` (workload-aware AMI patching)
* `fsx_open_zfs_config` instance storage
* Slurm orchestrator config and `instance_requirements`

Notes for maintainers:
* This schema remains listed in `internal/update/suppressions_checkout.txt`; this PR updates the pinned copy rather than un-pinning it.
* Omitting the instance-storage `FsxLustreConfig` is intentional and temporary. The durable fix is proposed in #3284 (*feat: path-aware attribute name translation to resolve FSxLustreConfig collision*), which makes the attribute-name translator path-aware so both `FsxLustreConfig` and `FSxLustreConfig` can coexist under `fsx_lustre_config` (correct casing chosen per object path). This PR is the lighter-weight interim so the other new properties aren't blocked while #3284 is under review. The backend API is unaffected by the omission.

Generated files were produced by the standard generators (`make resources` / `make singular-data-sources` / `make docs`); only `awscc_sagemaker_cluster` is affected.