### PR TITLE
build: pin all go invocations to the module Go via exported GOTOOLCHAIN; add bigdiffer-test

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,12 +5,18 @@ ACCTEST_TIMEOUT     ?= 180m
 ACCTEST_PARALLELISM ?= 20
 GO_VER              ?= go
 
-# Pin bigdiffer generation to the module's Go version so gofmt/goimports output is
-# byte-identical to CI regardless of the contributor's locally installed Go (map
-# alignment and other gofmt rules change between Go releases, and GOTOOLCHAIN=auto
-# will not downgrade a newer local Go). Sourced from the go.mod `go` directive,
-# e.g. `go 1.26.6` -> `go1.26.6`; falls back to auto if it cannot be read.
+# Pin every go invocation (generation, tests, tool installs) to the module's Go
+# version so gofmt/goimports output is byte-identical to CI regardless of the
+# contributor's locally installed Go. Map alignment and other gofmt rules change
+# between Go releases, and GOTOOLCHAIN=auto will not downgrade a newer local Go, so
+# formatting-sensitive targets (bigdiffer-*, the legacy generators, and the parity
+# test in `make test`) would otherwise drift. Sourced from the go.mod `go` directive
+# (e.g. `go 1.26.6` -> `go1.26.6`); falls back to auto if it cannot be read. Exported
+# below so it reaches every recipe; override via the environment, e.g.
+# `GOTOOLCHAIN=go1.27.1 make test`.
 GOTOOLCHAIN_PIN     := $(or $(addprefix go,$(shell sed -n 's/^go //p' go.mod)),auto)
+GOTOOLCHAIN         ?= $(GOTOOLCHAIN_PIN)
+export GOTOOLCHAIN
 
 default: build
 
@@ -30,13 +36,16 @@ build: prereq-go ## Build the provider
 	$(GO_VER) install
 
 bigdiffer-update: prereq-go ## Weekly update via bigdiffer (discover, regenerate changed types, reconcile all_schemas.hcl)
-	GOTOOLCHAIN=$(GOTOOLCHAIN_PIN) $(GO_VER) run ./internal/tools/bigdiffer -update
+	$(GO_VER) run ./internal/tools/bigdiffer -update
 
 bigdiffer-generate: prereq-go ## Regenerate the whole provider offline via bigdiffer (no AWS)
-	GOTOOLCHAIN=$(GOTOOLCHAIN_PIN) $(GO_VER) run ./internal/tools/bigdiffer -generate
+	$(GO_VER) run ./internal/tools/bigdiffer -generate
 
 bigdiffer-docs: prereq-go ## Regenerate documentation via bigdiffer (docs-import + terraform fmt + tfplugindocs)
-	GOTOOLCHAIN=$(GOTOOLCHAIN_PIN) $(GO_VER) run ./internal/tools/bigdiffer -docs
+	$(GO_VER) run ./internal/tools/bigdiffer -docs
+
+bigdiffer-test: prereq-go ## Run the bigdiffer tool's unit + full-corpus parity suite
+	$(GO_VER) test ./internal/tools/bigdiffer/... -timeout 20m
 
 plural-data-sources: prereq-go ## Generate plural data sources
 	@echo "==> Counting existing plural data source files..."
@@ -327,6 +336,7 @@ biglister: prereq-go ## List all resources and data sources
 .PHONY: bigdiffer
 .PHONY: bigdiffer-docs
 .PHONY: bigdiffer-generate
+.PHONY: bigdiffer-test
 .PHONY: bigdiffer-update
 .PHONY: biglister
 .PHONY: build


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2021, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!--- See what makes a good Pull Request at: https://github.com/hashicorp/terraform-provider-awscc/blob/main/contributing/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
* The resources and data sources in this provider are generated from the CloudFormation schema, so they can only support the actions that the underlying schema supports. For this reason submitted bugs should be limited to defects in the generation and runtime code of the provider. Customizing behavior of the resource, or noting a gap in behavior are not valid bugs and should be submitted as enhancements to AWS via the CloudFormation Open Coverage Roadmap.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #3316

Merge order: #3317 -> #3316

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

gofmt/goimports formatting changed between Go 1.26 and 1.27, so any target that generates or byte-compares formatted code must run under the module's Go version. Only the three bigdiffer generation targets were pinned; `make test` (`TEST=./...`, which runs `TestFullCorpusParity` that regenerates the corpus and compares byte-for-byte), the legacy generators, and `make tools` (which builds goimports/golangci-lint, whose formatting is baked in at build time) were not, so they drift under a newer local Go.

Replace the per-target `GOTOOLCHAIN` prefixes with a single exported `GOTOOLCHAIN` (`?=` so it stays overridable, e.g. `GOTOOLCHAIN=go1.27.1 make test`) near the top of the Makefile, so every recipe's go / go-tool invocation uses the pinned toolchain. Add a bigdiffer-test convenience target for the tool's unit + parity suite.

Verified: `GOTOOLCHAIN_PIN` resolves to `go1.26.6`, a recipe environment sees `GOTOOLCHAIN=go1.26.6`, and `make bigdiffer-test` is green (241s incl. `TestFullCorpusParity`) on a host whose default Go is 1.27.1.