### PR TITLE
generic: remove empty read artifacts from update patch documents

### DIFF
--- a/internal/generic/patch.go
+++ b/internal/generic/patch.go
@@ -6,6 +6,7 @@ package generic
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -68,14 +69,18 @@ func patchDocument(old, new string) (string, error) {
 // Terraform schema cannot represent) are returned by GetResource with values the
 // caller never set by definition, and must not be patched.
 func resolveEmptyReadArtifacts(patchDocument, oldState, newState, resourceModel string, isMutable func(tokens []string) bool) (string, error) {
-	var model, oldDoc, newDoc map[string]any
-	if err := json.Unmarshal([]byte(resourceModel), &model); err != nil {
+	// Unparseable input is not an error here: the caller has already validated the
+	// documents that produced patchDocument, so the patch is returned untouched.
+	model, ok := unmarshalObject(resourceModel)
+	if !ok {
 		return patchDocument, nil
 	}
-	if err := json.Unmarshal([]byte(oldState), &oldDoc); err != nil {
+	oldDoc, ok := unmarshalObject(oldState)
+	if !ok {
 		return patchDocument, nil
 	}
-	if err := json.Unmarshal([]byte(newState), &newDoc); err != nil {
+	newDoc, ok := unmarshalObject(newState)
+	if !ok {
 		return patchDocument, nil
 	}
 
@@ -90,8 +95,8 @@ func resolveEmptyReadArtifacts(patchDocument, oldState, newState, resourceModel 
 		case map[string]any:
 			for key, val := range v {
 				childPath := path + "/" + escapeJSONPointerToken(key)
-				// Full slice expression so sibling appends cannot share a backing array.
-				childTokens := append(tokens[:len(tokens):len(tokens)], key)
+				// Fresh slice so sibling children never share a backing array.
+				childTokens := slices.Concat(tokens, []string{key})
 				switch cv := val.(type) {
 				case string:
 					if cv == "" && isArtifact(childTokens) {
@@ -112,7 +117,7 @@ func resolveEmptyReadArtifacts(patchDocument, oldState, newState, resourceModel 
 		case []any:
 			for idx, val := range v {
 				token := strconv.Itoa(idx)
-				walk(val, path+"/"+token, append(tokens[:len(tokens):len(tokens)], token))
+				walk(val, path+"/"+token, slices.Concat(tokens, []string{token}))
 			}
 		}
 	}
@@ -342,4 +347,14 @@ func comparePathsNumerically(path1, path2 string) bool {
 		}
 	}
 	return len(parts1) > len(parts2)
+}
+
+// unmarshalObject decodes s as a JSON object, reporting false when s is not one.
+func unmarshalObject(s string) (map[string]any, bool) {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil, false
+	}
+
+	return m, true
 }

--- a/internal/generic/patch.go
+++ b/internal/generic/patch.go
@@ -47,6 +47,127 @@ func patchDocument(old, new string) (string, error) {
 	return result, nil
 }
 
+// resolveEmptyReadArtifacts appends remove operations to the patch document for
+// properties that are empty in the current resource model but absent from both the
+// prior and the planned desired state. Cloud Control's GetResource can inject such
+// values into the resource model for properties the caller never set: AWS::WAFv2::WebACL
+// returns a CustomResponse created without ResponseHeaders with "ResponseHeaders": []
+// (whose schema requires minItems: 1) and a web ACL created without a description with
+// "Description": "" (whose schema pattern forbids the empty string). UpdateResource
+// validates the patched model as a whole, so the untouched artifacts fail every
+// subsequent update of the resource. A property that is empty in the model but null in
+// both prior state and configuration is a read artifact, not user intent, and is
+// removed explicitly.
+//
+// Only empty arrays and empty strings that are object property values are removed:
+// array elements are never removed (that would shift sibling indices), and empty
+// objects are left alone — an empty object's presence is often the setting itself
+// (e.g. DefaultAction.Allow). Removals are additionally gated on isMutable, which
+// receives the property path as unescaped JSON Pointer reference tokens and reports
+// whether the property is user-settable: read-only properties (and properties the
+// Terraform schema cannot represent) are returned by GetResource with values the
+// caller never set by definition, and must not be patched.
+func resolveEmptyReadArtifacts(patchDocument, oldState, newState, resourceModel string, isMutable func(tokens []string) bool) (string, error) {
+	var model, oldDoc, newDoc map[string]any
+	if err := json.Unmarshal([]byte(resourceModel), &model); err != nil {
+		return patchDocument, nil
+	}
+	if err := json.Unmarshal([]byte(oldState), &oldDoc); err != nil {
+		return patchDocument, nil
+	}
+	if err := json.Unmarshal([]byte(newState), &newDoc); err != nil {
+		return patchDocument, nil
+	}
+
+	isArtifact := func(tokens []string) bool {
+		return getValueAtTokens(oldDoc, tokens) == nil && getValueAtTokens(newDoc, tokens) == nil && isMutable(tokens)
+	}
+
+	var removals []jsonpatch.JsonPatchOperation
+	var walk func(node any, path string, tokens []string)
+	walk = func(node any, path string, tokens []string) {
+		switch v := node.(type) {
+		case map[string]any:
+			for key, val := range v {
+				childPath := path + "/" + escapeJSONPointerToken(key)
+				// Full slice expression so sibling appends cannot share a backing array.
+				childTokens := append(tokens[:len(tokens):len(tokens)], key)
+				switch cv := val.(type) {
+				case string:
+					if cv == "" && isArtifact(childTokens) {
+						removals = append(removals, jsonpatch.NewPatch("remove", childPath, nil))
+					}
+				case []any:
+					if len(cv) == 0 {
+						if isArtifact(childTokens) {
+							removals = append(removals, jsonpatch.NewPatch("remove", childPath, nil))
+						}
+						continue
+					}
+					walk(cv, childPath, childTokens)
+				case map[string]any:
+					walk(cv, childPath, childTokens)
+				}
+			}
+		case []any:
+			for idx, val := range v {
+				token := strconv.Itoa(idx)
+				walk(val, path+"/"+token, append(tokens[:len(tokens):len(tokens)], token))
+			}
+		}
+	}
+	walk(model, "", nil)
+
+	if len(removals) == 0 {
+		return patchDocument, nil
+	}
+
+	var patch []jsonpatch.JsonPatchOperation
+	if err := json.Unmarshal([]byte(patchDocument), &patch); err != nil {
+		return "", err
+	}
+	patch = append(patch, removals...)
+
+	// Re-sort so remove operations are still applied first, in reverse path order.
+	b, err := json.Marshal(sortPatchOperations(patch))
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+// escapeJSONPointerToken escapes a single JSON Pointer reference token (RFC 6901).
+func escapeJSONPointerToken(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	return strings.ReplaceAll(s, "/", "~1")
+}
+
+// getValueAtTokens retrieves the value at the path given as unescaped JSON Pointer
+// reference tokens. Unlike getValueAtPath it is safe for keys containing '/' or '~'.
+func getValueAtTokens(doc map[string]any, tokens []string) any {
+	var current any = doc
+	for _, token := range tokens {
+		switch v := current.(type) {
+		case map[string]any:
+			var ok bool
+			current, ok = v[token]
+			if !ok {
+				return nil
+			}
+		case []any:
+			idx, err := strconv.Atoi(token)
+			if err != nil || idx < 0 || idx >= len(v) {
+				return nil
+			}
+			current = v[idx]
+		default:
+			return nil
+		}
+	}
+	return current
+}
+
 // replaceKeyValueArrayPatchesWithFullReplace replaces index-based patch operations targeting
 // key-value arrays with full array replacements. CloudFormation does not preserve array ordering
 // for key-value structures (objects with "Key"/"key" field), so positional patches target wrong elements.

--- a/internal/generic/patch_test.go
+++ b/internal/generic/patch_test.go
@@ -4,6 +4,8 @@
 package generic
 
 import (
+	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -222,6 +224,290 @@ func Test_replaceKeyValueArrayPatchesWithFullReplace(t *testing.T) {
 			got := replaceKeyValueArrayPatchesWithFullReplace(tt.patch, tt.newState)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("replaceKeyValueArrayPatchesWithFullReplace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resolveEmptyReadArtifacts(t *testing.T) {
+	resourceModel := `{
+		"Description": "d",
+		"Rules": [
+			{
+				"Name": "r1",
+				"Action": {
+					"Block": {
+						"CustomResponse": {
+							"ResponseCode": 403,
+							"ResponseHeaders": []
+						}
+					}
+				}
+			}
+		]
+	}`
+	oldState := `{
+		"Description": "d",
+		"Rules": [
+			{
+				"Name": "r1",
+				"Action": {
+					"Block": {
+						"CustomResponse": {
+							"ResponseCode": 403
+						}
+					}
+				}
+			}
+		]
+	}`
+	newState := `{
+		"Description": "d",
+		"Rules": [
+			{
+				"Name": "r1",
+				"Action": {
+					"Block": {
+						"CustomResponse": {
+							"ResponseCode": 404
+						}
+					}
+				}
+			}
+		]
+	}`
+
+	tests := []struct {
+		name          string
+		patchDocument string
+		oldState      string
+		newState      string
+		resourceModel string
+		isMutable     func(tokens []string) bool
+		want          []jsonpatch.JsonPatchOperation
+	}{
+		{
+			name:          "read artifact is removed",
+			patchDocument: `[{"op":"replace","path":"/Rules/0/Action/Block/CustomResponse/ResponseCode","value":404}]`,
+			oldState:      oldState,
+			newState:      newState,
+			resourceModel: resourceModel,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "remove", Path: "/Rules/0/Action/Block/CustomResponse/ResponseHeaders"},
+				{Operation: "replace", Path: "/Rules/0/Action/Block/CustomResponse/ResponseCode", Value: float64(404)},
+			},
+		},
+		{
+			name:          "empty array present in prior state is kept",
+			patchDocument: `[{"op":"replace","path":"/Description","value":"e"}]`,
+			oldState:      `{"Description":"d","Rules":[{"Name":"r1","Action":{"Block":{"CustomResponse":{"ResponseCode":403,"ResponseHeaders":[]}}}}]}`,
+			newState:      newState,
+			resourceModel: resourceModel,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "e"},
+			},
+		},
+		{
+			name:          "empty array present in planned state is kept",
+			patchDocument: `[{"op":"replace","path":"/Description","value":"e"}]`,
+			oldState:      oldState,
+			newState:      `{"Description":"e","Rules":[{"Name":"r1","Action":{"Block":{"CustomResponse":{"ResponseCode":403,"ResponseHeaders":[]}}}}]}`,
+			resourceModel: resourceModel,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "e"},
+			},
+		},
+		{
+			name:          "model without empty arrays leaves patch unchanged",
+			patchDocument: `[{"op":"replace","path":"/Description","value":"e"}]`,
+			oldState:      oldState,
+			newState:      newState,
+			resourceModel: `{"Description":"d","Rules":[{"Name":"r1","Action":{"Block":{"CustomResponse":{"ResponseCode":403,"ResponseHeaders":[{"Name":"n","Value":"v"}]}}}}]}`,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "e"},
+			},
+		},
+		{
+			name:          "multiple artifacts are removed in reverse path order",
+			patchDocument: `[{"op":"replace","path":"/Description","value":"e"}]`,
+			oldState:      `{"Description":"d"}`,
+			newState:      `{"Description":"e"}`,
+			resourceModel: `{"Description":"d","A":[],"B":{"C":[]}}`,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "remove", Path: "/B/C"},
+				{Operation: "remove", Path: "/A"},
+				{Operation: "replace", Path: "/Description", Value: "e"},
+			},
+		},
+		{
+			name:          "string and array artifacts as returned by a live WAF web ACL",
+			patchDocument: `[{"op":"replace","path":"/Rules/0/Action/Block/CustomResponse/ResponseCode","value":404}]`,
+			oldState:      `{"Rules":[{"Name":"r1","Action":{"Block":{"CustomResponse":{"ResponseCode":403}}}}]}`,
+			newState:      `{"Rules":[{"Name":"r1","Action":{"Block":{"CustomResponse":{"ResponseCode":404}}}}]}`,
+			resourceModel: `{"Description":"","Rules":[{"Name":"r1","RuleLabels":[],"Action":{"Block":{"CustomResponse":{"ResponseCode":403,"ResponseHeaders":[]}}}}]}`,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "remove", Path: "/Rules/0/RuleLabels"},
+				{Operation: "remove", Path: "/Rules/0/Action/Block/CustomResponse/ResponseHeaders"},
+				{Operation: "remove", Path: "/Description"},
+				{Operation: "replace", Path: "/Rules/0/Action/Block/CustomResponse/ResponseCode", Value: float64(404)},
+			},
+		},
+		{
+			name:          "empty string present in planned state is kept",
+			patchDocument: `[{"op":"add","path":"/Description","value":""}]`,
+			oldState:      `{"Rules":[]}`,
+			newState:      `{"Description":"","Rules":[]}`,
+			resourceModel: `{"Description":"","Rules":[]}`,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "add", Path: "/Description", Value: ""},
+			},
+		},
+		{
+			name:          "empty string array elements are never removed",
+			patchDocument: `[{"op":"replace","path":"/Name","value":"n"}]`,
+			oldState:      `{"Name":"m"}`,
+			newState:      `{"Name":"n"}`,
+			resourceModel: `{"Name":"m","A":["","x"]}`,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Name", Value: "n"},
+			},
+		},
+		{
+			name:          "immutable properties are never removed",
+			patchDocument: `[{"op":"replace","path":"/Name","value":"n"}]`,
+			oldState:      `{"Name":"m"}`,
+			newState:      `{"Name":"n"}`,
+			resourceModel: `{"Name":"m","FailureReasons":[],"Detail":""}`,
+			isMutable:     func([]string) bool { return false },
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Name", Value: "n"},
+			},
+		},
+		{
+			name:          "keys containing JSON Pointer special characters are looked up correctly",
+			patchDocument: `[{"op":"replace","path":"/Name","value":"n"}]`,
+			oldState:      `{"Name":"m","Attributes":{"a/b":""}}`,
+			newState:      `{"Name":"n","Attributes":{"a/b":""}}`,
+			resourceModel: `{"Name":"m","Attributes":{"a/b":""}}`,
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Name", Value: "n"},
+			},
+		},
+		{
+			name:          "real schema predicate: mutable empty array removed, read-only empty string kept",
+			patchDocument: `[{"op":"replace","path":"/Name","value":"n"}]`,
+			oldState:      `{"Name":"m"}`,
+			newState:      `{"Name":"n"}`,
+			resourceModel: `{"Name":"m","Ports":[],"Arn":""}`,
+			isMutable: func(tokens []string) bool {
+				r := &genericResource{tfSchema: testSimpleSchemaWithList, cfToTfNameMap: simpleCfToTfNameMap}
+				return r.isMutablePropertyPath(context.TODO(), tokens)
+			},
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "remove", Path: "/Ports"},
+				{Operation: "replace", Path: "/Name", Value: "n"},
+			},
+		},
+		{
+			name:          "invalid resource model is a no-op",
+			patchDocument: `[{"op":"replace","path":"/Description","value":"e"}]`,
+			oldState:      oldState,
+			newState:      newState,
+			resourceModel: "not json",
+			want: []jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Description", Value: "e"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isMutable := tt.isMutable
+			if isMutable == nil {
+				isMutable = func([]string) bool { return true }
+			}
+			got, err := resolveEmptyReadArtifacts(tt.patchDocument, tt.oldState, tt.newState, tt.resourceModel, isMutable)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			var gotOps []jsonpatch.JsonPatchOperation
+			if err := json.Unmarshal([]byte(got), &gotOps); err != nil {
+				t.Fatalf("unmarshaling result %q: %s", got, err)
+			}
+			if !reflect.DeepEqual(gotOps, tt.want) {
+				t.Errorf("resolveEmptyReadArtifacts() = %v, want %v", gotOps, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isMutablePropertyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource *genericResource
+		tokens   []string
+		want     bool
+	}{
+		{
+			name:     "required attribute",
+			resource: &genericResource{tfSchema: testSimpleSchema, cfToTfNameMap: simpleCfToTfNameMap},
+			tokens:   []string{"Name"},
+			want:     true,
+		},
+		{
+			name:     "optional attribute",
+			resource: &genericResource{tfSchema: testSimpleSchema, cfToTfNameMap: simpleCfToTfNameMap},
+			tokens:   []string{"Number"},
+			want:     true,
+		},
+		{
+			name:     "read-only (Computed-only) attribute",
+			resource: &genericResource{tfSchema: testSimpleSchema, cfToTfNameMap: simpleCfToTfNameMap},
+			tokens:   []string{"Arn"},
+			want:     false,
+		},
+		{
+			name:     "unknown property",
+			resource: &genericResource{tfSchema: testSimpleSchema, cfToTfNameMap: simpleCfToTfNameMap},
+			tokens:   []string{"Bogus"},
+			want:     false,
+		},
+		{
+			name:     "nested attribute in a list element",
+			resource: &genericResource{tfSchema: testComplexSchema, cfToTfNameMap: complexCfToTfNameMap},
+			tokens:   []string{"Disks", "0", "DeleteWithInstance"},
+			want:     true,
+		},
+		{
+			name:     "nested attribute in a single-nested attribute",
+			resource: &genericResource{tfSchema: testComplexSchema, cfToTfNameMap: complexCfToTfNameMap},
+			tokens:   []string{"BootDisk", "Id"},
+			want:     true,
+		},
+		{
+			name:     "non-numeric index into a list",
+			resource: &genericResource{tfSchema: testComplexSchema, cfToTfNameMap: complexCfToTfNameMap},
+			tokens:   []string{"Disks", "x", "Id"},
+			want:     false,
+		},
+		{
+			name:     "attribute in a map-nested attribute",
+			resource: &genericResource{tfSchema: testMapsSchema, cfToTfNameMap: mapsCfToTfNameMap},
+			tokens:   []string{"ComplexMap", "x", "Flags"},
+			want:     true,
+		},
+		{
+			name:     "structure inside a JSON-string-typed attribute",
+			resource: &genericResource{tfSchema: testMapsSchema, cfToTfNameMap: mapsCfToTfNameMap},
+			tokens:   []string{"JsonString", "Inner"},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.resource.isMutablePropertyPath(context.TODO(), tt.tokens); got != tt.want {
+				t.Errorf("isMutablePropertyPath(%v) = %v, want %v", tt.tokens, got, tt.want)
 			}
 		})
 	}

--- a/internal/generic/resource.go
+++ b/internal/generic/resource.go
@@ -6,6 +6,7 @@ package generic
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -676,6 +677,35 @@ func (r *genericResource) Update(ctx context.Context, request resource.UpdateReq
 		"value": patchDocument,
 	})
 
