### PR TITLE
generic: preserve present-but-empty objects and maps in DesiredState

### DIFF
--- a/internal/generic/translate.go
+++ b/internal/generic/translate.go
@@ -167,9 +167,11 @@ func (t toCloudControl) rawFromValue(ctx context.Context, schema typeAtTerraform
 				vs[name] = v
 			}
 		}
-		if len(vs) == 0 {
-			return nil, nil
-		}
+		// A null value has already returned nil above, so an empty map here means
+		// the object is present-but-empty in configuration (e.g. `allow = {}`).
+		// Preserve it as {}: for properties like AWS::WAFv2::WebACL's
+		// DefaultAction.Allow the presence of the empty object is the setting,
+		// and dropping it removes a required key from DesiredState.
 		return vs, nil
 	}
 

--- a/internal/generic/translate_test.go
+++ b/internal/generic/translate_test.go
@@ -68,6 +68,31 @@ func TestTranslateToCloudControl(t *testing.T) {
 			},
 		},
 		{
+			TestName:      "complex Plan with empty objects",
+			Plan:          makeComplexTestPlanWithEmptyObjects(),
+			TfToCfNameMap: complexTfToCfNameMap,
+			ExpectedState: map[string]any{
+				"Name": "hello, world",
+				// Present-but-empty objects are preserved as {}: for properties like
+				// AWS::WAFv2::WebACL's DefaultAction.Allow the presence of the empty
+				// object is the setting.
+				"BootDisk":    map[string]any{},
+				"ScratchDisk": map[string]any{},
+				"Disks": []any{
+					map[string]any{},
+				},
+			},
+		},
+		{
+			TestName:      "maps Plan with empty map",
+			Plan:          makeMapsTestPlanWithEmptyMap(),
+			TfToCfNameMap: mapsTfToCfNameMap,
+			ExpectedState: map[string]any{
+				"Name":      "testing",
+				"SimpleMap": map[string]any{},
+			},
+		},
+		{
 			TestName:      "maps Plan",
 			Plan:          makeMapsTestPlan(),
 			TfToCfNameMap: mapsTfToCfNameMap,
@@ -1043,5 +1068,63 @@ func BenchmarkReorderKeyValueSlicesToMatchPrior(b *testing.B) {
 
 	for b.Loop() {
 		reorderKeyValueSlicesToMatchPrior(current, prior)
+	}
+}
+
+func makeComplexTestPlanWithEmptyObjects() tfsdk.Plan {
+	return tfsdk.Plan{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"name": tftypes.String,
+				"disks": tftypes.List{
+					ElementType: diskElementType,
+				},
+				"boot_disk": diskElementType,
+				"scratch_disk": tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"interface": tftypes.String,
+					},
+				},
+			},
+		}, map[string]tftypes.Value{
+			"name": tftypes.NewValue(tftypes.String, "hello, world"),
+			"disks": tftypes.NewValue(tftypes.List{
+				ElementType: diskElementType,
+			}, []tftypes.Value{
+				tftypes.NewValue(diskElementType, map[string]tftypes.Value{
+					"id":                   tftypes.NewValue(tftypes.String, nil),
+					"delete_with_instance": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+			}),
+			"boot_disk": tftypes.NewValue(diskElementType, map[string]tftypes.Value{
+				"id":                   tftypes.NewValue(tftypes.String, nil),
+				"delete_with_instance": tftypes.NewValue(tftypes.Bool, nil),
+			}),
+			"scratch_disk": tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"interface": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"interface": tftypes.NewValue(tftypes.String, nil),
+			}),
+		}),
+		Schema: testComplexSchema,
+	}
+}
+
+func makeMapsTestPlanWithEmptyMap() tfsdk.Plan {
+	return tfsdk.Plan{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"name":       tftypes.String,
+				"simple_map": tftypes.Map{ElementType: tftypes.String},
+			},
+		}, map[string]tftypes.Value{
+			"name": tftypes.NewValue(tftypes.String, "testing"),
+			"simple_map": tftypes.NewValue(tftypes.Map{
+				ElementType: tftypes.String,
+			}, map[string]tftypes.Value{}),
+		}),
+		Schema: testMapsSchema,
 	}
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2021, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

Closes #3288
Relates #397
Relates #768

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

## Description

`toCloudControl.rawFromValue` collapses empty objects/maps to `nil` when building `DesiredState`, so required properties whose valid value is an empty object are silently dropped from create/update payloads and Cloud Control rejects the request with a model-validation error naming the parent key as missing (`required key [Targets] not found`, `required key [DefaultAction] not found`, ...). Symptom reports: #3288, #397 (`awscc_fis_experiment_template` with valid empty `targets`), #768 (`awscc_ssmcontacts_contact`).

A null value never reaches the map/object translation (it returns `nil` earlier), so an empty translated map there means the value is **present-but-empty in configuration** (e.g. `allow = {}`, `targets = {}`). This change preserves it as `{}` instead of dropping it: for empty-able object properties the presence of the object is the setting, and the unset case is still represented by null. Empty **lists** still collapse — deliberately out of scope, see the discussion in #2997 and the update-side story in #3289.

Behavioral note for review: configurations that previously wrote `x = {}` and had it silently dropped (the create "worked" by ignoring what the user wrote) will now send `{}` and may receive a service validation error — failing loudly on what the configuration actually says.

## Testing

Unit: two new `TestTranslateToCloudControl` cases (empty nested objects, including as a list element, and an empty map); full `go test ./internal/generic/`, `gofmt`, `go vet` clean.

Live (us-east-1): reproduced #397's failure with `awscc_fis_experiment_template` and `targets = {}` on a provider built from `main`:

```
api error ValidationException: Model validation failed (#: required key [Targets] not found)
```

The identical configuration on a provider built from this branch: create succeeds, `aws cloudcontrol get-resource` shows `"Targets": {}` in the live model, a follow-up description-only update succeeds, `terraform plan` afterwards reports no changes, and `terraform destroy` deletes the template (deletion verified via the FIS API).
