### PR TITLE
generic: use the path-aware translator when filling unknowns and listing resources

### DIFF
--- a/internal/generic/list_resource.go
+++ b/internal/generic/list_resource.go
@@ -78,7 +78,7 @@ func (r *genericResource) List(ctx context.Context, request list.ListRequest, st
 				return
 			}
 
-			translator := toTerraform{cfToTfNameMap: r.cfToTfNameMap}
+			translator := r.toTerraformTranslator()
 			schema := request.ResourceSchema
 			val, err := translator.FromString(ctx, schema, aws.ToString(description.Properties), nil)
 			if err != nil {

--- a/internal/generic/resource.go
+++ b/internal/generic/resource.go
@@ -97,11 +97,10 @@ func resourceWithPathAwareAttributeNameMap(v map[string]string) ResourceOptionsF
 		}
 		o.pathCfToTfNameMap = reverse
 
-		// Populate the flat maps for SetUnknownValuesFromResourceModel, which fills in
-		// computed attributes (like cluster_arn, creation_time) after Create/Update.
-		// That function uses the old flat map interface shared by all resources.
-		// The flat map is lossy for colliding properties (FSxLustreConfig vs FsxLustreConfig)
-		// but those are user-provided, never computed unknowns, so this path never resolves them.
+		// Populate the flat maps for the callers that still key by bare property name
+		// (unorderedArrayPaths, propertyPathToAttributePath). The flat map is lossy for
+		// colliding properties, so it must not be used for value translation: the
+		// toTerraform / toCloudControl translators always receive the path-aware maps.
 		flatTfToCf := make(map[string]string)
 		flatCfToTf := make(map[string]string)
 		for tfPathKey, cfName := range v {
@@ -615,7 +614,7 @@ func (r *genericResource) Read(ctx context.Context, request resource.ReadRequest
 		return
 	}
 
-	translator := toTerraform{cfToTfNameMap: r.cfToTfNameMap, pathAwareNames: r.pathAwareNames, pathCfToTfNameMap: r.pathCfToTfNameMap}
+	translator := r.toTerraformTranslator()
 	schema := currentState.Schema
 	// Reorder key-value lists (Tags, LoadBalancerAttributes, etc.) to match prior state
 	// so plan shows no diff regardless of user config order.
@@ -1001,7 +1000,7 @@ func (r *genericResource) populateUnknownValues(ctx context.Context, id string, 
 		return diags
 	}
 
-	err = SetUnknownValuesFromResourceModel(ctx, state, unknowns, aws.ToString(description.Properties), r.cfToTfNameMap)
+	err = SetUnknownValuesFromResourceModel(ctx, state, unknowns, aws.ToString(description.Properties), r.toTerraformTranslator())
 
 	if err != nil {
 		diags.AddError(
@@ -1016,6 +1015,12 @@ func (r *genericResource) populateUnknownValues(ctx context.Context, id string, 
 }
 
 // bootstrapContext injects the CloudFormation type name into logger contexts
+// toTerraformTranslator returns the Cloud Control -> Terraform translator for the resource,
+// carrying the path-aware attribute name map when the resource uses one.
+func (r *genericResource) toTerraformTranslator() toTerraform {
+	return toTerraform{cfToTfNameMap: r.cfToTfNameMap, pathAwareNames: r.pathAwareNames, pathCfToTfNameMap: r.pathCfToTfNameMap}
+}
+
 func (r *genericResource) bootstrapContext(ctx context.Context) context.Context {
 	ctx = tflog.SetField(ctx, LoggingKeyCFNType, r.cfTypeName)
 	return r.provider.RegisterLogger(ctx)

--- a/internal/generic/unknown.go
+++ b/internal/generic/unknown.go
@@ -61,9 +61,11 @@ func UnknownValuePaths(_ context.Context, val tftypes.Value) ([]*tftypes.Attribu
 // The unknown value paths are obtained from the State via a previous call to UnknownValuePaths.
 // Functionality is split between these 2 functions, rather than calling UnknownValuePaths from within this function,
 // so as to avoid unnecessary Cloud Control API calls to obtain the current ResourceModel.
-func SetUnknownValuesFromResourceModel(ctx context.Context, state *tfsdk.State, unknowns []*tftypes.AttributePath, resourceModel string, cfToTfNameMap map[string]string) error {
+// The translator must be the resource's own toTerraform translator so that path-aware
+// attribute name maps are honoured: a flat name map cannot distinguish a colliding
+// property (e.g. a top-level computed "Id" and a nested "Id") and would fill the wrong one.
+func SetUnknownValuesFromResourceModel(ctx context.Context, state *tfsdk.State, unknowns []*tftypes.AttributePath, resourceModel string, translator toTerraform) error {
 	// Get the Terraform Value of the ResourceModel.
-	translator := toTerraform{cfToTfNameMap: cfToTfNameMap}
 	schema := state.Schema
 	val, err := translator.FromString(ctx, schema, resourceModel, nil)
 

--- a/internal/generic/unknown_test.go
+++ b/internal/generic/unknown_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -74,13 +75,42 @@ func TestUnknowns(t *testing.T) {
 
 func TestUnknownsSetValue(t *testing.T) {
 	testCases := []struct {
-		TestName      string
-		State         tfsdk.State
-		ResourceModel string
-		CfToTfNameMap map[string]string
-		ExpectedError bool
-		ExpectedState tfsdk.State
+		TestName          string
+		State             tfsdk.State
+		ResourceModel     string
+		CfToTfNameMap     map[string]string
+		PathCfToTfNameMap map[string]string
+		ExpectedError     bool
+		ExpectedState     tfsdk.State
 	}{
+		{
+			// A computed top-level "Id" (renamed to thing_id) colliding with a nested "Id":
+			// only the path-aware map can fill the top-level unknown correctly.
+			TestName: "path-aware State with colliding computed Id",
+			State: tfsdk.State{
+				Raw:    makePathAwareValueWithUnknowns(),
+				Schema: testPathAwareSchema,
+			},
+			ResourceModel: `{"Id": "E123", "Origins": [{"Id": "origin-a"}]}`,
+			CfToTfNameMap: map[string]string{"Id": "id", "Origins": "origins"},
+			PathCfToTfNameMap: map[string]string{
+				"Id":         "thing_id",
+				"Origins":    "origins",
+				"Origins/Id": "id",
+			},
+			ExpectedState: tfsdk.State{
+				Raw: tftypes.NewValue(pathAwareObjectType, map[string]tftypes.Value{
+					"id":       tftypes.NewValue(tftypes.String, "E123"),
+					"thing_id": tftypes.NewValue(tftypes.String, "E123"),
+					"origins": tftypes.NewValue(tftypes.List{ElementType: originElementType}, []tftypes.Value{
+						tftypes.NewValue(originElementType, map[string]tftypes.Value{
+							"id": tftypes.NewValue(tftypes.String, "origin-a"),
+						}),
+					}),
+				}),
+				Schema: testPathAwareSchema,
+			},
+		},
 		{
 			TestName: "simple State",
 			State: tfsdk.State{
@@ -232,7 +262,12 @@ func TestUnknownsSetValue(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			err = SetUnknownValuesFromResourceModel(context.TODO(), &testCase.State, unknowns, testCase.ResourceModel, testCase.CfToTfNameMap)
+			translator := toTerraform{cfToTfNameMap: testCase.CfToTfNameMap}
+			if testCase.PathCfToTfNameMap != nil {
+				translator.pathAwareNames = true
+				translator.pathCfToTfNameMap = testCase.PathCfToTfNameMap
+			}
+			err = SetUnknownValuesFromResourceModel(context.TODO(), &testCase.State, unknowns, testCase.ResourceModel, translator)
 
 			if err == nil && testCase.ExpectedError {
 				t.Fatalf("expected error")
@@ -249,4 +284,53 @@ func TestUnknownsSetValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+var originElementType = tftypes.Object{
+	AttributeTypes: map[string]tftypes.Type{
+		"id": tftypes.String,
+	},
+}
+
+var pathAwareObjectType = tftypes.Object{
+	AttributeTypes: map[string]tftypes.Type{
+		"id":       tftypes.String,
+		"thing_id": tftypes.String,
+		"origins":  tftypes.List{ElementType: originElementType},
+	},
+}
+
+// testPathAwareSchema models a resource whose top-level CloudFormation "Id" property is
+// computed (renamed to thing_id) and whose nested Origins items also carry an "Id".
+var testPathAwareSchema = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed: true,
+		},
+		"thing_id": schema.StringAttribute{
+			Computed: true,
+		},
+		"origins": schema.ListNestedAttribute{
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			Required: true,
+		},
+	},
+}
+
+func makePathAwareValueWithUnknowns() tftypes.Value {
+	return tftypes.NewValue(pathAwareObjectType, map[string]tftypes.Value{
+		"id":       tftypes.NewValue(tftypes.String, "E123"),
+		"thing_id": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		"origins": tftypes.NewValue(tftypes.List{ElementType: originElementType}, []tftypes.Value{
+			tftypes.NewValue(originElementType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "origin-a"),
+			}),
+		}),
+	})
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #3307.
Relates #3284, #2311.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

## Description

Follow-up to #3284. `SetUnknownValuesFromResourceModel` (fills computed attributes after Create/Update) and `genericResource.List` still built their `toTerraform` translator from the flat `cfToTfNameMap`. In path-aware mode that map is derived "first wins" over a Go map, so a property that collides across paths — a computed top-level `Id` next to a nested `Origins[].Id`, the shape of every resource still suppressed for `duplicate attribute name mapping for CloudFormation property Id` — resolves to a random attribute on each provider start (measured 26/40 vs 14/40 for `aws_cloudfront_distribution`). When the nested name wins, the computed top-level value is never filled and apply fails with an unknown value.

Changes:

* `genericResource.toTerraformTranslator()` returns the translator with the path-aware maps; Read, `SetUnknownValuesFromResourceModel` and `List` all use it.
* `SetUnknownValuesFromResourceModel` takes the translator instead of a bare map.
* Regression test `TestUnknownsSetValue/path-aware State with colliding computed Id`: a model `{"Id": "E123", "Origins": [{"Id": "origin-a"}]}` with an unknown top-level `thing_id` and a flat map that resolves `Id` → `id`. Fails through the flat map, passes through the path-aware translator.
* Comment in `resourceWithPathAwareAttributeNameMap` updated: the flat maps remain for the callers that key by bare property name (`unorderedArrayPaths`, `propertyPathToAttributePath`), not for value translation.

No generated code changes; resources without `path_aware_attribute_names` are unaffected (the translator carries the same flat map as before).

## Verification

* `go build ./...`, `go vet ./internal/generic/`, `go test ./internal/generic/`, `golangci-lint run ./internal/generic/...` — clean.
* On `main` with `path_aware_attribute_names = true` for `aws_cloudfront_distribution`: generation, provider startup, `terraform plan` and `terraform import` of a real distribution all succeed; create is blocked separately by #3308, so the post-create path is covered by the unit test above.