+	// Cloud Control's GetResource can inject properties the caller never set into the
+	// resource model (e.g. AWS::WAFv2::WebACL's "ResponseHeaders": [] and
+	// "Description": ""). UpdateResource validates the patched model as a
+	// whole, so an artifact that violates the resource type schema fails every update,
+	// even one that doesn't touch it. Resolve such artifacts against the current model.
+	// Best-effort: a failed read leaves the patch document unchanged.
+	if description, err := r.describe(ctx, conn, id); err != nil {
+		tflog.Debug(ctx, "skipping read artifact resolution", map[string]any{
+			"error": err.Error(),
+		})
+	} else if description != nil && description.Properties != nil {
+		patchDocument, err = resolveEmptyReadArtifacts(patchDocument, currentDesiredState, plannedDesiredState, aws.ToString(description.Properties), func(tokens []string) bool {
+			return r.isMutablePropertyPath(ctx, tokens)
+		})
+
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Creation Of JSON Patch Unsuccessful",
+				fmt.Sprintf("Unable to create a JSON Patch for resource update. This is typically an error with the Terraform provider implementation. Original Error: %s", err.Error()),
+			)
+
+			return
+		}
+
+		tflog.Debug(ctx, "Cloud Control API PatchDocument after read artifact resolution", map[string]any{
+			"value": patchDocument,
+		})
+	}
+
 	input := &cloudcontrol.UpdateResourceInput{
 		ClientToken:   aws.String(tfresource.UniqueId()),
 		Identifier:    aws.String(id),
@@ -856,6 +886,55 @@ func (r *genericResource) ConfigValidators(context.Context) []resource.ConfigVal
 // describe returns the live state of the specified resource.
 func (r *genericResource) describe(ctx context.Context, conn *cloudcontrol.Client, id string) (*cctypes.ResourceDescription, error) {
 	return tfcloudcontrol.FindResourceByTypeNameAndID(ctx, conn, r.provider.RoleARN(ctx), r.cfTypeName, id)
+}
+
+// isMutablePropertyPath reports whether the Cloud Control property path, given as
+// unescaped JSON Pointer reference tokens, resolves to a user-settable attribute in
+// the Terraform schema. Read-only attributes are generated as Computed-only, so an
+// attribute that is neither Optional nor Required cannot carry user intent. Paths
+// that do not resolve (unknown property names, content beyond what the schema
+// represents, structure inside JSON-string-typed attributes) return false.
+func (r *genericResource) isMutablePropertyPath(ctx context.Context, tokens []string) bool {
+	tfPath := tftypes.NewAttributePath()
+	for _, token := range tokens {
+		attrType, err := r.tfSchema.TypeAtTerraformPath(ctx, tfPath)
+		if err != nil {
+			return false
+		}
+		switch typ := attrType.TerraformType(ctx); {
+		case typ.Is(tftypes.Object{}):
+			name, ok := r.cfToTfNameMap[token]
+			if !ok {
+				return false
+			}
+			tfPath = tfPath.WithAttributeName(name)
+		case typ.Is(tftypes.Map{}):
+			tfPath = tfPath.WithElementKeyString(token)
+		case typ.Is(tftypes.Set{}):
+			// No need to worry about a specific value here.
+			tfPath = tfPath.WithElementKeyValue(tftypes.NewValue(typ.(tftypes.Set).ElementType, nil))
+		case typ.Is(tftypes.List{}), typ.Is(tftypes.Tuple{}):
+			idx, err := strconv.Atoi(token)
+			if err != nil {
+				return false
+			}
+			tfPath = tfPath.WithElementKeyInt(idx)
+		default:
+			return false
+		}
+	}
+
+	fwPath, diags := attributePath(ctx, tfPath, r.tfSchema)
+	if diags.HasError() {
+		return false
+	}
+
+	attribute, diags := r.tfSchema.AttributeAtPath(ctx, fwPath)
+	if diags.HasError() {
+		return false
+	}
+
+	return attribute.IsOptional() || attribute.IsRequired()
 }
 
 // getId returns the resource's primary identifier value from State.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2021, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

Closes #3289
Relates #3243

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

## Description

Cloud Control's `GetResource` can inject properties the caller never set into the resource model, and `UpdateResource` validates the **patched model as a whole** — so an injected artifact that violates the resource type schema fails every subsequent update, even one that doesn't touch it, and the configuration becomes create-once. Observed live on `AWS::WAFv2::WebACL`: a `CustomResponse` created without `ResponseHeaders` is returned with `"ResponseHeaders": []` (schema requires `minItems: 1`), and a web ACL created without a description is returned with `"Description": ""` (schema `pattern` forbids the empty string). `AWS::Logs::LogGroup` similarly injects `"FieldIndexPolicies": []`.

Prior Terraform state cannot see these artifacts (reads translate them away), so the state-based patch generation in `patchDocument` produces no operation for them, and no state-side fix can: the service validates the resulting *live* model, and a JSON Patch `remove` on a path that may not exist would fail the whole update. `Update` therefore fetches the current resource model (the same `GetResource` call `Read` issues, one additional read per update) and appends an explicit `remove` for every **array or string property that is empty in the model but null in both prior state and plan** — neither the user nor prior state expresses the property, so the empty value is a read artifact, not intent.

Removals are additionally **gated on the Terraform schema**: a property is only removed if it resolves to a user-settable attribute (`Optional` or `Required`) at its path. This matters because prior state cannot distinguish an artifact from a legitimately-empty value it never carries: read-only properties are generated `Computed`-only and must never be patched, and content the schema cannot represent — properties the bundled CloudFormation schema doesn't know yet (schema lag), structure inside JSON-string-typed attributes, or subtrees beyond a depth-limited schema — is conservatively kept.

Deliberate limits:
* Array **elements** are never removed (that would shift sibling indices).
* Empty **objects** are left alone — an empty object's presence is often the setting itself (e.g. `DefaultAction.Allow`, see #3288).
* Create-only properties are generated `Optional + Computed` with a `RequiresReplace` plan modifier, which is not visible through `fwschema.Attribute` — so an empty create-only property injected by the read model passes the writability gate. If that matters in practice, the complete fix is for the generator to emit read-only/create-only property paths the way it already emits `WithWriteOnlyPropertyPaths`; happy to do that as a follow-up if preferred.
* The model read is best-effort: a failed read logs and leaves the patch document unchanged (today's behavior).

## Testing

Unit: `Test_resolveEmptyReadArtifacts` (11 cases: removal of array/string artifacts including the live WAF model shape, values present in prior state or plan are kept, immutable properties never removed — including a case composed with the real schema-backed predicate showing a mutable empty array removed while a read-only empty string is kept — array elements never removed, JSON-Pointer-special map keys, deterministic remove ordering, malformed-input no-ops) and `Test_isMutablePropertyPath` (9 cases over required/optional/computed-only/unknown attributes, nested list/single/map-nested paths, non-numeric list indices, and JSON-string-typed attribute internals); full `go test ./internal/generic/`, `gofmt`, `go vet` clean.

Live (us-east-1):

* Created the web ACL from #3289 (rule with `Block` → `CustomResponse`, no `ResponseHeaders`). `GetResource` returns `"ResponseHeaders": []`, `"RuleLabels": []`, and `"Description": ""`.
* The patch today's provider generates (`replace` of `ResponseCode` only) fails: `Model validation failed (#/Description: failed validation constraint for keyword [pattern] #/Rules/0/Action/Block/CustomResponse/ResponseHeaders: expected minimum item count: 1, found: 0)`. Removing only the array still fails on `#/Description` — which is why the fix covers empty strings too.
* The patch this change generates (removes for the three artifacts + the `replace`) succeeds; the live rule shows `ResponseCode: 404` with no headers.
* Regression: `awscc_logs_log_group` create → retention update → destroy on a provider built from this branch; `GetResource` injects `"FieldIndexPolicies": []`, a property the bundled LogGroup schema doesn't know yet — the writability gate conservatively kept it (debug log shows the patch unchanged), and the update succeeded and `terraform plan` reported no drift. An earlier build of this branch without the gate removed it and the update also succeeded, so both paths are exercised live.

All test resources were deleted and deletion verified.
