### PR TITLE
restore cloudcontrol client behavior for throttling exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.100.0 (Unreleased)
 
+NOTES:
+
+* provider: The client level handing for `ThrottlingException` has been reverted while keeping the retry for the `cloudcontrol` waiter. This is being tracked in an [upstream Go SDK issue](https://github.com/aws/aws-sdk-go-v2/issues/3248). Once this addressed upstream, the provider retry handling will be reverted ([#3298](https://github.com/hashicorp/terraform-provider-awscc/pull/3298))
+
 ## 1.99.0 (August 28, 2026)
 
 NOTES:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,15 +5,11 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
-	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	basediag "github.com/hashicorp/aws-sdk-go-base/v2/diag"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
@@ -611,10 +607,6 @@ func newProviderData(ctx context.Context, c *configModel) (*providerData, diag.D
 		if c.Endpoints != nil {
 			o.BaseEndpoint = flex.StringFromFramework(ctx, c.Endpoints.CloudControlAPI)
 		}
-		// Add custom retry for CloudControl throttling
-		o.Retryer = retry.NewStandard(func(so *retry.StandardOptions) {
-			so.Retryables = append(so.Retryables, retry.IsErrorRetryableFunc(ThrottlingErrRetryableFunc))
-		})
 	})
 
 	accountID, partitionID, awsDiags := awsbase.GetAwsAccountIDAndPartition(ctx, cfg, &awsbaseConfig)
@@ -637,17 +629,4 @@ func newProviderData(ctx context.Context, c *configModel) (*providerData, diag.D
 	}
 
 	return providerData, diags
-}
-
-// ThrottlingErrRetryableFunc retries CloudControl throttline exceptions
-//
-// This is a temporary workaround for missing AWS service SDK retry behavior.
-// https://github.com/hashicorp/terraform-provider-awscc/issues/2939
-// https://github.com/aws/aws-sdk-go-v2/issues/3248
-func ThrottlingErrRetryableFunc(err error) aws.Ternary {
-	var throttlingErr *cctypes.ThrottlingException
-	if errors.As(err, &throttlingErr) {
-		return aws.TrueTernary
-	}
-	return aws.UnknownTernary
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -4,44 +4,7 @@
 package provider
 
 import (
-	"errors"
 	"testing"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 )
 
 func TestProvider(t *testing.T) {}
-
-func TestThrottlingErrRetryableFunc(t *testing.T) {
-	tests := []struct {
-		name        string
-		err         error
-		expectRetry aws.Ternary
-	}{
-		{
-			name:        "ThrottlingException should retry",
-			err:         &cctypes.ThrottlingException{Message: aws.String("Rate exceeded")},
-			expectRetry: aws.TrueTernary,
-		},
-		{
-			name:        "Non-throttling error should not retry",
-			err:         &cctypes.InvalidRequestException{Message: aws.String("Invalid request")},
-			expectRetry: aws.UnknownTernary,
-		},
-		{
-			name:        "Generic error should not retry",
-			err:         errors.New("some other error"),
-			expectRetry: aws.UnknownTernary,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ThrottlingErrRetryableFunc(tt.err)
-			if result != tt.expectRetry {
-				t.Errorf("Expected retry=%v, got %v", tt.expectRetry, result)
-			}
-		})
-	}
-}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2021, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2940
Closes #3295

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

Restore original retry behavior on cloudcontrol client. Retry behavior for client event wait will remain to handle retries on Throttling progress events.

```console
make smoke
make: Running smoke tests...
make: NOTE: All tests should pass. Error output for sdk.proto, "Response contains error diagnostic" can be ignored.
TF_ACC=1 go test ./internal/aws/logs -v -count 1 -parallel 3 -run=TestAccAWSLogsLogGroup_\|TestAccAWSLogsLogGroupDataSource_ -timeout 180m
=== RUN   TestAccAWSLogsLogGroup_basic
=== PAUSE TestAccAWSLogsLogGroup_basic
=== RUN   TestAccAWSLogsLogGroup_disappears
=== PAUSE TestAccAWSLogsLogGroup_disappears
=== RUN   TestAccAWSLogsLogGroup_update
=== PAUSE TestAccAWSLogsLogGroup_update
=== RUN   TestAccAWSLogsLogGroup_providerMeta
=== PAUSE TestAccAWSLogsLogGroup_providerMeta
=== RUN   TestAccAWSLogsLogGroup_providerMetaWithModule
    log_group_resource_test.go:90: The ConfigDirectory field does not currently support copying modules to the working directory
--- SKIP: TestAccAWSLogsLogGroup_providerMetaWithModule (0.00s)
=== RUN   TestAccAWSLogsLogGroupDataSource_basic
=== PAUSE TestAccAWSLogsLogGroupDataSource_basic
=== RUN   TestAccAWSLogsLogGroupDataSource_NonExistent
=== PAUSE TestAccAWSLogsLogGroupDataSource_NonExistent
=== CONT  TestAccAWSLogsLogGroup_basic
=== CONT  TestAccAWSLogsLogGroup_providerMeta
=== CONT  TestAccAWSLogsLogGroupDataSource_NonExistent
--- PASS: TestAccAWSLogsLogGroupDataSource_NonExistent (2.40s)
=== CONT  TestAccAWSLogsLogGroupDataSource_basic
--- PASS: TestAccAWSLogsLogGroup_providerMeta (29.58s)
=== CONT  TestAccAWSLogsLogGroup_update
--- PASS: TestAccAWSLogsLogGroupDataSource_basic (29.11s)
=== CONT  TestAccAWSLogsLogGroup_disappears
--- PASS: TestAccAWSLogsLogGroup_basic (31.87s)
--- PASS: TestAccAWSLogsLogGroup_disappears (33.10s)
--- PASS: TestAccAWSLogsLogGroup_update (42.83s)
PASS
ok      github.com/hashicorp/terraform-provider-awscc/internal/aws/logs 73.527s
```